### PR TITLE
Fix compilation issue

### DIFF
--- a/include/tvm/utils/internal/map.h
+++ b/include/tvm/utils/internal/map.h
@@ -56,7 +56,7 @@ namespace internal
   };
 
   template<typename KeyWithId, typename Value, 
-           typename Allocator = std::allocator< std::pair<KeyWithId, Value> > >
+           typename Allocator = std::allocator< std::pair<const KeyWithId, Value> > >
   using map = std::map<KeyWithId, Value, IdComparator<KeyWithId>, Allocator >;
 
 }  // namespace internal

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ make && make install
 ```
 
 where the main options are:
- * `-DCMAKE_BUIlD_TYPE=Release` Build in Release mode
+ * `-DCMAKE_BUILD_TYPE=Release` Build in Release mode
  * `-DCMAKE_INSTALL_PREFIX=some/path/to/install` default is `/usr/local`
  
 Documentation


### PR DESCRIPTION
The code failed to compile with GCC 9.1 and Clang 8.0. 
This was due to an incorrect allocator type given to std::map.
According to cppreference, the default allocator for an `std::map` is `std::allocator<std::pair<const Key, T>` but here the `const was missing`.
I can't run the tests because I don't have access to `hrp2_drc_description` and `mc_env_description` but the change shouldn't break anything