### PR TITLE
Feed forward and composable task dynamics

### DIFF
--- a/examples/TaskDynamicsExample.cpp
+++ b/examples/TaskDynamicsExample.cpp
@@ -4,7 +4,7 @@
 
 namespace tvm::example
 {
-  /** A class implementing the task dynamics 
+  /** A class implementing the task dynamics
     * \f$
     *     \dot{e}^* = - (a \exp(-b \left\|e\right\|) + c) e
     * \f$
@@ -30,6 +30,8 @@ namespace tvm::example
       std::unique_ptr<task_dynamics::abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
       task_dynamics::Order order_() const override;
 
+      TASK_DYNAMICS_DERIVED_FACTORY(a_, b_, c_)
+
     private:
       double a_;
       double b_;
@@ -37,7 +39,7 @@ namespace tvm::example
   };
 }
 
-// So far tvm::function::abstract::Function was only forward-declared 
+// So far tvm::function::abstract::Function was only forward-declared
 #include<tvm/function/abstract/Function.h>
 
 namespace tvm::example

--- a/examples/TaskDynamicsExample.dox
+++ b/examples/TaskDynamicsExample.dox
@@ -90,6 +90,8 @@
  *       task_dynamics::Order order_() const override;
  *       std::unique_ptr<task_dynamics::abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
  *
+ *        TASK_DYNAMICS_DERIVED_FACTORY(a_, b_, c_)
+ *
  *     private:
  *       double a_, b_, c_;
  *   };
@@ -117,6 +119,10 @@
  *   }
  * \endcode</pre>
  *
+ * * \p TASK_DYNAMICS_DERIVED_FACTORY(a_, b_, c_) is required to enable the use
+ *   of our new task dynamic in a composable task dynamic (for example, to create
+ *   a \p Clamped<AdaptiveProportional> dynamic). The arguments provided to the
+ *   macro are the arguments that are required by \p AdaptiveProportional::Impl
  *
  * The \p Impl class is declared as
  * <pre>\code
@@ -190,10 +196,15 @@
  *    you need to declare the computation dependencies in the constructor of
  *    \p Impl. The constructor of tvm::task_dynamics::abstract::TaskDynamicsImpl
  *    offers a good example of how to do so.
+ *  * Composable task dynamic, i.e. a task dynamic that encapsulate another
+ *    task dynamic, are not covered by this document but the gist of the
+ *    implementation is similar. The \p Clamped task dynamic is a reasonably
+ *    simple example of such a dynamic.
  *
  *
- * Example file
+ * Example files
  * ------------
- * [example/TaskDynamicsExample.cpp](https://github.com/jrl-umi3218/tvm/blob/master/examples/TaskDynamicsExample.cpp)
+ * * [example/TaskDynamicsExample.cpp](https://github.com/jrl-umi3218/tvm/blob/master/examples/TaskDynamicsExample.cpp)
+ * * [Clamped composable task dynamic](https://github.com/jrl-umi3218/tvm/blob/master/include/tvm/task_dynamics/Clamped.h)
  */
- 
+

--- a/include/tvm/Task.h
+++ b/include/tvm/Task.h
@@ -62,8 +62,8 @@ namespace tvm
     TaskDynamicsPtr taskDynamics() const;
     TaskDynamicsPtr secondBoundTaskDynamics() const;  //the dynamics of the upper bound, in the case of double-sided task only.
 
-    template<typename T>
-    std::shared_ptr<typename T::Impl> taskDynamics() const;
+    template<typename T, typename TDImpl = typename T::Impl>
+    std::shared_ptr<TDImpl> taskDynamics() const;
 
     template<typename T>
     std::shared_ptr<typename T::Impl> secondBoundTaskDynamics() const;
@@ -76,11 +76,11 @@ namespace tvm
   };
 
 
-  template<typename T>
-  std::shared_ptr<typename T::Impl> Task::taskDynamics() const
+  template<typename T, typename TDImpl>
+  std::shared_ptr<TDImpl> Task::taskDynamics() const
   {
-    if (td_->checkType<T>())
-      return std::static_pointer_cast<typename T::Impl>(td_);
+    if (td_->checkType<TDImpl>())
+      return std::static_pointer_cast<TDImpl>(td_);
     else
       throw std::runtime_error("Unable to cast the task dynamics into the desired type.");
   }

--- a/include/tvm/graph/abstract/Node.h
+++ b/include/tvm/graph/abstract/Node.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 

--- a/include/tvm/graph/abstract/Node.hpp
+++ b/include/tvm/graph/abstract/Node.hpp
@@ -1,22 +1,8 @@
-#pragma once
-
-/* Copyright 2017 CNRS-UM LIRMM, CNRS-AIST JRL
- *
- * This file is part of TVM.
- *
- * TVM is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * TVM is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with TVM.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
  */
+
+#pragma once
 
 #include <tvm/graph/internal/Logger.h>
 
@@ -75,9 +61,9 @@ void Node<T>::registerUpdates(EnumT u, void(U::*fn)())
   {
     throw std::range_error("Attempted to register an update call using an id that was already registered.");
   }
-  updates_[static_cast<int>(u)] = [this,fn]()
+  updates_[static_cast<int>(u)] = [fn](AbstractNode & self)
   {
-    return (static_cast<U*>(this)->*fn)();
+    return (static_cast<U&>(self).*fn)();
   };
   TVM_GRAPH_LOG_REGISTER_UPDATE(this, u, fn)
 }

--- a/include/tvm/graph/internal/AbstractNode.h
+++ b/include/tvm/graph/internal/AbstractNode.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -125,11 +100,11 @@ public:
   inline void update(int i)
   {
     assert(updates_.count(i));
-    updates_[i]();
+    updates_[i](*this);
   }
 protected:
   /** Map from a update id to  corresponding dependency function.*/
