### PR TITLE
Anisotropic velocity damper

### DIFF
--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -23,8 +23,8 @@ namespace tvm
         * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
         * be computed automatically, otherwise, we need \f$\xi > 0\f$.
         * In automatic mode, the value is recomputed each time the error value
-        * is at a distance to its bound lower or equal to \p \di with the 
-        * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k + 
+        * is at a distance to its bound lower or equal to \p \di with the
+        * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
         * \xi_{\mathrm{off}} \f$.
         * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
         * computation of \f$\xi\f$. Used only in the case xsi=0.
@@ -35,6 +35,43 @@ namespace tvm
       double ds_;
       double xsi_;
       double xsiOff_;
+    };
+
+    /** A structure grouping the parameters for an anisotropic velocity damper.
+     * \sa VelocityDamper
+     */
+    class TVM_DLLAPI VelocityDamperAnisotropicConfig
+    {
+    public:
+      /**
+        * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
+        * \param ds safety distance \f$d_s\f$.
+        * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
+        * be computed automatically, otherwise, we need \f$\xi > 0\f$.
+        * In automatic mode, the value is recomputed each time the error value
+        * is at a distance to its bound lower or equal to \p \di with the
+        * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
+        * \xi_{\mathrm{off}} \f$.
+        * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
+        * computation of \f$\xi\f$. Used only in the case xsi=0.
+        *
+        * All parameters must be of the same size
+        */
+      VelocityDamperAnisotropicConfig(const VectorConstRef & di,
+                                      const VectorConstRef & ds,
+                                      const VectorConstRef & xsi,
+                                      const std::optional<VectorConstRef> & xsiOff = std::nullopt);
+
+      /** Construct from a non-anisotropic configuration
+       *
+       * \param config Configuration to use
+       */
+      VelocityDamperAnisotropicConfig(const VelocityDamperConfig & config);
+
+      Eigen::VectorXd di_;
+      Eigen::VectorXd ds_;
+      Eigen::VectorXd xsi_;
+      Eigen::VectorXd xsiOff_;
     };
 
     /** A first or second order dynamic task implementing the so-called velocity
@@ -71,10 +108,10 @@ namespace tvm
       {
       public:
         //First order dynamics
-        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, bool autoXsi, double di, double ds, double xsi, double big);
+        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, bool autoXsi, const Eigen::VectorXd & di, const Eigen::VectorXd & ds, const Eigen::VectorXd & xsi, double big);
         //Second order dynamics
-        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, double dt, bool autoXsi, double di, double ds, double xsi, double big);
-        
+        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, double dt, bool autoXsi, const Eigen::VectorXd & di, const Eigen::VectorXd & ds, const Eigen::VectorXd & xsi, double big);
+
         void updateValue() override;
 
         ~Impl() override = default;
@@ -84,10 +121,10 @@ namespace tvm
         void updateValue_(double s);
 
         double dt_;
-        double ds_;
-        double di_;
-        double xsiOff_;
-        double a_;                  // -1 / (di - ds)
+        Eigen::VectorXd ds_;
+        Eigen::VectorXd di_;
+        Eigen::VectorXd xsiOff_;
+        Eigen::VectorXd a_;                  // -1 / (di - ds)
         double big_;
 
         bool autoXsi_;
@@ -97,24 +134,52 @@ namespace tvm
       };
 
       /** \bried Velocity damper for first order dynamics.
-        * \param config configuration of the damper. \sa VelocityDamperConfig
-        * \param big value used as infinity.
-        * \attention When \p autoXsi is \p true, the value update will declare a
-        * dependency to the \p Velocity of the error function. It is the user
-        * responsibility to ensure the velocity is correctly provided (in
-        * particular, this might require the value of the variables first
-        * derivatives to be set correctly).
-        */
+       *
+       * \param config configuration of the damper. \sa VelocityDamperConfig
+       *
+       * \param big value used as infinity.
+       *
+       * \attention When \p autoXsi is \p true, the value update will declare a
+       * dependency to the \p Velocity of the error function. It is the user
+       * responsibility to ensure the velocity is correctly provided (in
+       * particular, this might require the value of the variables first
+       * derivatives to be set correctly).
+       */
       VelocityDamper(const VelocityDamperConfig& config, double big = constant::big_number);
