### PR TITLE
Topic/manifold function

### DIFF
--- a/examples/FunctionWritingExample.cpp
+++ b/examples/FunctionWritingExample.cpp
@@ -98,6 +98,8 @@ namespace tvm::example
     , g_(g)
     , h_(h)
   {
+    if (!g->imageSpace().isEuclidean() || !h->imageSpace().isEuclidean())
+      throw std::runtime_error("Function g and h must have their values in an Euclidean space.");
     if (g->size() != h->size())
       throw std::runtime_error("Function g and h must have the same size");
 

--- a/include/tvm/Space.h
+++ b/include/tvm/Space.h
@@ -110,7 +110,8 @@ namespace tvm
 
     bool operator==(const Space& other) const
     {
-      return this->mSize_ == other.mSize_ && this->rSize_ == other.rSize_ && this->tSize_ == other.tSize_;
+      return this->mSize_ == other.mSize_ && this->rSize_ == other.rSize_ 
+        && this->tSize_ == other.tSize_ && this->type_ == other.type_;
     }
 
     bool operator!=(const Space& other) const

--- a/include/tvm/Space.h
+++ b/include/tvm/Space.h
@@ -59,6 +59,15 @@ namespace tvm
   class TVM_DLLAPI Space
   {
   public:
+    /** Predifined space types.*/
+    enum class Type
+    {
+      Euclidean,    /** Euclidean space \f$ \mathbb{R}^n \f$.*/
+      SO3,          /** Space of 3d rotations, represented by unit quaternions.*/
+      SE3,          /** Space of 3d transformation, represented by a quaternion and a 3d-vector.*/
+      Unspecified   /** Non-euclidean space of unknown type.*/
+    };
+
     /** Constructor for an Euclidean space
       *
       * /param size size of the space
@@ -78,6 +87,13 @@ namespace tvm
       */
     Space(int size, int representationSize, int tangentRepresentationSize);
 
+    /** Constructor for a given space type
+      *
+      * /param type type of space
+      * /param size size of the space. Only for space types whose size is not fixed.
+      */
+    Space(Type type, int size=-1);
+
     /** Factory function to create a variable.*/
     std::unique_ptr<Variable> createVariable(const std::string& name) const;
 
@@ -87,7 +103,9 @@ namespace tvm
     int rSize() const;
     /** Size of the vector needed to represent a derivative in this space.*/
     int tSize() const;
-    /** Check if this is an Euclidean space (size==representationSize)*/
+    /** Type of the space. */
+    Type type() const;
+    /** Check if this is an Euclidean space.*/
     bool isEuclidean() const;
 
     bool operator==(const Space& other) const
@@ -101,9 +119,10 @@ namespace tvm
     }
 
   private:
-    int mSize_;   //size of this space (as a manifold)
-    int rSize_;   //size of a vector representing a point in this space
-    int tSize_;   //size of a vector representing a velocity in this space
+    int  mSize_;   //size of this space (as a manifold)
+    int  rSize_;   //size of a vector representing a point in this space
+    int  tSize_;   //size of a vector representing a velocity in this space
+    Type type_;    //the space type
   };
 
 }  // namespace tvm

--- a/include/tvm/function/abstract/Function.h
+++ b/include/tvm/function/abstract/Function.h
@@ -83,11 +83,19 @@ namespace abstract
     virtual const Eigen::MatrixXd& JDot(const Variable& x) const;
 
   protected:
-    /** Constructor
-      * /param m the output size of the function, i.e. the size of the value (or
-      * equivalently the row size of the jacobians).
+    /** Constructor for a function with value in \f$ \mathbb{R}^m \f$.
+      *
+      * \param m the size of the function/constraint image space, i.e. the row
+      * size of the jacobians (or equivalently in this case the size of the
+      * output value).
       */
     Function(int m=0);
+
+    /** Constructor for a function with value in a specified space.
+      *
+      * \param image Description of the image space
+      */
+    Function(Space image);
 
     /** Resize all cache members corresponding to active output*/
     void resizeCache() override;

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -88,18 +88,32 @@ namespace internal
     /** Linearity w.r.t \p x*/
     bool linearIn(const Variable& x) const;
 
-    /** Return the output size \p m*/
+    const Space& imageSpace() const;
+
+    /** Return the image space size.*/
     int size() const;
+    /** Size of the output value (representation size of the image space).*/
+    int rSize() const;
+    /** Size of the tangent space to the image space (or equivalently row size of the jacobian matrices).*/
+    int tSize() const;
 
     /** Return the variables*/
     const VariableVector& variables() const;
 
   protected:
-    /** Constructor
-      * \param m the output size of the function/constraint, i.e. the size of
-      * the value (or equivalently the row size of the jacobians).
+    /** Constructor for a function/constraint with value in \f$ \mathbb{R}^m \f$.
+      *
+      * \param m the size of the function/constraint image space, i.e. the row
+      * size of the jacobians (or equivalently in this case the size of the
+      * output value).
       */
     FirstOrderProvider(int m);
+
+    /** Constructor for a function/constraint with value in a specified space.
+      *
+      * \param image Description of the image space
+      */
+    FirstOrderProvider(Space image);
 
     /** Resize all cache members corresponding to active outputs.
       *
@@ -173,7 +187,7 @@ namespace internal
     /** Resize the function */
     void resize(int m);
 
-    int m_; //output size
+    Space imageSpace_; //output space
     VariableVector variables_;
     utils::internal::map<Variable const*, bool> linear_;
   };
@@ -194,9 +208,23 @@ namespace internal
     return linear_.at(&x);
   }
 
+  inline const Space& FirstOrderProvider::imageSpace() const
+  {
+    return imageSpace_;
+  }
+
   inline int FirstOrderProvider::size() const
   {
-    return m_;
+    return imageSpace_.size();
+  }
+
+  inline int FirstOrderProvider::rSize() const
+  {
+    return imageSpace_.rSize();
+  }
+  inline int FirstOrderProvider::tSize() const
+  {
+    return imageSpace_.tSize();
   }
 
   inline const VariableVector& FirstOrderProvider::variables() const

--- a/include/tvm/utils/ProtoTask.h
+++ b/include/tvm/utils/ProtoTask.h
@@ -57,7 +57,7 @@ namespace utils
     ProtoTaskCommon(FunT f, const internal::RHS& rhs)
     : f_(f), rhs_(rhs)
     {
-      if (rhs.type_ == internal::RHSType::Vector && f->size() != rhs.v_.size())
+      if (rhs.type_ == internal::RHSType::Vector && f->rSize() != rhs.v_.size())
       {
         throw std::runtime_error("The vector you provided has not the correct size.");
       }
@@ -80,11 +80,11 @@ namespace utils
     ProtoTaskCommon(FunT f, const internal::RHS& l, const internal::RHS & u)
     : f_(f), l_(l), u_(u)
     {
-      if (l.type_ == internal::RHSType::Vector && f->size() != l.v_.size())
+      if (l.type_ == internal::RHSType::Vector && f->rSize() != l.v_.size())
       {
         throw std::runtime_error("The lower bound vector you provided has not the correct size.");
       }
-      if (u.type_ == internal::RHSType::Vector && f->size() != u.v_.size())
+      if (u.type_ == internal::RHSType::Vector && f->rSize() != u.v_.size())
       {
         throw std::runtime_error("The upper bound vector you provided has not the correct size.");
       }

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -47,7 +47,25 @@ namespace tvm
 
   Space::Space(int size, int representationSize, int tangentRepresentationSize)
     : mSize_(size), rSize_(representationSize), tSize_(tangentRepresentationSize)
+    , type_((size==representationSize&&size==tangentRepresentationSize)?Type::Euclidean:Type::Unspecified)
   {
+    assert(size >= 0);
+    assert(representationSize >= size);
+    assert(tangentRepresentationSize >= size);
+  }
+
+  Space::Space(Type type, int size)
+    : type_(type)
+  {
+    switch (type)
+    {
+    case Type::Euclidean: mSize_ = rSize_ = tSize_ = size; break;
+    case Type::SO3: assert(size < 0); mSize_ = 3; rSize_ = 4; tSize_ = 3; break;
+    case Type::SE3: assert(size < 0); mSize_ = 6; rSize_ = 7; tSize_ = 6; break;
+    case Type::Unspecified:
+    default:
+      throw std::runtime_error("[Space::Space] Unable to build the required space.");
+    }
   }
 
   std::unique_ptr<Variable> Space::createVariable(const std::string& name) const
@@ -70,9 +88,14 @@ namespace tvm
     return tSize_;
   }
 
+  Space::Type Space::type() const
+  {
+    return type_;
+  }
+
   bool Space::isEuclidean() const
   {
-    return mSize_ == rSize_;
+    return type_ == Type::Euclidean;
   }
 
 }  // namespace tvm

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -43,6 +43,8 @@ namespace tvm
   {
     if (t == constraint::Type::DOUBLE_SIDED)
       throw std::runtime_error("Double sided tasks need to have non-zero bounds.");
+    if (!f->imageSpace().isEuclidean())
+      throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
   }
 
   Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, double rhs)