-  std::map<int, std::function<void()>> updates_;
+  std::map<int, std::function<void(AbstractNode&)>> updates_;
 
   /** Map from an output to the list of updates it depends on (expressed by the respective ids).*/
   std::map<int, std::vector<int>> outputDependencies_;

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -56,6 +56,7 @@ namespace tvm::task_dynamics
     public:
       Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const TD& innerTaskDynamics, const Bounds& min, const Bounds& max);
       void updateValue() override;
+      ~Impl() override = default;
 
       /** Access to the task dynamics being clamped. */
       const std::shared_ptr<TDImpl>& inner() const;
@@ -117,6 +118,8 @@ namespace tvm::task_dynamics
       *        have (\f$ b_{min}\f$). We need \f$ b_{min} \leq 0 \leq b_{max}\f$.
       */
     Clamped(const TD& innerTaskDynamics, const VectorConstRef& min, const VectorConstRef& max);
+
+    ~Clamped() override = default;
 
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -21,24 +21,22 @@ namespace tvm::task_dynamics
     * \f$ b_{max} \f$ are given bounds, specified as scalars or vectors.
     */
   template <class TD, class TDImpl = typename TD::Impl>
-  class Clamped : public abstract::TaskDynamics
+  class Clamped : public TD
   {
   public:
     using Bounds = mpark::variant<double, Eigen::VectorXd>;
 
-    class Impl : public abstract::TaskDynamicsImpl
+    class Impl : public TDImpl
     {
     public:
-      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const TD& innerTaskDynamics, const Bounds& min, const Bounds& max);
+      template<typename ... Args>
+      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const Bounds& min, const Bounds& max, Args&& ... args);
       void updateValue() override;
       ~Impl() override = default;
 
-      /** Access to the task dynamics being clamped. */
-      const std::shared_ptr<TDImpl>& inner() const;
-
       /** Access to \f$ b_{min} \f$. */
       const Eigen::VectorXd& min() const { return min_; }
-      /** Access to \f$ b_{min} \f$. 
+      /** Access to \f$ b_{min} \f$.
         *
         * \warning It is your responsibility to give a valid \f$ b_{min} \f$ i.e.
         *  * correct size
@@ -56,70 +54,83 @@ namespace tvm::task_dynamics
       Eigen::VectorXd& max() { return max_; }
 
     private:
-      std::shared_ptr<TDImpl> innerTaskDynamicsImpl_;
       Eigen::VectorXd min_;
       Eigen::VectorXd max_;
     };
 
     /** Constructor with \f$ b_{min} = -b_{max}\f$  (scalar version).
       *
-      * \param innerTaskDynamics The task dynamics to clamp.
       * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
       *        have, in absolute value (\f$ b_{max}\f$).
+      * \param args These are forwarded to the TD constructor
       */
-    Clamped(const TD& innerTaskDynamics, double max);
-    /** Constructor with \f$ b_{min} = -b_{max}\f$  (scalar version).
+    template<typename ... Args>
+    Clamped(double max, Args&& ... args);
+
+    /** Constructor with \f$b_{min}\f$ and \f$b_{max}\f$  (scalar version).
       *
-      * \param innerTaskDynamics The task dynamics to clamp.
-      * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
-      *        have (\f$ b_{max}\f$).
-      * \param min The minimum value that a component of \f$ e_c^{(k)*} \f$ can
-      *        have (\f$ b_{min}\f$). We need \f$ b_{min} \leq 0 \leq b_{max}\f$.
+      * \param minMax The minimum (\f$b_{min}\f$) and maximum (\f$b_{max}\f$)
+      *               value that a component of \f$ e_c^{(k)*}\f$ can have. We require that
+      *               \f$b_{min} \leq 0 \leq b_{max}\f$.
+      * \param args These are forwarded to the TD constructor
       */
-    Clamped(const TD& innerTaskDynamics, double min, double max);
+    template<typename ... Args>
+    Clamped(const std::pair<double, double>& minMax, Args&& ... args);
+
     /** Constructor with \f$ b_{min} = -b_{max}\f$  (vector version).
       *
-      * \param innerTaskDynamics The task dynamics to clamp.
       * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
       *        have, in absolute value (\f$ b_{max}\f$).
+      * \param args These are forwarded to the TD constructor
       */
-    Clamped(const TD& innerTaskDynamics, const VectorConstRef& max);
-    /** Constructor with \f$ b_{min} = -b_{max}\f$  (vector version).
+    template<typename ... Args>
+    Clamped(const VectorConstRef& max, Args&& ... args);
+
+    /** Constructor with \f$b_{min}\f$ and \f$b_{max}\f$  (vector version).
       *
-      * \param innerTaskDynamics The task dynamics to clamp.
-      * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
-      *        have (\f$ b_{max}\f$).
-      * \param min The minimum value that a component of \f$ e_c^{(k)*} \f$ can
-      *        have (\f$ b_{min}\f$). We need \f$ b_{min} \leq 0 \leq b_{max}\f$.
+      * \param minMax The minimum (\f$b_{min}\f$) and maximum (\f$b_{max}\f$)
+      *               value that a component of \f$ e_c^{(k)*}\f$ can have. We require that
+      *               \f$b_{min} \leq 0 \leq b_{max}\f$.
+      * \param args These are forwarded to the TD constructor
       */
-    Clamped(const TD& innerTaskDynamics, const VectorConstRef& min, const VectorConstRef& max);
+    template<typename ... Args>
+    Clamped(const std::pair<VectorConstRef, VectorConstRef>& minMax, Args&& ... args);
 
     ~Clamped() override = default;
 
   protected:
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-    Order order_() const override;
+    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override
+    {
+      return TD::template impl_<Impl>(f, t, rhs, min_, max_);
+    }
 
-    TASK_DYNAMICS_DERIVED_FACTORY(innerTaskDynamics_, min_, max_)
+    template<typename Derived, typename ... Args>
+    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, Args&& ... args) const
+    {
+      return TD::template impl_<Derived>(f, t, rhs, std::forward<Args>(args)..., min_, max_);
+    }
 
   private:
-    TD innerTaskDynamics_;
     Bounds min_;
     Bounds max_;
   };
 
   template<class TD, class TDImpl>
-  inline Clamped<TD, TDImpl>::Clamped(const TD& innerTaskDynamics, double max)
-    : Clamped<TD, TDImpl>(innerTaskDynamics, -max, max)
+  template<typename ... Args>
+  inline Clamped<TD, TDImpl>::Clamped(double max, Args&& ... args)
+    : Clamped<TD, TDImpl>({-max, max}, std::forward<Args>(args)...)
   {
   }
 
   template<class TD, class TDImpl>
-  inline Clamped<TD, TDImpl>::Clamped(const TD& innerTaskDynamics, double min, double max)
-    : innerTaskDynamics_(innerTaskDynamics)
-    , min_(min)
-    , max_(max)
+  template<typename ... Args>
+  inline Clamped<TD, TDImpl>::Clamped(const std::pair<double, double> & minMax, Args&& ... args)
+    : TD(std::forward<Args>(args)...),
+      min_(minMax.first)
+    , max_(minMax.second)
   {
+    const auto & min = minMax.first;
+    const auto & max = minMax.second;
     if (min > 0)
     {
       throw std::runtime_error("[task_dynamics::Clamped] Minimum values must be negative.");
@@ -129,19 +140,23 @@ namespace tvm::task_dynamics
       throw std::runtime_error("[task_dynamics::Clamped] Maximum values must be positive.");
     }
   }
-  
+
   template<class TD, class TDImpl>
-  inline Clamped<TD, TDImpl>::Clamped(const TD& innerTaskDynamics, const VectorConstRef& max)
-    : Clamped<TD>(innerTaskDynamics, -max, max)
+  template<typename ... Args>
+  inline Clamped<TD, TDImpl>::Clamped(const VectorConstRef& max, Args&& ... args)
+    : Clamped<TD>({-max, max}, std::forward<Args>(args)...)
   {
   }
 
   template<class TD, class TDImpl>
-  inline Clamped<TD, TDImpl>::Clamped(const TD& innerTaskDynamics, const VectorConstRef& min, const VectorConstRef& max)
-    : innerTaskDynamics_(innerTaskDynamics)
-    , min_(min)
-    , max_(max)
+  template<typename ... Args>
+  inline Clamped<TD, TDImpl>::Clamped(const std::pair<VectorConstRef, VectorConstRef>& minMax, Args&& ... args)
+    : TD(std::forward<Args>(args)...)
+    , min_(minMax.first)
+    , max_(minMax.second)
   {
+    const auto & min = minMax.first;
+    const auto & max = minMax.second;
     if (min.size() !=  max.size())
     {
       throw std::runtime_error("[task_dynamics::Clamped] The minimum and maximum must have the same size.");
@@ -155,23 +170,11 @@ namespace tvm::task_dynamics
       throw std::runtime_error("[task_dynamics::Clamped] Maximum values must be positive.");
     }
   }
-  
-  template<class TD, class TDImpl>
-  inline std::unique_ptr<abstract::TaskDynamicsImpl> Clamped<TD, TDImpl>::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
-  {
-    return std::make_unique<Impl>(f, t, rhs, innerTaskDynamics_, min_, max_);
-  }
 
   template<class TD, class TDImpl>
-  inline Order Clamped<TD, TDImpl>::order_() const
-  {
-    return innerTaskDynamics_.order();
-  }
-
-  template<class TD, class TDImpl>
-  inline Clamped<TD, TDImpl>::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const TD& innerTaskDynamics, const Bounds& min, const Bounds& max)
-    : TaskDynamicsImpl(innerTaskDynamics.order(), f, t, rhs)
-    , innerTaskDynamicsImpl_(static_cast<TDImpl*>(innerTaskDynamics.impl(f, t, rhs).release()))
+  template<typename ... Args>
+  inline Clamped<TD, TDImpl>::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Bounds& min, const Bounds& max, Args&& ... args)
+    : TDImpl(f, t, rhs, std::forward<Args>(args)...)
     , min_(min.index() == 1 ? mpark::get<Eigen::VectorXd>(min) : Eigen::VectorXd::Constant(f->size(), mpark::get<double>(min)))
     , max_(max.index() == 1 ? mpark::get<Eigen::VectorXd>(max) : Eigen::VectorXd::Constant(f->size(), mpark::get<double>(max)))
   {
@@ -187,37 +190,28 @@ namespace tvm::task_dynamics
     {
       throw std::runtime_error("[task_dynamics::Clamped::Impl] Maximum values must be positive.");
     }
-    addInput(innerTaskDynamicsImpl_, TaskDynamicsImpl::Output::Value);
-    addInputDependency(Update::UpdateValue, innerTaskDynamicsImpl_, TaskDynamicsImpl::Output::Value);
   }
 
 
   template<class TD, class TDImpl>
   inline void Clamped<TD, TDImpl>::Impl::updateValue()
   {
-    const auto& innerValue = innerTaskDynamicsImpl_->value();
-
+    TDImpl::updateValue();
     double s = 1;
-    for (int i = 0; i < function().size(); ++i)
+    for (int i = 0; i < this->function().size(); ++i)
     {
-      if (innerValue[i] > max_[i])
+      if (this->value_[i] > max_[i])
       {
         // innerValue[i] > max_[i] >= 0 so that innerValue[i] != 0
-        s = std::min(s, max_[i] / innerValue[i]);
+        s = std::min(s, max_[i] / this->value_[i]);
       }
-      else if (innerValue[i] < min_[i])
+      else if (this->value_[i] < min_[i])
       {
-        // innerValue[i] < min_[i] <= 0 so that innerValue[i] != 0
-        s = std::min(s, min_[i] / innerValue[i]);
+        // this->value_[i] < min_[i] <= 0 so that this->value_[i] != 0
+        s = std::min(s, min_[i] / this->value_[i]);
       }
     }
+    this->value_ *= s;
+  }
 