-      
-      /** \brief Velocity damper for second order dynamics.
+
+      /** \bried Velocity damper for first order dynamics.
+       *
+        * \param config configuration of the damper. \sa VelocityDamperAnisotropicConfig
         *
-        * \param dt integration time step to integrate acceleration to velocity
-        * (should be the control time step). Must be non-negative.
-        * \param config configuration of the damper. \sa VelocityDamperConfig
         * \param big value used as infinity.
+        *
+        * \attention Previous remark on \p autoXsi apply. Furthermore, the
+        * dimensions of \p config must match the function for which this task
+        * dynamic will be used.
         */
+      VelocityDamper(const VelocityDamperAnisotropicConfig& config, double big = constant::big_number);
+
+      /** \brief Velocity damper for second order dynamics.
+       *
+       * \param dt integration time step to integrate acceleration to velocity
+       * (should be the control time step). Must be strictly positive.
+       *
+       * \param config configuration of the damper. \sa VelocityDamperConfig
+       *
+       * \param big value used as infinity.
+       */
       VelocityDamper(double dt, const VelocityDamperConfig& config, double big = constant::big_number);
+
+      /** \brief Velocity damper for second order dynamics.
+       *
+       * \param dt integration time step to integrate acceleration to velocity
+       * (should be the control time step). Must be strictly positive.
+       *
+       * \param config configuration of the damper. \sa VelocityDamperAnisotropicConfig
+       *
+       * \param big value used as infinity.
+       */
+      VelocityDamper(double dt, const VelocityDamperAnisotropicConfig& config, double big = constant::big_number);
 
       ~VelocityDamper() override = default;
 
@@ -138,9 +203,9 @@ namespace tvm
 
     private:
       double dt_;
-      double xsi_;
-      double ds_;
-      double di_;
+      Eigen::VectorXd xsi_;
+      Eigen::VectorXd ds_;
+      Eigen::VectorXd di_;
       double big_;
       bool autoXsi_;
     };

