### PR TITLE
Ensure the derivative of a variable is always the same

### DIFF
--- a/include/tvm/Variable.h
+++ b/include/tvm/Variable.h
@@ -151,7 +151,7 @@ namespace tvm
     Variable(const Space& s, const std::string& name);
 
     /** Constructor for the derivative of var */
-    Variable(VariablePtr var);
+    Variable(Variable* var);
 
     /** Same as primitive<n> but without checking if n is valid.*/
     template <int n>
@@ -172,12 +172,12 @@ namespace tvm
     int derivativeNumber_;
 
     /** If the variable is the time derivative of another one, primitive_ is a
-      * reference to the latter, otherwise it is uninitialized.
+      * reference to the latter, otherwise it is a nullptr.
       */
-    VariablePtr primitive_;
+    Variable* primitive_;
 
     /** If the variable has a time derivative, keep a pointer on it */
-    std::weak_ptr<Variable> derivative_;
+    std::unique_ptr<Variable> derivative_;
 
     /** A helper structure for mapping purpose*/
     mutable MappingHelper mappingHelper_;
@@ -207,7 +207,10 @@ namespace tvm
   template <>
   inline VariablePtr Variable::primitiveNoCheck<1>() const
   {
-    return primitive_;
+    if (derivativeNumber_ > 1)
+      return { basePrimitive(), primitive_ };
+    else
+      return primitive_->shared_from_this();
   }
 
   inline Eigen::CommaInitializer<Eigen::VectorXd> Variable::operator<<(double d)


### PR DESCRIPTION
This PR is meant to avoid surprises in the (quite corner) case when a `shared_ptr` on a derivative Variable is not kept and the derivative is accessed again,
For example, 
```
VariablePtr x = Space(3).createVariable("x");
{
  dot(x)->value(Eigen::Vector3d(3, 1, 4));
}
std::cout << dot(x)->value() << std::endl;
```
prints (0,0,0) and not (3,1,4).

This is because, so far, a derived variable was keeping a `share_ptr` on its primitive, ensuring the derivative could not outlast its primitive, but kept only a `weak_ptr` on its derivative, so that in case the derivative was still alive we could return it, but would otherwise need to re-create it.

This PR ensures that all variables in a primitives - derivatives chain live as long as one of them is referenced by a `shared_ptr`. This is done by using `shared_ptr` aliasing so that all ref counting is done at the same place (i.e. the original variable).

Now, a variable control the lifetime of its derivative through a unique_ptr, and the base variable lifetime is ensured by always returning a pointer to a derivative that refers to it.