-    value_ = s * innerValue;
-  }
-  
-  template<class TD, class TDImpl>
-  inline const std::shared_ptr<TDImpl>& Clamped<TD, TDImpl>::Impl::inner() const
-  {
-    return innerTaskDynamicsImpl_;
-  }
-}
+} // namespace task_dynamics

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -104,11 +104,7 @@ namespace tvm::task_dynamics
       return TD::template impl_<Impl>(f, t, rhs, min_, max_);
     }
 
-    template<typename Derived, typename ... Args>
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, Args&& ... args) const
-    {
-      return TD::template impl_<Derived>(f, t, rhs, std::forward<Args>(args)..., min_, max_);
-    }
+    COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(TD, min_, max_)
 
   private:
     Bounds min_;

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -124,6 +99,8 @@ namespace tvm::task_dynamics
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
     Order order_() const override;
+
+    TASK_DYNAMICS_DERIVED_FACTORY(innerTaskDynamics_, min_, max_)
 
   private:
     TD innerTaskDynamics_;

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -125,8 +125,7 @@ namespace tvm::task_dynamics
       min_(minMax.first)
     , max_(minMax.second)
   {
-    const auto & min = minMax.first;
-    const auto & max = minMax.second;
+    const auto& [min, max] = minMax;
     if (min > 0)
     {
       throw std::runtime_error("[task_dynamics::Clamped] Minimum values must be negative.");
@@ -151,8 +150,7 @@ namespace tvm::task_dynamics
     , min_(minMax.first)
     , max_(minMax.second)
   {
-    const auto & min = minMax.first;
-    const auto & max = minMax.second;
+    const auto& [min, max] = minMax;
     if (min.size() !=  max.size())
     {
       throw std::runtime_error("[task_dynamics::Clamped] The minimum and maximum must have the same size.");

--- a/include/tvm/task_dynamics/Constant.h
+++ b/include/tvm/task_dynamics/Constant.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -55,6 +30,8 @@ namespace tvm
     protected:
       std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
       Order order_() const override;
+
+      TASK_DYNAMICS_DERIVED_FACTORY()
     };
 
   }  // namespace task_dynamics

--- a/include/tvm/task_dynamics/Constant.h
+++ b/include/tvm/task_dynamics/Constant.h
@@ -45,9 +45,12 @@ namespace tvm
       public:
         Impl(FunctionPtr, constraint::Type t, const Eigen::VectorXd& rhs);
         void updateValue() override;
+        ~Impl() override = default;
       };
 
       Constant();
+
+      ~Constant() override = default;
 
     protected:
       std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/FeedForward.h
+++ b/include/tvm/task_dynamics/FeedForward.h
@@ -76,11 +76,7 @@ namespace task_dynamics
       return TD::template impl_<Impl>(f, t, rhs, feedForward_, addProviderDependency_);
     }
 
-    template<typename Derived, typename ... Args>
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, Args&& ... args) const
-    {
-      return TD::template impl_<Derived>(f, t, rhs, std::forward<Args>(args)..., feedForward_, addProviderDependency_);
-    }
+    COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(TD, feedForward_, addProviderDependency_)
   };
 
   using FeedForwardPD = FeedForward<ProportionalDerivative>;

--- a/include/tvm/task_dynamics/FeedForward.h
+++ b/include/tvm/task_dynamics/FeedForward.h
@@ -34,7 +34,7 @@ namespace task_dynamics
         return ((provider.get())->*method)();
       };
       makeImpl_ = [provider, signal](const FeedForward & self, FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) {
-        auto impl = std::make_unique<Impl>(static_cast<TDImpl&>(*self.TD::impl_(f, t, rhs).release()), self.feedForward_);
+        auto impl = std::make_unique<Impl>(static_cast<TDImpl&&>(*self.TD::impl_(f, t, rhs).release()), self.feedForward_);
         impl->addInputDependency(TDImpl::Update::UpdateValue, provider, signal);
         return impl;
       };
@@ -47,7 +47,7 @@ namespace task_dynamics
     public:
       friend class FeedForward;
 