--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -11,68 +11,6 @@ namespace tvm
 
   namespace task_dynamics
   {
-    /** A structure grouping the parameters of a velocity damper.
-      * \sa VelocityDamper.
-      */
-    class TVM_DLLAPI VelocityDamperConfig
-    {
-    public:
-      /**
-        * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
-        * \param ds safety distance \f$d_s\f$.
-        * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
-        * be computed automatically, otherwise, we need \f$\xi > 0\f$.
-        * In automatic mode, the value is recomputed each time the error value
-        * is at a distance to its bound lower or equal to \p \di with the
-        * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
-        * \xi_{\mathrm{off}} \f$.
-        * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
-        * computation of \f$\xi\f$. Used only in the case xsi=0.
-        */
-      VelocityDamperConfig(double di, double ds, double xsi, double xsiOff=0);
-
-      double di_;
-      double ds_;
-      double xsi_;
-      double xsiOff_;
-    };
-
-    /** A structure grouping the parameters for an anisotropic velocity damper.
-     * \sa VelocityDamper
-     */
-    class TVM_DLLAPI VelocityDamperAnisotropicConfig
-    {
-    public:
-      /**
-        * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
-        * \param ds safety distance \f$d_s\f$.
-        * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
-        * be computed automatically, otherwise, we need \f$\xi > 0\f$.
-        * In automatic mode, the value is recomputed each time the error value
-        * is at a distance to its bound lower or equal to \p \di with the
-        * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
-        * \xi_{\mathrm{off}} \f$.
-        * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
-        * computation of \f$\xi\f$. Used only in the case xsi=0.
-        *
-        * All parameters must be of the same size
-        */
-      VelocityDamperAnisotropicConfig(const VectorConstRef & di,
-                                      const VectorConstRef & ds,
-                                      const VectorConstRef & xsi,
-                                      const std::optional<VectorConstRef> & xsiOff = std::nullopt);
-
-      /** Construct from a non-anisotropic configuration
-       *
-       * \param config Configuration to use
-       */
-      VelocityDamperAnisotropicConfig(const VelocityDamperConfig & config);
-
-      Eigen::VectorXd di_;
-      Eigen::VectorXd ds_;
-      Eigen::VectorXd xsi_;
-      Eigen::VectorXd xsiOff_;
-    };
 
     /** A first or second order dynamic task implementing the so-called velocity
       * damper of Faverjon and Tournassoud.
@@ -104,6 +42,69 @@ namespace tvm
     class TVM_DLLAPI VelocityDamper : public abstract::TaskDynamics
     {
     public:
+      /** A structure grouping the parameters of a velocity damper.
+        * \sa VelocityDamper.
+        */
+      class TVM_DLLAPI Config
+      {
+      public:
+        /**
+          * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
+          * \param ds safety distance \f$d_s\f$.
+          * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
+          * be computed automatically, otherwise, we need \f$\xi > 0\f$.
+          * In automatic mode, the value is recomputed each time the error value
+          * is at a distance to its bound lower or equal to \p \di with the
+          * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
+          * \xi_{\mathrm{off}} \f$.
+          * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
+          * computation of \f$\xi\f$. Used only in the case xsi=0.
+          */
+        Config(double di, double ds, double xsi, double xsiOff=0);
+
+        double di_;
+        double ds_;
+        double xsi_;
+        double xsiOff_;
+      };
+
+      /** A structure grouping the parameters for an anisotropic velocity damper.
+       * \sa VelocityDamper
+       */
+      class TVM_DLLAPI AnisotropicConfig
+      {
+      public:
+        /**
+          * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
+          * \param ds safety distance \f$d_s\f$.
+          * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
+          * be computed automatically, otherwise, we need \f$\xi > 0\f$.
+          * In automatic mode, the value is recomputed each time the error value
+          * is at a distance to its bound lower or equal to \p \di with the
+          * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
+          * \xi_{\mathrm{off}} \f$.
+          * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
+          * computation of \f$\xi\f$. Used only in the case xsi=0.
+          *
+          * All parameters must be of the same size
+          */
+        AnisotropicConfig(const VectorConstRef & di,
+                                        const VectorConstRef & ds,
+                                        const VectorConstRef & xsi,
+                                        const std::optional<VectorConstRef> & xsiOff = std::nullopt);
+
+        /** Construct from a non-anisotropic configuration
+         *
+         * \param config Configuration to use
+         */
+        AnisotropicConfig(const Config & config);
+
+        Eigen::VectorXd di_;
+        Eigen::VectorXd ds_;
+        Eigen::VectorXd xsi_;
+        Eigen::VectorXd xsiOff_;
+      };
+
       class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
       {
       public:
@@ -145,7 +146,7 @@ namespace tvm
        * particular, this might require the value of the variables first
        * derivatives to be set correctly).
        */
-      VelocityDamper(const VelocityDamperConfig& config, double big = constant::big_number);
+      VelocityDamper(const Config& config, double big = constant::big_number);
 
       /** \bried Velocity damper for first order dynamics.
        *
@@ -157,7 +158,7 @@ namespace tvm
         * dimensions of \p config must match the function for which this task
         * dynamic will be used.
         */
-      VelocityDamper(const VelocityDamperAnisotropicConfig& config, double big = constant::big_number);
+      VelocityDamper(const AnisotropicConfig& config, double big = constant::big_number);
 
       /** \brief Velocity damper for second order dynamics.
        *
@@ -168,7 +169,7 @@ namespace tvm
        *
        * \param big value used as infinity.
        */
-      VelocityDamper(double dt, const VelocityDamperConfig& config, double big = constant::big_number);
+      VelocityDamper(double dt, const Config& config, double big = constant::big_number);
 
       /** \brief Velocity damper for second order dynamics.
        *
@@ -179,7 +180,7 @@ namespace tvm
        *
        * \param big value used as infinity.
        */
-      VelocityDamper(double dt, const VelocityDamperAnisotropicConfig& config, double big = constant::big_number);
+      VelocityDamper(double dt, const AnisotropicConfig& config, double big = constant::big_number);
 
       ~VelocityDamper() override = default;
 

--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -91,9 +91,9 @@ namespace tvm
           * All parameters must be of the same size
           */
         AnisotropicConfig(const VectorConstRef & di,
-                                        const VectorConstRef & ds,
-                                        const VectorConstRef & xsi,
-                                        const std::optional<VectorConstRef> & xsiOff = std::nullopt);
+                          const VectorConstRef & ds,
+                          const VectorConstRef & xsi,
+                          const std::optional<VectorConstRef> & xsiOff = std::nullopt);
 
         /** Construct from a non-anisotropic configuration
          *

--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -6,6 +6,8 @@
 
 #include <tvm/task_dynamics/abstract/TaskDynamics.h>
 
+#include <optional>
+
 namespace tvm
 {
 

--- a/src/task_dynamics/VelocityDamper.cpp
+++ b/src/task_dynamics/VelocityDamper.cpp
@@ -85,7 +85,7 @@ namespace task_dynamics
     , ds_(config.ds_)
     , di_(config.di_)
     , big_(big)
-    , autoXsi_(config.xsi_(0) == 0) // we have ensure they are either all 0 or all specified
+    , autoXsi_(config.xsi_[0] == 0) // we have ensure they are either all 0 or all specified
   {
     if (autoXsi_)
     {
@@ -112,7 +112,7 @@ namespace task_dynamics
     , ds_(config.ds_)
     , di_(config.di_)
     , big_(big)
-    , autoXsi_(config.xsi_(0) == 0) // we have ensure they are either all 0 or all specified
+    , autoXsi_(config.xsi_[0] == 0) // we have ensure they are either all 0 or all specified
   {
     if (autoXsi_)
     {
@@ -156,7 +156,7 @@ namespace task_dynamics
   {
     if(in.size() == 1)
     {
-      return Eigen::VectorXd::Constant(f->size(), 1, in(0));
+      return Eigen::VectorXd::Constant(f->size(), 1, in[0]);
     }
     else if(in.size() != f->size())
     {
@@ -250,12 +250,12 @@ namespace task_dynamics
       const auto& dv = function().velocity();
       for (int i = 0; i < function().size(); ++i)
       {
-        if (d_[i] <= di_(i) && !active_[static_cast<size_t>(i)])
+        if (d_[i] <= di_[i] && !active_[static_cast<size_t>(i)])
         {
           active_[static_cast<size_t>(i)] = true;
-          axsi_[i] = a_(i) * (s * dv[i] * (ds_(i) - di_(i)) / (d_[i] - ds_(i)) + xsiOff_(i));
+          axsi_[i] = a_[i] * (s * dv[i] * (ds_[i] - di_[i]) / (d_[i] - ds_[i]) + xsiOff_[i]);
         }
-        else if (d_[i] > di_(i) && active_[static_cast<size_t>(i)])
+        else if (d_[i] > di_[i] && active_[static_cast<size_t>(i)])
         {
           active_[static_cast<size_t>(i)] = false;
         }

--- a/src/task_dynamics/VelocityDamper.cpp
+++ b/src/task_dynamics/VelocityDamper.cpp
@@ -11,7 +11,7 @@ namespace tvm
 
 namespace task_dynamics
 {
-  VelocityDamperConfig::VelocityDamperConfig(double di, double ds, double xsi, double xsiOff)
+  VelocityDamper::Config::Config(double di, double ds, double xsi, double xsiOff)
     : di_(di), ds_(ds), xsi_(xsi), xsiOff_(xsiOff)
   {
     if (di_ <= ds_)
@@ -32,10 +32,10 @@ namespace task_dynamics
     }
   }
 
-  VelocityDamperAnisotropicConfig::VelocityDamperAnisotropicConfig(const VectorConstRef & di,
-                                                                   const VectorConstRef & ds,
-                                                                   const VectorConstRef & xsi,
-                                                                   const std::optional<VectorConstRef> & xsiOff)
+  VelocityDamper::AnisotropicConfig::AnisotropicConfig(const VectorConstRef & di,
+                                                       const VectorConstRef & ds,
+                                                       const VectorConstRef & xsi,
+                                                       const std::optional<VectorConstRef> & xsiOff)
   : di_(di), ds_(ds), xsi_(xsi),
     xsiOff_(xsiOff.value_or(Eigen::VectorXd::Constant(di_.size(), 1, 0.0)))
   {
@@ -66,20 +66,20 @@ namespace task_dynamics
     }
   }
 
-  VelocityDamperAnisotropicConfig::VelocityDamperAnisotropicConfig(const VelocityDamperConfig & config)
-  : VelocityDamperAnisotropicConfig(Eigen::VectorXd::Constant(1, 1, config.di_),
-                                    Eigen::VectorXd::Constant(1, 1, config.ds_),
-                                    Eigen::VectorXd::Constant(1, 1, config.xsi_),
-                                    Eigen::VectorXd::Constant(1, 1, config.xsiOff_))
+  VelocityDamper::AnisotropicConfig::AnisotropicConfig(const Config & config)
+  : AnisotropicConfig(Eigen::VectorXd::Constant(1, 1, config.di_),
+                      Eigen::VectorXd::Constant(1, 1, config.ds_),
+                      Eigen::VectorXd::Constant(1, 1, config.xsi_),
+                      Eigen::VectorXd::Constant(1, 1, config.xsiOff_))
   {
   }
 
-  VelocityDamper::VelocityDamper(const VelocityDamperConfig & config, double big)
-  : VelocityDamper(VelocityDamperAnisotropicConfig{config}, big)
+  VelocityDamper::VelocityDamper(const Config & config, double big)
+  : VelocityDamper(AnisotropicConfig{config}, big)
   {
   }
 
-  VelocityDamper::VelocityDamper(const VelocityDamperAnisotropicConfig& config, double big)
+  VelocityDamper::VelocityDamper(const AnisotropicConfig& config, double big)
     : dt_(0)
     , xsi_(0)
     , ds_(config.ds_)
@@ -101,12 +101,12 @@ namespace task_dynamics
     }
   }
 
-  VelocityDamper::VelocityDamper(double dt, const VelocityDamperConfig & config, double big)
-  : VelocityDamper(dt, VelocityDamperAnisotropicConfig{config}, big)
+  VelocityDamper::VelocityDamper(double dt, const Config & config, double big)
+  : VelocityDamper(dt, AnisotropicConfig{config}, big)
   {
   }
 
-  VelocityDamper::VelocityDamper(double dt, const VelocityDamperAnisotropicConfig& config, double big)
+  VelocityDamper::VelocityDamper(double dt, const AnisotropicConfig& config, double big)
     : dt_(dt)
     , xsi_(0)
     , ds_(config.ds_)


### PR DESCRIPTION
This PR implements the option to specify anisotropic parameters for the `VelocityDamper` dynamic. Dimension checking doesn't happen before the implementation of the dynamic is created but I don't think we can do much better.

To keep the changes simple the automatic xsi computation is either enabled or disabled on all-dimensions.