@@ -57,6 +59,8 @@ namespace tvm
   {
     if (t == constraint::Type::DOUBLE_SIDED)
       throw std::runtime_error("Double sided tasks need to have two bounds.");
+    if (!f->imageSpace().isEuclidean())
+      throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
   }
 
   Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, double l, double u)
@@ -72,6 +76,8 @@ namespace tvm
   {
     if (t != constraint::Type::DOUBLE_SIDED)
       throw std::runtime_error("This constructor is for double sided constraints only.");
+    if (!f->imageSpace().isEuclidean())
+      throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
   }
 
   Task::Task(utils::ProtoTaskEQ proto, const task_dynamics::abstract::TaskDynamics& td)

--- a/src/constraint/LinearizedTaskConstraint.cpp
+++ b/src/constraint/LinearizedTaskConstraint.cpp
@@ -47,6 +47,7 @@ namespace internal
     , f_(task.function())
     , td_(task.taskDynamics())
   {
+    assert(f_->imageSpace().isEuclidean());
     if (type() == constraint::Type::DOUBLE_SIDED)
     {
       td2_ = task.secondBoundTaskDynamics();

--- a/src/function/Function.cpp
+++ b/src/function/Function.cpp
@@ -41,7 +41,12 @@ namespace abstract
 {
 
   Function::Function(int m)
-    : FirstOrderProvider(m)
+    : Function(Space(m))
+  {
+  }
+
+  Function::Function(Space image)
+    : FirstOrderProvider(std::move(image))
   {
     resizeVelocityCache();
     resizeNormalAccelerationCache();
@@ -59,13 +64,13 @@ namespace abstract
   void Function::resizeVelocityCache()
   {
     if (isOutputEnabled((int)Output::Velocity))
-      velocity_.resize(size());
+      velocity_.resize(tSize());
   }
 
   void Function::resizeNormalAccelerationCache()
   {
     if (isOutputEnabled((int)Output::NormalAcceleration))
-      normalAcceleration_.resize(size());
+      normalAcceleration_.resize(tSize());
   }
 
   void Function::resizeJDotCache()
@@ -73,13 +78,13 @@ namespace abstract
     if (isOutputEnabled((int)Output::JDot))
     {
       for (auto v : variables())
-        JDot_[v.get()].resize(size(), v->space().tSize());
+        JDot_[v.get()].resize(tSize(), v->space().tSize());
     }
   }
 
   void Function::addVariable_(VariablePtr v)
   {
-    JDot_[v.get()].resize(size(), v->space().tSize());
+    JDot_[v.get()].resize(tSize(), v->space().tSize());
     variablesDot_.push_back(dot(v));
   }
 

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -37,7 +37,12 @@ namespace tvm
 namespace internal
 {
   FirstOrderProvider::FirstOrderProvider(int m)
-    : m_(m)
+    : FirstOrderProvider(Space(m))
+  {
+  }
+
+  FirstOrderProvider::FirstOrderProvider(Space image)
+    : imageSpace_(std::move(image))
   {
     resizeCache(); //resize value_
   }
@@ -51,7 +56,7 @@ namespace internal
   void FirstOrderProvider::resizeValueCache()
   {
     if (isOutputEnabled((int)Output::Value))
-      value_.resize(m_);
+      value_.resize(imageSpace_.rSize());
   }
 
   void FirstOrderProvider::resizeJacobianCache()
@@ -59,7 +64,7 @@ namespace internal
     if (isOutputEnabled((int)Output::Jacobian))
     {
       for (auto v : variables_.variables())
-        jacobian_[v.get()].resize(m_, v->space().tSize());
+        jacobian_[v.get()].resize(imageSpace_.tSize(), v->space().tSize());
     }
   }
 
@@ -67,7 +72,7 @@ namespace internal
   {
     if(variables_.add(v))
     {
-      jacobian_[v.get()].resize(m_, v->space().tSize());
+      jacobian_[v.get()].resize(imageSpace_.tSize(), v->space().tSize());
       linear_[v.get()] = linear;
 
       addVariable_(v);
@@ -112,7 +117,8 @@ namespace internal
 
   void FirstOrderProvider::resize(int m)
   {
-    m_ = m;
+    assert(imageSpace_.isEuclidean());
+    imageSpace_ = Space(m);
     resizeCache();
   }
 

--- a/src/robot/JointsSelector.cpp
+++ b/src/robot/JointsSelector.cpp
@@ -119,7 +119,7 @@ std::unique_ptr<JointsSelector> JointsSelector::InactiveJoints(FunctionPtr f,
 }
 
  JointsSelector::JointsSelector(FunctionPtr f, RobotPtr robot, bool ffActive, const std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> & activeIndex)
-: function::abstract::Function(f->size()),
+: function::abstract::Function(f->imageSpace()),
   f_(f),
   robot_(robot),
   ffActive_(ffActive),

--- a/src/task_dynamics/TaskDynamicsImpl.cpp
+++ b/src/task_dynamics/TaskDynamicsImpl.cpp
@@ -49,6 +49,8 @@ namespace tvm
         {
           throw std::runtime_error("[TaskDynamicsImpl] rhs does not have the same size as f.");
         }
+        if (!f->imageSpace().isEuclidean())
+          throw std::runtime_error("[TaskDynamicsImpl::TaskDynamicsImpl] Task dynamics are for function into a Euclidean space.");
         setFunction(f);
         registerUpdates(Update::UpdateValue, &TaskDynamicsImpl::updateValue);
         addOutputDependency(Output::Value, Update::UpdateValue);

--- a/tests/SolverTestFunctions.cpp
+++ b/tests/SolverTestFunctions.cpp
@@ -174,6 +174,7 @@ Difference::Difference(FunctionPtr f, FunctionPtr g)
   , f_(f)
   , g_(g)
 {
+  assert(f->imageSpace().isEuclidean() && g->imageSpace().isEuclidean());
   assert(f->size() == g->size());
 
   using BasicOutput = tvm::internal::FirstOrderProvider::Output;

--- a/tests/VariableTest.cpp
+++ b/tests/VariableTest.cpp
@@ -22,6 +22,7 @@ TEST_CASE("Test Variable creation")
   FAST_CHECK_EQ(u->space().tSize(), 3);
   FAST_CHECK_UNARY(u->isEuclidean());
   FAST_CHECK_UNARY(dot(u)->isEuclidean());
+  FAST_CHECK_EQ(u->space().type(), Space::Type::Euclidean);
 
   VariablePtr v = Space(3, 4, 3).createVariable("v");
   FAST_CHECK_EQ(v->size(), 4);
@@ -33,12 +34,25 @@ TEST_CASE("Test Variable creation")
   FAST_CHECK_EQ(v->space().tSize(), 3);
   FAST_CHECK_UNARY_FALSE(v->isEuclidean());
   FAST_CHECK_UNARY(dot(v)->isEuclidean());
+  FAST_CHECK_EQ(v->space().type(), Space::Type::Unspecified);
 
   VariablePtr w = v->duplicate("w");
   FAST_CHECK_NE(v, w);
   FAST_CHECK_EQ(v->space(), w->space());
   FAST_CHECK_UNARY_FALSE(w->isEuclidean());
   FAST_CHECK_UNARY(dot(w)->isEuclidean());
+
+  VariablePtr x = Space(Space::Type::SO3).createVariable("x");
+  FAST_CHECK_EQ(x->size(), 4);
+  FAST_CHECK_EQ(dot(x)->size(), 3);
+  FAST_CHECK_UNARY_FALSE(x->space().isEuclidean());
+  FAST_CHECK_EQ(x->space().type(), Space::Type::SO3);
+
+  VariablePtr y = Space(Space::Type::SE3).createVariable("y");
+  FAST_CHECK_EQ(y->size(), 7);
+  FAST_CHECK_EQ(dot(y)->size(), 6);
+  FAST_CHECK_UNARY_FALSE(y->space().isEuclidean());
+  FAST_CHECK_EQ(y->space().type(), Space::Type::SE3);
 }
 
 TEST_CASE("Test Variable value")


### PR DESCRIPTION
This PR adds the possibility to have functions into manifolds (and not just into R^m).
This is done by specifying a image (output) space instead of just the size of the function. I also add an enumeration for space types, to be able to later choose the correct operations between points of a space. Constraints are still only into R^m.

I replicated the interface of `Space` on `Function` for the size, with `size` the size of the image manifold, `rSize` the size used for representing an element of this manifold (and thus the size of `value()`) and `tSize` the size used for representing an element in the tangent space (and thus the size of `velocity()`). Wherever the assumption could be made that the image manifold was Euclidean, I kept using `size` for what would logically be `rSize`, to minimize the number of changes.

This PR opens the door to having a "Difference" function between two entities with values in the same manifold. WIth a systematic use of it, and by paying attention to double-sided tasks, I think we could remove entirely the notion of rhs from the `ProtoTask`/`TaskDynamics`, which would clarify that tasks only take error functions, that compare to 0.