-      Impl(const TDImpl& base, const getFeedForwardT& ff) : TDImpl(base), feedForward_(ff)
+      Impl(TDImpl&& base, const getFeedForwardT& ff) : TDImpl(base), feedForward_(ff)
       {
         if(feedForward_().size() != this->function().size())
         {

--- a/include/tvm/task_dynamics/FeedForward.h
+++ b/include/tvm/task_dynamics/FeedForward.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
+
+#pragma once
+
+#include <tvm/task_dynamics/Proportional.h>
+#include <tvm/task_dynamics/ProportionalDerivative.h>
+
+namespace tvm
+{
+
+namespace task_dynamics
+{
+
+  /** Given a task dynamics value \f$ e^{(k)*} \f$, compute the new value \f$
+   * e_ff^{(k)*} = e^{(k)*} - ff \f$, \f$ ff \f$ is data provided by another
+   * TVM node of the same size
+    */
+  template <class TD, class TDImpl = typename TD::Impl>
+  class FeedForward : public TD
+  {
+  public:
+
+    using getFeedForwardT = std::function<const Eigen::VectorXd&()>;
+    using makeImplT = std::function<std::unique_ptr<abstract::TaskDynamicsImpl>(const FeedForward&, FunctionPtr, constraint::Type, const Eigen::VectorXd&)>;
+
+    template<class FFProvider, class FFSignal, typename ... Args>
+    FeedForward(std::shared_ptr<FFProvider> provider, const Eigen::VectorXd & (FFProvider::*method)() const,
+                FFSignal signal, Args && ... args)
+    : TD(std::forward<Args>(args)...)
+    {
+      feedForward_ = [provider, method]() -> const Eigen::VectorXd & {
+        return ((provider.get())->*method)();
+      };
+      makeImpl_ = [provider, signal](const FeedForward & self, FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) {
+        auto impl = std::make_unique<Impl>(static_cast<TDImpl&>(*self.TD::impl_(f, t, rhs).release()), self.feedForward_);
+        impl->addInputDependency(TDImpl::Update::UpdateValue, provider, signal);
+        return impl;
+      };
+    }
+
+    ~FeedForward() override = default;
+
+    class Impl : public TDImpl
+    {
+    public:
+      friend class FeedForward;
+
+      Impl(const TDImpl& base, const getFeedForwardT& ff) : TDImpl(base), feedForward_(ff)
+      {
+        if(feedForward_().size() != this->function().size())
+        {
+          throw std::runtime_error("[task_dynamics::FeedForward] Feed forward term does not have the same size as the provided function");
+        }
+      }
+
+      ~Impl() override = default;
+
+      void updateValue() override
+      {
+        TDImpl::updateValue();
+        this->value_ -= feedForward_();
+      }
+    private:
+      getFeedForwardT feedForward_;
+    };
+
+  protected:
+    getFeedForwardT feedForward_;
+    makeImplT makeImpl_;
+    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override
+    {
+      return makeImpl_(*this, f, t, rhs);
+    }
+  };
+
+  using FeedForwardPD = FeedForward<ProportionalDerivative>;
+  using FeedForwardP = FeedForward<Proportional>;
+
+
+} // namespace task_dynamics
+
+} // namespace tvm

--- a/include/tvm/task_dynamics/FeedForward.h
+++ b/include/tvm/task_dynamics/FeedForward.h
@@ -62,7 +62,7 @@ namespace task_dynamics
       void updateValue() override
       {
         TDImpl::updateValue();
-        this->value_ -= feedForward_();
+        this->value_ += feedForward_();
       }
     private:
       getFeedForwardT feedForward_;

--- a/include/tvm/task_dynamics/None.h
+++ b/include/tvm/task_dynamics/None.h
@@ -46,10 +46,13 @@ namespace tvm
       public:
         Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs);
         void updateValue() override;
+        ~Impl() override = default;
 
       private:
         const function::abstract::LinearFunction* lf_;
       };
+
+      ~None() override = default;
 
     protected:
       std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/None.h
+++ b/include/tvm/task_dynamics/None.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -57,6 +32,8 @@ namespace tvm
     protected:
       std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
       Order order_() const override;
+
+      TASK_DYNAMICS_DERIVED_FACTORY()
     };
 
   }  // namespace task_dynamics

--- a/include/tvm/task_dynamics/Proportional.h
+++ b/include/tvm/task_dynamics/Proportional.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -102,6 +77,8 @@ namespace task_dynamics
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
     Order order_() const override;
+
+    TASK_DYNAMICS_DERIVED_FACTORY(kp_)
 
   private:
     Gain kp_;

--- a/include/tvm/task_dynamics/Proportional.h
+++ b/include/tvm/task_dynamics/Proportional.h
@@ -56,6 +56,8 @@ namespace task_dynamics
       Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Gain& kp);
       void updateValue() override;
 
+      ~Impl() override = default;
+
       /** Change the gain to a new scalar. */
       void gain(double kp);
       /** Change the gain to a new diagonal matrix. */
@@ -94,6 +96,8 @@ namespace task_dynamics
     Proportional(const Eigen::VectorXd& kp);
     /** Proportional dynamics with matrix gain. */
     Proportional(const Eigen::MatrixXd& kp);
+
+    ~Proportional() override = default;
 
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/ProportionalDerivative.h
+++ b/include/tvm/task_dynamics/ProportionalDerivative.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -205,6 +180,8 @@ namespace task_dynamics
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
     Order order_() const override;
+
+    TASK_DYNAMICS_DERIVED_FACTORY(kp_, kv_)
 
   private:
     Gain kp_; //Stiffness gain

--- a/include/tvm/task_dynamics/ProportionalDerivative.h
+++ b/include/tvm/task_dynamics/ProportionalDerivative.h
@@ -57,6 +57,8 @@ namespace task_dynamics
       Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Gain& kp, const Gain& kv);
       void updateValue() override;
 
+      ~Impl() override = default;
+
       /** Get the current gains as a pair (kp, kv). */
       std::pair<const Gain&, const Gain&> gains() const;
       /** Set gains.
@@ -197,6 +199,8 @@ namespace task_dynamics
       * decomposition, matrices multiplications and memory allocation.
       */
     ProportionalDerivative(const Eigen::MatrixXd& kp);
+
+    ~ProportionalDerivative() override = default;
 
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/Reference.h
+++ b/include/tvm/task_dynamics/Reference.h
@@ -43,6 +43,8 @@ namespace tvm::task_dynamics
       Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, Order order, FunctionPtr ref);
       void updateValue() override;
 
+      ~Impl() override = default;
+
       /** Getter on the reference function. */
       FunctionPtr ref() const { return ref_; }
       /** Setter on the reference function. */
@@ -58,6 +60,8 @@ namespace tvm::task_dynamics
       * \param ref The reference function. 
       */
     Reference(Order order, const FunctionPtr& ref);
+
+    ~Reference() override = default;
 
   protected:
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/Reference.h
+++ b/include/tvm/task_dynamics/Reference.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -67,6 +42,7 @@ namespace tvm::task_dynamics
     std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
     Order order_() const override;
 
+    TASK_DYNAMICS_DERIVED_FACTORY(refOrder_, ref_)
   private:
     Order refOrder_;
     FunctionPtr ref_;

--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -102,6 +102,8 @@ namespace tvm
         
         void updateValue() override;
 
+        ~Impl() override = default;
+
       private:
         /** Partial update computation. \p s is a sign factor to apply on the velocity.*/
         void updateValue_(double s);
@@ -138,6 +140,8 @@ namespace tvm
         * \param big value used as infinity.
         */
       VelocityDamper(double dt, const VelocityDamperConfig& config, double big = constant::big_number);
+
+      ~VelocityDamper() override = default;
 
     protected:
       std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;

--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -146,6 +121,20 @@ namespace tvm
     protected:
       std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
       Order order_() const override;
