### PR TITLE
CI consumer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,11 @@ jobs:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         options: -DTVM_WITH_QLD:BOOL=ON -DTVM_WITH_QUADPROG:BOOL=ON -DTVM_WITH_ROBOT:BOOL=${{ matrix.with-robot }}
+    - name: Check TVM usage
+      shell: bash
+      run: |
+        set -x
+        ./.github/workflows/scripts/test-usage.sh ${{ matrix.build-type }}
     - name: Upload documentation
       # Only run on master branch and for one configuration
       if: matrix.os == 'ubuntu-18.04' && matrix.build-type == 'RelWithDebInfo' && matrix.compiler == 'gcc' && github.ref == 'refs/heads/master' && matrix.with-robot == 'OFF'

--- a/.github/workflows/scripts/test-usage.sh
+++ b/.github/workflows/scripts/test-usage.sh
@@ -16,6 +16,8 @@ cp -r $tvm_dir/tests/doctest $project_dir/helpers
 cat > $project_dir/CMakeLists.txt << EOF
 cmake_minimum_required(VERSION 3.1)
 
+set(CMAKE_CXX_STANDARD 17)
+
 project(tvm_consumer LANGUAGES CXX)
 enable_testing()
 

--- a/.github/workflows/scripts/test-usage.sh
+++ b/.github/workflows/scripts/test-usage.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+readonly CMAKE_BUILD_TYPE=$1
+readonly this_dir=`cd $(dirname $0); pwd`
+readonly tvm_dir=`cd $this_dir/../../../; pwd`
+readonly project_dir=$HOME/test-tvm
+
+mkdir -p $project_dir/examples
+mkdir -p $project_dir/helpers
+mkdir -p $project_dir/build
+
+cp $tvm_dir/tests/SolverTestFunctions.* $project_dir/helpers
+cp -r $tvm_dir/examples/*.cpp $project_dir/examples
+cp -r $tvm_dir/tests/doctest $project_dir/helpers
+
+cat > $project_dir/CMakeLists.txt << EOF
+cmake_minimum_required(VERSION 3.1)
+
+project(tvm_consumer LANGUAGES CXX)
+enable_testing()
+
+find_package(TVM REQUIRED)
+
+file(GLOB tvm_helpers_src helpers/*.cpp)
+add_library(tvm_helpers OBJECT \${tvm_helpers_src})
+target_compile_definitions(tvm_helpers PUBLIC $<TARGET_PROPERTY:TVM::TVM,INTERFACE_COMPILE_DEFINITIONS>)
+target_include_directories(tvm_helpers PUBLIC $<TARGET_PROPERTY:TVM::TVM,INTERFACE_INCLUDE_DIRECTORIES>)
+
+file(GLOB tvm_examples examples/*.cpp)
+
+foreach(example \${tvm_examples})
+  get_filename_component(name \${example} NAME_WE)
+  add_executable(\${name} \${example} \$<TARGET_OBJECTS:tvm_helpers>)
+  target_link_libraries(\${name} PUBLIC TVM::TVM)
+  target_include_directories(\${name} PUBLIC \${PROJECT_SOURCE_DIR}/helpers)
+  add_test(\${name} \${name})
+endforeach()
+EOF
+
+cd $project_dir/build
+cmake ../ -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} || exit 1
+cmake --build . --config ${CMAKE_BUILD_TYPE} || exit 1
+ctest -V -C ${CMAKE_BUILD_TYPE} || exit 1

--- a/3rd-party/mpark/CMakeLists.txt
+++ b/3rd-party/mpark/CMakeLists.txt
@@ -3,8 +3,8 @@ set(HEADERS_INCLUDE_DIR $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_
 set(MPARK_VARIANT_HEADERS
   ${HEADERS_INCLUDE_DIR}/variant.hpp
 )
-install(FILES ${MPARK_VARIANT_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/tvm/3rd-party/mpark}")
+install(FILES ${MPARK_VARIANT_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/tvm/3rd-party/mpark")
 add_library(tvm_3rd-party_mpark-variant INTERFACE)
 target_sources(tvm_3rd-party_mpark-variant INTERFACE ${MPARK_VARIANT_HEADERS})
-target_include_directories(tvm_3rd-party_mpark-variant INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd-party> $<INSTALL_INTERFACE:include/tvm/3rd-party/mpark>)
+target_include_directories(tvm_3rd-party_mpark-variant INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd-party> $<INSTALL_INTERFACE:include/tvm/3rd-party/>)
 install(TARGETS tvm_3rd-party_mpark-variant EXPORT "${TARGETS_EXPORT_NAME}")


### PR DESCRIPTION
This PR:
* adds a CI check that the package can be consumed (by compiling and testing the examples in a separate project)
* fix installation and consumption issue with mpark/variant