+
+      template<typename Derived, typename ... Args>
+      std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                        constraint::Type t,
+                                                        const Eigen::VectorXd& rhs,
+                                                        Args&& ... args) const
+      {
+        if (dt_ > 0)
+        {
+          return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., dt_, autoXsi_, di_, ds_, xsi_, big_);
+        }
+        return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., autoXsi_, di_, ds_, xsi_, big_);
+
+      }
 
     private:
       double dt_;

--- a/include/tvm/task_dynamics/abstract/TaskDynamics.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamics.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -76,3 +51,17 @@ namespace abstract
 }  // namespace task_dynamics
 
 }  // namespace tvm
+
+/** This macro can be used to define the derived factory required in
+ * TaskDynamics implementation, Args are the arguments required by the derived
+ * class, the macro arguments are members of the class passed to the derived
+ * constructor */
+#define TASK_DYNAMICS_DERIVED_FACTORY(...)                                                          \
+  template<typename Derived, typename ... Args>                                                     \
+  std::unique_ptr<tvm::task_dynamics::abstract::TaskDynamicsImpl> impl_(tvm::FunctionPtr f,         \
+                                                                        tvm::constraint::Type t,    \
+                                                                        const Eigen::VectorXd& rhs, \
+                                                                        Args&& ... args) const      \
+  {                                                                                                 \
+    return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., ## __VA_ARGS__);       \
+  }

--- a/include/tvm/task_dynamics/abstract/TaskDynamics.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamics.h
@@ -65,3 +65,18 @@ namespace abstract
   {                                                                                                 \
     return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., ## __VA_ARGS__);       \
   }
+
+/** This macro can be used to define the derived factory required in composable
+ * TaskDynamics implementation, Args are the arguments required by the derived
+ * class, the macro variadic arguments are members of the class passed to the
+ * derived constructor, the first argument is the template argument
+ * representing the encapsulated TaskDynamic type */
+#define COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(T, ...)                                            \
+  template<typename Derived, typename ... Args>                                                     \
+  std::unique_ptr<tvm::task_dynamics::abstract::TaskDynamicsImpl> impl_(tvm::FunctionPtr f,         \
+                                                                        tvm::constraint::Type t,    \
+                                                                        const Eigen::VectorXd& rhs, \
+                                                                        Args&& ... args) const      \
+  {                                                                                                 \
+    return T::template impl_<Derived>(f, t, rhs, std::forward<Args>(args)..., ## __VA_ARGS__);      \
+  }

--- a/include/tvm/task_dynamics/abstract/TaskDynamics.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamics.h
@@ -53,7 +53,7 @@ namespace abstract
 }  // namespace tvm
 
 /** This macro can be used to define the derived factory required in
- * TaskDynamics implementation, Args are the arguments required by the derived
+ * TaskDynamics implementation, \p Args are the arguments required by the derived
  * class, the macro arguments are members of the class passed to the derived
  * constructor */
 #define TASK_DYNAMICS_DERIVED_FACTORY(...)                                                          \
@@ -67,7 +67,7 @@ namespace abstract
   }
 
 /** This macro can be used to define the derived factory required in composable
- * TaskDynamics implementation, Args are the arguments required by the derived
+ * TaskDynamics implementation, \p Args are the arguments required by the derived
  * class, the macro variadic arguments are members of the class passed to the
  * derived constructor, the first argument is the template argument
  * representing the encapsulated TaskDynamic type */

--- a/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
@@ -91,9 +91,6 @@ namespace tvm
         constraint::Type type_;
         Eigen::VectorXd rhs_;
 
-        //for casting back to the derived type
-        size_t typeInfo_;
-
         friend TaskDynamics;
       };
 
@@ -126,7 +123,7 @@ namespace tvm
       template<typename T>
       inline bool TaskDynamicsImpl::checkType() const
       {
-        return typeid(T).hash_code() == typeInfo_;
+        return dynamic_cast<const T *>(this) != nullptr;
       }
 
     }  // namespace abstract

--- a/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 
@@ -72,7 +47,7 @@ namespace tvm
 
       protected:
         TaskDynamicsImpl(Order order, FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs);
-        
+
         /** Access to the task function.*/
         const function::abstract::Function & function() const;
         /** Access to the task operator. */

--- a/include/tvm/task_dynamics/enums.h
+++ b/include/tvm/task_dynamics/enums.h
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #pragma once
 

--- a/include/tvm/utils/internal/graphDetails.h
+++ b/include/tvm/utils/internal/graphDetails.h
@@ -75,7 +75,7 @@ namespace internal
   */
   template<typename Object1, typename Object2, typename... Args>
   inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user,
-    std::shared_ptr<Object1> obj1, std::shared_ptr<Object2> obj2, Args&&... args)
+    std::shared_ptr<Object1>, std::shared_ptr<Object2> obj2, Args&&... args)
   {
     g->add(user);
     auto newUser = std::make_shared<graph::internal::Inputs>();
@@ -86,7 +86,7 @@ namespace internal
   * End of recursion.
   */
   template<typename Object>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user, std::shared_ptr<Object> obj)
+  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user, std::shared_ptr<Object>)
   {
     g->add(user);
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,7 @@ set(TVM_HEADERS
   ${TVM_INCLUDE_DIR}/task_dynamics/Clamped.h
   ${TVM_INCLUDE_DIR}/task_dynamics/Constant.h
   ${TVM_INCLUDE_DIR}/task_dynamics/enums.h
+  ${TVM_INCLUDE_DIR}/task_dynamics/FeedForward.h
   ${TVM_INCLUDE_DIR}/task_dynamics/None.h
   ${TVM_INCLUDE_DIR}/task_dynamics/ProportionalDerivative.h
   ${TVM_INCLUDE_DIR}/task_dynamics/Proportional.h

--- a/src/task_dynamics/Constant.cpp
+++ b/src/task_dynamics/Constant.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/Constant.h>
 
@@ -59,7 +34,7 @@ namespace tvm
 
     void Constant::Impl::updateValue()
     {
-      // do nothing
+      value_ = rhs();
     }
 
   }  // namespace task_dynamics

--- a/src/task_dynamics/None.cpp
+++ b/src/task_dynamics/None.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/None.h>
 

--- a/src/task_dynamics/Proportional.cpp
+++ b/src/task_dynamics/Proportional.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/Proportional.h>
 

--- a/src/task_dynamics/ProportionalDerivative.cpp
+++ b/src/task_dynamics/ProportionalDerivative.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <Eigen/Eigenvalues>
 

--- a/src/task_dynamics/Reference.cpp
+++ b/src/task_dynamics/Reference.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/Reference.h>
 

--- a/src/task_dynamics/TaskDynamics.cpp
+++ b/src/task_dynamics/TaskDynamics.cpp
@@ -43,7 +43,6 @@ namespace abstract
   std::unique_ptr<TaskDynamicsImpl> TaskDynamics::impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
   {
     auto ptr = impl_(f, t, rhs);
-    ptr->typeInfo_ = typeid(*this).hash_code();
     return ptr;
   }
 

--- a/src/task_dynamics/TaskDynamics.cpp
+++ b/src/task_dynamics/TaskDynamics.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/abstract/TaskDynamics.h>
 

--- a/src/task_dynamics/TaskDynamicsImpl.cpp
+++ b/src/task_dynamics/TaskDynamicsImpl.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/abstract/TaskDynamicsImpl.h>
 

--- a/src/task_dynamics/VelocityDamper.cpp
+++ b/src/task_dynamics/VelocityDamper.cpp
@@ -1,31 +1,6 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
 
 #include <tvm/task_dynamics/VelocityDamper.h>
 

--- a/tests/TaskDynamicsTest.cpp
+++ b/tests/TaskDynamicsTest.cpp
@@ -46,8 +46,8 @@ TEST_CASE("Test Constant")
   FAST_CHECK_EQ(td.order(), task_dynamics::Order::Zero);
   FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::Zero);
   FAST_CHECK_UNARY(tdi->value().isApprox(Vector3d(1, 0, 0)));
-  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::Constant>());
-  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::None>());
+  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::Constant::Impl>());
+  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::None::Impl>());
 }
 
 TEST_CASE("Test None")
@@ -66,8 +66,8 @@ TEST_CASE("Test None")
   FAST_CHECK_EQ(td.order(), task_dynamics::Order::Zero);
   FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::Zero);
   FAST_CHECK_UNARY(tdi->value().isApprox(Vector2d(0,-2)));
-  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::None>());
-  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant>());
+  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::None::Impl>());
+  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant::Impl>());
 }
 
 TEST_CASE("Test Proportional")
@@ -87,8 +87,8 @@ TEST_CASE("Test Proportional")
   FAST_CHECK_EQ(td.order(), task_dynamics::Order::One);
   FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::One);
   FAST_CHECK_EQ(tdi->value()[0], -kp*(36 - rhs[0]));  // -kp*||(1,2,3) - (1,0,-3)||^2 - 2^2 - rhs
-  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::P>());
-  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant>());
+  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::P::Impl>());
+  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant::Impl>());
 
   kp = 3;
   dynamic_cast<task_dynamics::P::Impl*>(tdi.get())->gain(kp);
@@ -176,8 +176,8 @@ TEST_CASE("Test Proportional Derivative")
   FAST_CHECK_EQ(td.order(), task_dynamics::Order::Two);
   FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::Two);
   FAST_CHECK_EQ(tdi->value()[0], -kp*(36 - rhs[0])-kv*16);
-  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::PD>());
-  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant>());
+  FAST_CHECK_UNARY(tdi->checkType<task_dynamics::PD::Impl>());
+  FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant::Impl>());
 }
 
 TEST_CASE("Test Proportional Derivative gain types")
@@ -333,8 +333,8 @@ TEST_CASE("Test Velocity Damper")
     FAST_CHECK_EQ(tdl->value()[0], 0);
     FAST_CHECK_EQ(tdl->value()[1], -1);
     FAST_CHECK_EQ(tdl->value()[2], -constant::big_number);
-    FAST_CHECK_UNARY(tdl->checkType<task_dynamics::VelocityDamper>());
-    FAST_CHECK_UNARY_FALSE(tdl->checkType<task_dynamics::Constant>());
+    FAST_CHECK_UNARY(tdl->checkType<task_dynamics::VelocityDamper::Impl>());
+    FAST_CHECK_UNARY_FALSE(tdl->checkType<task_dynamics::Constant::Impl>());
 
 
     x << -1, -2, -4;
@@ -362,8 +362,8 @@ TEST_CASE("Test Velocity Damper")
     FAST_CHECK_EQ(td2.order(), task_dynamics::Order::Two);
     FAST_CHECK_EQ(tdl->order(), task_dynamics::Order::Two);
     FAST_CHECK_UNARY(tdl->value().isApprox(Vector3d(-10, -20, -1000)));
-    FAST_CHECK_UNARY(tdl->checkType<task_dynamics::VelocityDamper>());
-    FAST_CHECK_UNARY_FALSE(tdl->checkType<task_dynamics::Constant>());
+    FAST_CHECK_UNARY(tdl->checkType<task_dynamics::VelocityDamper::Impl>());
+    FAST_CHECK_UNARY_FALSE(tdl->checkType<task_dynamics::Constant::Impl>());
 
     x << -1, -2, -4;
     dx << -1, -1, -1;
@@ -386,7 +386,6 @@ TEST_CASE("Test automatic xsi")
   double di = 3;
   double ds = 1;
   double xsiOff = 1;
-  double dt = 0.1;
 
   //test kinematics
   double big = 100;

--- a/tests/TaskDynamicsTest.cpp
+++ b/tests/TaskDynamicsTest.cpp
@@ -562,22 +562,19 @@ TEST_CASE("Test Clamped")
   auto f = std::make_shared<function::IdentityFunction>(x);
 
   double kp = 1;
-  task_dynamics::P td(kp);
+  task_dynamics::Clamped<task_dynamics::P> c(1.0, kp);
   VectorXd rhs = Vector3d::Ones();
 
-  {
-    task_dynamics::Clamped c(td, 1);
-    TaskDynamicsPtr tdi = c.impl(f, constraint::Type::EQUAL, rhs);
-    auto Value = task_dynamics::abstract::TaskDynamicsImpl::Output::Value;
-    auto gl = utils::generateUpdateGraph(tdi, Value);
-    gl->execute();
+  TaskDynamicsPtr tdi = c.impl(f, constraint::Type::EQUAL, rhs);
+  auto Value = task_dynamics::abstract::TaskDynamicsImpl::Output::Value;
+  auto gl = utils::generateUpdateGraph(tdi, Value);
+  gl->execute();
 
-    FAST_CHECK_EQ(c.order(), task_dynamics::Order::One);
-    FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::One);
-    FAST_CHECK_UNARY(tdi->value().isApprox(Vector3d(-.5,-1,1))); // e'= -e = (-1,-2,2)
+  FAST_CHECK_EQ(c.order(), task_dynamics::Order::One);
+  FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::One);
+  FAST_CHECK_UNARY(tdi->value().isApprox(Vector3d(-.5,-1,1))); // e'= -e = (-1,-2,2)
 
-    x << 0.5, 1, 1.5;
-    gl->execute();
-    FAST_CHECK_UNARY(tdi->value().isApprox(Vector3d(.5, 0, -.5))); // e'= -e = (0.5,0,-0.5)
-  }
+  x << 0.5, 1, 1.5;
+  gl->execute();
+  FAST_CHECK_UNARY(tdi->value().isApprox(Vector3d(.5, 0, -.5))); // e'= -e = (0.5,0,-0.5)
 }

--- a/tests/TaskDynamicsTest.cpp
+++ b/tests/TaskDynamicsTest.cpp
@@ -233,7 +233,7 @@ TEST_CASE("Test Feed Forward Proportional Derivative")
   FAST_CHECK_UNARY(provider->updated_);
   FAST_CHECK_EQ(td.order(), task_dynamics::Order::Two);
   FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::Two);
-  FAST_CHECK_EQ(tdi->value()[0], -kp*(36 - rhs[0])-kv*16 - 10.0);
+  FAST_CHECK_EQ(tdi->value()[0], -kp*(36 - rhs[0])-kv*16 + 10.0);
   FAST_CHECK_UNARY(tdi->checkType<task_dynamics::PD::Impl>());
   FAST_REQUIRE_UNARY(tdi->checkType<task_dynamics::FeedForwardPD::Impl>()); // REQUIRE because we do a static_cast after
   FAST_CHECK_UNARY_FALSE(tdi->checkType<task_dynamics::Constant::Impl>());
@@ -242,7 +242,7 @@ TEST_CASE("Test Feed Forward Proportional Derivative")
   kv = 2;
   static_cast<task_dynamics::FeedForwardPD::Impl *>(tdi.get())->gains(kp , kv);
   gl->execute();
-  FAST_CHECK_EQ(tdi->value()[0], -kp*(36 - rhs[0])-kv*16 - 10.0);
+  FAST_CHECK_EQ(tdi->value()[0], -kp*(36 - rhs[0])-kv*16 + 10.0);
 }
 
 TEST_CASE("Test Proportional Derivative gain types")
@@ -603,7 +603,7 @@ TEST_CASE("Test Clamped<FeedForward<PD>>")
   FAST_CHECK_UNARY(provider->updated_);
   FAST_CHECK_EQ(td.order(), task_dynamics::Order::Two);
   FAST_CHECK_EQ(tdi->order(), task_dynamics::Order::Two);
-  FAST_CHECK_EQ(tdi->value()[0], std::min(max, std::max(-max, -kp*(36 - rhs[0])-kv*16 - 10.0)));
+  FAST_CHECK_EQ(tdi->value()[0], std::min(max, std::max(-max, -kp*(36 - rhs[0])-kv*16 + 10.0)));
   FAST_CHECK_UNARY(tdi->value()[0] == -max); // clamped error
   FAST_CHECK_UNARY(tdi->checkType<task_dynamics::PD::Impl>());
   FAST_CHECK_UNARY(tdi->checkType<decltype(td)::Impl>());
@@ -614,6 +614,6 @@ TEST_CASE("Test Clamped<FeedForward<PD>>")
   kv = 0.3;
   static_cast<task_dynamics::FeedForwardPD::Impl *>(tdi.get())->gains(kp , kv);
   gl->execute();
-  FAST_CHECK_EQ(tdi->value()[0], std::min(max, std::max(-max, -kp*(36 - rhs[0])-kv*16 - 10.0)));
+  FAST_CHECK_EQ(tdi->value()[0], std::min(max, std::max(-max, -kp*(36 - rhs[0])-kv*16 + 10.0)));
   FAST_CHECK_UNARY_FALSE(tdi->value()[0] == -max); // not clamped anymore
 }


### PR DESCRIPTION
This PR adds/changes three items:
1. Adds a mechanism to allow composable task dynamics
2. Adds the `FeedForward` (composable) task dynamic
3. Make `Clamped` a composable task dynamics

Composable task dynamic
--

A composable task dynamic inherits from the task dynamic it encapsulates and its implementation inherits from the implementation provided by the composed task dynamic. Their constructor accepts a variable number of arguments that are forwarded to the task dynamic (or task dynamic implementation) it inherits.

All task dynamics provide a templated (by `Derived`) `impl_` method that must accept a variable number of arguments, then:
- if the task dynamic is composable its forward these arguments and its own arguments to the templated `impl_` method of the task dynamic it encapsulates
- if the task dynamic is not composable this method calls the `Derived` constructor by forwarding the provided arguments and its own arguments

Macros are provided to simplify the writing of such derived factories.