### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
 AlignOperands:   true
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
@@ -43,26 +43,6 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks: Preserve
-IncludeCategories:
-  - Regex:           '^(<mc_[a-z]*/)'
-    Priority:        1
-  - Regex:           '^(<Tasks/)'
-    Priority:        2
-  - Regex:           '^(<mc_rbdyn_urdf/)'
-    Priority:        3
-  - Regex:           '^(<RBDyn/)'
-    Priority:        4
-  - Regex:           '^(<SpaceVecAlg/)'
-    Priority:        5
-  - Regex:           '^(<sch-core/)'
-    Priority:        6
-  - Regex:           '^(<boost/)'
-    Priority:        7
-  - Regex:           '^(<(nanomsg|geos|.*_msgs|ros|tf2.*)/)'
-    Priority:        8
-  - Regex:           '.*'
-    Priority:        9
-IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash
 IndentWidth:     2

--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,22 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: false
 BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,106 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^(<mc_[a-z]*/)'
+    Priority:        1
+  - Regex:           '^(<Tasks/)'
+    Priority:        2
+  - Regex:           '^(<mc_rbdyn_urdf/)'
+    Priority:        3
+  - Regex:           '^(<RBDyn/)'
+    Priority:        4
+  - Regex:           '^(<SpaceVecAlg/)'
+    Priority:        5
+  - Regex:           '^(<sch-core/)'
+    Priority:        6
+  - Regex:           '^(<boost/)'
+    Priority:        7
+  - Regex:           '^(<(nanomsg|geos|.*_msgs|ros|tf2.*)/)'
+    Priority:        8
+  - Regex:           '.*'
+    Priority:        9
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 150
+PenaltyReturnTypeOnItsOwnLine: 300
+PointerAlignment: Middle
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never
+...
+

--- a/.clang-format-check.sh
+++ b/.clang-format-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+readonly this_dir=`cd $(dirname $0); pwd`
+cd $this_dir
+source .clang-format-common.sh
+
+out=0
+tmpfile=$(mktemp /tmp/clang-format-check.XXXXXX)
+for f in ${src_files}; do
+  $clang_format -style=file $f > $tmpfile
+  if ! [[ -z `diff $tmpfile $f` ]]; then
+    echo "Wrong formatting in $f"
+    out=1
+  fi
+done
+rm -f $tmpfile
+if [[ $out -eq 1 ]]; then
+  echo "You can run ./.clang-format-fix.sh to fix the issues locally, then commit/push again"
+fi
+exit $out

--- a/.clang-format-common.sh
+++ b/.clang-format-common.sh
@@ -2,7 +2,7 @@
 
 # Check for clang-format, prefer 10 if available
 if [[ -x "$(command -v clang-format-10)" ]]; then
-  clang_format=clang-format-6.0
+  clang_format=clang-format-10
 elif [[ -x "$(command -v clang-format)" ]]; then
   clang_format=clang-format
 else

--- a/.clang-format-common.sh
+++ b/.clang-format-common.sh
@@ -1,12 +1,12 @@
 # This script is meant to be sourced from other scripts
 
-# Check for clang-format, prefer 6.0 if available
-if [[ -x "$(command -v clang-format-6.0)" ]]; then
+# Check for clang-format, prefer 10 if available
+if [[ -x "$(command -v clang-format-10)" ]]; then
   clang_format=clang-format-6.0
 elif [[ -x "$(command -v clang-format)" ]]; then
   clang_format=clang-format
 else
-  echo "clang-format or clang-format-6.0 must be installed"
+  echo "clang-format or clang-format-10 must be installed"
   exit 1
 fi
 

--- a/.clang-format-common.sh
+++ b/.clang-format-common.sh
@@ -11,4 +11,4 @@ else
 fi
 
 # Find all source files in the project minus those that are auto-generated or we do not maintain
-src_files=`find examples include src tests -name '*.cpp' -or -name '*.h' -or -name '*.hpp'`
+src_files=`find examples include src tests -name '*.cpp' -or -name '*.h' -or -name '*.hpp'|grep -Ev "tests/doctest/doctest.h"`

--- a/.clang-format-common.sh
+++ b/.clang-format-common.sh
@@ -1,0 +1,14 @@
+# This script is meant to be sourced from other scripts
+
+# Check for clang-format, prefer 6.0 if available
+if [[ -x "$(command -v clang-format-6.0)" ]]; then
+  clang_format=clang-format-6.0
+elif [[ -x "$(command -v clang-format)" ]]; then
+  clang_format=clang-format
+else
+  echo "clang-format or clang-format-6.0 must be installed"
+  exit 1
+fi
+
+# Find all source files in the project minus those that are auto-generated or we do not maintain
+src_files=`find examples include src tests -name '*.cpp' -or -name '*.h' -or -name '*.hpp'`

--- a/.clang-format-fix.sh
+++ b/.clang-format-fix.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+readonly this_dir=`cd $(dirname $0); pwd`
+cd $this_dir
+source .clang-format-common.sh
+
+for f in ${src_files}; do
+  $clang_format -style=file -i $f
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,8 @@ on:
   push:
     paths-ignore:
       # Changes to those files don't mandate running CI
-      - ".gitlab-ci.yml"
-      - ".jrl-ci"
-      - ".github/workflows/package.yml"
-      - "debian/**"
+      - ".github/workflows/clang-format.yml"
+      - ".clang-format*"
     branches:
       - '**'
   pull_request:
@@ -15,22 +13,7 @@ on:
       - '**'
 
 jobs:
-
-  #clang-format:
-  #  runs-on: ubuntu-18.04
-  #  steps:
-  #  - uses: actions/checkout@v1
-  #  - name: Install clang-format-6.0
-  #    run: |
-  #      sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-  #      sudo apt-get -qq update
-  #      sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
-  #      sudo apt-get -qq install clang-format-6.0 clang-format
-  #  - name: Run clang-format-check
-  #    run: |
-  #      ./.clang-format-check.sh
   build:
-    #needs: clang-format
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,24 @@
+name: clang-format TVM
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install clang-format-6.0
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get -qq update
+        sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
+        sudo apt-get -qq install clang-format-6.0 clang-format
+    - name: Run clang-format-check
+      run: |
+        ./.clang-format-check.sh

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Install clang-format-6.0
+    - name: Install clang-format-10
       run: |
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get -qq update
         sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
-        sudo apt-get -qq install clang-format-6.0 clang-format
+        sudo apt-get -qq install clang-format-10
     - name: Run clang-format-check
       run: |
         ./.clang-format-check.sh

--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+readonly mc_rtc_dir=`cd $(dirname $0)/../..; pwd`
+cd $mc_rtc_dir
+
+source .clang-format-common.sh
+
+out=0
+tmpfile=$(mktemp /tmp/clang-format-check.XXXXXX)
+for f in `git diff --cached --name-only --diff-filter=ACM|grep -v "^doc"`; do
+  case "$f" in
+    *.cpp | *.h | *.hpp)
+      $clang_format -style=file $f > $tmpfile
+      if ! [[ -z `diff $tmpfile $f` ]]; then
+        echo "Wrong formatting in $f"
+        out=1
+      fi
+      ;;
+    *)
+      ;;
+  esac
+done
+rm -f $tmpfile
+if [[ $out -eq 1 ]]; then
+  echo "Run ./.clang-format-fix.sh to fix issues"
+fi
+exit $out

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
+Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/examples/FunctionWritingExample.cpp
+++ b/examples/FunctionWritingExample.cpp
@@ -4,182 +4,179 @@
 
 namespace tvm::example
 {
-  class DotProduct : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(DotProduct, Value, Jacobian, VelocityAndNormalAcc, JDot)
+class DotProduct : public function::abstract::Function
+{
+public:
+  SET_UPDATES(DotProduct, Value, Jacobian, VelocityAndNormalAcc, JDot)
 
-    DotProduct(VariablePtr x, VariablePtr y);
+  DotProduct(VariablePtr x, VariablePtr y);
 
-    void updateValue();
-    void updateJacobian();
-    void updateVelocityAndNormalAcc();
-    void updateJDot();
+  void updateValue();
+  void updateJacobian();
+  void updateVelocityAndNormalAcc();
+  void updateJDot();
 
-  private:
-    Variable& x_;
-    Variable& y_;
-    Variable& dx_;
-    Variable& dy_;
-  };
+private:
+  Variable & x_;
+  Variable & y_;
+  Variable & dx_;
+  Variable & dy_;
+};
 
-  DotProduct::DotProduct(VariablePtr x, VariablePtr y)
-    : Function(1)
-    , x_(*x)
-    , y_(*y)
-    , dx_(*dot(x))
-    , dy_(*dot(y))
-  {
+DotProduct::DotProduct(VariablePtr x, VariablePtr y) : Function(1), x_(*x), y_(*y), dx_(*dot(x)), dy_(*dot(y))
+{
+  // clang-format off
     registerUpdates(Update::Value, &DotProduct::updateValue,
       Update::Jacobian, &DotProduct::updateJacobian,
       Update::VelocityAndNormalAcc, &DotProduct::updateVelocityAndNormalAcc,
       Update::JDot, &DotProduct::updateJDot);
-    addOutputDependency<DotProduct>(Output::Value, Update::Value);
-    addOutputDependency<DotProduct>(Output::Jacobian, Update::Jacobian);
-    addOutputDependency<DotProduct>({ Output::Velocity, Output::NormalAcceleration }, Update::VelocityAndNormalAcc);
-    addOutputDependency<DotProduct>(Output::JDot, Update::JDot);
-    addVariable(x, true);
-    addVariable(y, true);
-  }
-
-  void DotProduct::updateValue()
-  {
-    value_ = x_.value().transpose() * y_.value();
-  }
-
-  void DotProduct::updateJacobian()
-  {
-    jacobian_.at(&x_) = y_.value().transpose();
-    jacobian_.at(&y_) = x_.value().transpose();
-  }
-
-  void DotProduct::updateVelocityAndNormalAcc()
-  {
-    velocity_ = dx_.value().transpose() * y_.value() + x_.value().transpose() * dy_.value();
-    normalAcceleration_ = 2 * dx_.value().transpose() * dy_.value();
-  }
-
-  void DotProduct::updateJDot()
-  {
-    JDot_.at(&x_) = dy_.value().transpose();
-    JDot_.at(&y_) = dx_.value().transpose();
-  }
+  // clang-format on
+  addOutputDependency<DotProduct>(Output::Value, Update::Value);
+  addOutputDependency<DotProduct>(Output::Jacobian, Update::Jacobian);
+  addOutputDependency<DotProduct>({Output::Velocity, Output::NormalAcceleration}, Update::VelocityAndNormalAcc);
+  addOutputDependency<DotProduct>(Output::JDot, Update::JDot);
+  addVariable(x, true);
+  addVariable(y, true);
 }
+
+void DotProduct::updateValue() { value_ = x_.value().transpose() * y_.value(); }
+
+void DotProduct::updateJacobian()
+{
+  jacobian_.at(&x_) = y_.value().transpose();
+  jacobian_.at(&y_) = x_.value().transpose();
+}
+
+void DotProduct::updateVelocityAndNormalAcc()
+{
+  velocity_ = dx_.value().transpose() * y_.value() + x_.value().transpose() * dy_.value();
+  normalAcceleration_ = 2 * dx_.value().transpose() * dy_.value();
+}
+
+void DotProduct::updateJDot()
+{
+  JDot_.at(&x_) = dy_.value().transpose();
+  JDot_.at(&y_) = dx_.value().transpose();
+}
+} // namespace tvm::example
 
 #include <vector>
 #include <tvm/graph/abstract/OutputSelector.h>
 
 namespace tvm::example
 {
-  class FunctionDotProduct : public graph::abstract::OutputSelector<function::abstract::Function>
-  {
-  public:
-    DISABLE_OUTPUTS(Output::JDot)
-    SET_UPDATES(FunctionDotProduct, Value, Jacobian, Velocity, NormalAcc)
+class FunctionDotProduct : public graph::abstract::OutputSelector<function::abstract::Function>
+{
+public:
+  DISABLE_OUTPUTS(Output::JDot)
+  SET_UPDATES(FunctionDotProduct, Value, Jacobian, Velocity, NormalAcc)
 
-    FunctionDotProduct(FunctionPtr g, FunctionPtr h);
+  FunctionDotProduct(FunctionPtr g, FunctionPtr h);
 
-    void updateValue();
-    void updateJacobian();
-    void updateVelocity();
-    void updateNormalAcc();
+  void updateValue();
+  void updateJacobian();
+  void updateVelocity();
+  void updateNormalAcc();
 
-  private:
-    // Register the inputs and update, and specify the dependencies output <- update <- inputs
-    template<typename Out, typename Up, typename... In>
-    void processOutput(Out output, Up u, void (FunctionDotProduct::* update)(), In... inputs);
-
-    FunctionPtr g_;
-    FunctionPtr h_;
-  };
-
-  FunctionDotProduct::FunctionDotProduct(FunctionPtr g, FunctionPtr h)
-    : graph::abstract::OutputSelector<function::abstract::Function>(1)
-    , g_(g)
-    , h_(h)
-  {
-    if (!g->imageSpace().isEuclidean() || !h->imageSpace().isEuclidean())
-      throw std::runtime_error("Function g and h must have their values in an Euclidean space.");
-    if (g->size() != h->size())
-      throw std::runtime_error("Function g and h must have the same size");
-
-    processOutput(Output::Value, Update::Value, &FunctionDotProduct::updateValue, Output::Value);
-    processOutput(Output::Jacobian, Update::Jacobian, &FunctionDotProduct::updateJacobian, Output::Value, Output::Jacobian);
-    processOutput(Output::Velocity, Update::Velocity, &FunctionDotProduct::updateVelocity, Output::Value, Output::Velocity);
-    processOutput(Output::NormalAcceleration, Update::NormalAcc, &FunctionDotProduct::updateNormalAcc, Output::Value, Output::Velocity, Output::NormalAcceleration);
-
-    for (const auto& xi : g_->variables())
-    {
-      bool lin = g_->linearIn(*xi) && !h_->variables().contains(*xi);
-      addVariable(xi, lin);
-    }
-    for (const auto& xi : h_->variables())
-    {
-      bool lin = h_->linearIn(*xi) && !g_->variables().contains(*xi);
-      addVariable(xi, lin);
-    }
-  }
-
-  void FunctionDotProduct::updateValue()
-  {
-    value_ = g_->value().transpose() * h_->value();
-  }
-
-  void FunctionDotProduct::updateJacobian()
-  {
-    // We reset all the jacobian matrices (we could do that only for those corresponding to variable of h)
-    for (const auto& xi : variables_)
-      jacobian_.at(xi.get()).setZero();
-
-    for (const auto& xi : g_->variables())
-      jacobian_.at(xi.get()) = h_->value().transpose() * g_->jacobian(*xi);
-
-    // We use += here, because if a variable is also present in g, we need to add to the previously copied jacobian matrix
-    for (const auto& xi : h_->variables())
-      jacobian_.at(xi.get()) += g_->value().transpose() * h_->jacobian(*xi);
-  }
-
-  void FunctionDotProduct::updateVelocity()
-  {
-    velocity_ = g_->value().transpose() * h_->velocity() + g_->velocity().transpose() * h_->value();
-  }
-
-  void FunctionDotProduct::updateNormalAcc()
-  {
-    normalAcceleration_ = 2 * g_->velocity().transpose() * h_->velocity() 
-                        + g_->value().transpose() * h_->normalAcceleration() 
-                        + h_->value().transpose() * g_->normalAcceleration();
-  }
-
+private:
+  // Register the inputs and update, and specify the dependencies output <- update <- inputs
   template<typename Out, typename Up, typename... In>
-  void FunctionDotProduct::processOutput(Out output, Up u, void (FunctionDotProduct::* update)(), In... inputs)
-  {
-    // We enable the output is all the required inputs are enabled for g and h
-    bool enableOutput = (... && (g_->isOutputEnabled(inputs) && h_->isOutputEnabled(inputs)));
+  void processOutput(Out output, Up u, void (FunctionDotProduct::*update)(), In... inputs);
 
-    if (enableOutput)
-    {
-      addInput(g_, inputs...);
-      addInput(h_, inputs...);
-      registerUpdates(u, update);
-      addInputDependency<FunctionDotProduct>(u, g_, inputs...);
-      addInputDependency<FunctionDotProduct>(u, h_, inputs...);
-      addOutputDependency<FunctionDotProduct>(output, u);
-    }
-    else
-      disableOutput(output);
+  FunctionPtr g_;
+  FunctionPtr h_;
+};
+
+FunctionDotProduct::FunctionDotProduct(FunctionPtr g, FunctionPtr h)
+: graph::abstract::OutputSelector<function::abstract::Function>(1), g_(g), h_(h)
+{
+  if(!g->imageSpace().isEuclidean() || !h->imageSpace().isEuclidean())
+    throw std::runtime_error("Function g and h must have their values in an Euclidean space.");
+  if(g->size() != h->size())
+    throw std::runtime_error("Function g and h must have the same size");
+
+  processOutput(Output::Value, Update::Value, &FunctionDotProduct::updateValue, Output::Value);
+  processOutput(Output::Jacobian, Update::Jacobian, &FunctionDotProduct::updateJacobian, Output::Value,
+                Output::Jacobian);
+  processOutput(Output::Velocity, Update::Velocity, &FunctionDotProduct::updateVelocity, Output::Value,
+                Output::Velocity);
+  processOutput(Output::NormalAcceleration, Update::NormalAcc, &FunctionDotProduct::updateNormalAcc, Output::Value,
+                Output::Velocity, Output::NormalAcceleration);
+
+  for(const auto & xi : g_->variables())
+  {
+    bool lin = g_->linearIn(*xi) && !h_->variables().contains(*xi);
+    addVariable(xi, lin);
+  }
+  for(const auto & xi : h_->variables())
+  {
+    bool lin = h_->linearIn(*xi) && !g_->variables().contains(*xi);
+    addVariable(xi, lin);
   }
 }
 
+void FunctionDotProduct::updateValue() { value_ = g_->value().transpose() * h_->value(); }
 
-//Let's run some quick tests to ensure these examples are not outdated and compile.
+void FunctionDotProduct::updateJacobian()
+{
+  // We reset all the jacobian matrices (we could do that only for those corresponding to variable of h)
+  for(const auto & xi : variables_)
+  {
+    jacobian_.at(xi.get()).setZero();
+  }
+
+  for(const auto & xi : g_->variables())
+  {
+    jacobian_.at(xi.get()) = h_->value().transpose() * g_->jacobian(*xi);
+  }
+
+  // We use += here, because if a variable is also present in g, we need to add to the previously copied jacobian matrix
+  for(const auto & xi : h_->variables())
+  {
+    jacobian_.at(xi.get()) += g_->value().transpose() * h_->jacobian(*xi);
+  }
+}
+
+void FunctionDotProduct::updateVelocity()
+{
+  velocity_ = g_->value().transpose() * h_->velocity() + g_->velocity().transpose() * h_->value();
+}
+
+void FunctionDotProduct::updateNormalAcc()
+{
+  normalAcceleration_ = 2 * g_->velocity().transpose() * h_->velocity()
+                        + g_->value().transpose() * h_->normalAcceleration()
+                        + h_->value().transpose() * g_->normalAcceleration();
+}
+
+template<typename Out, typename Up, typename... In>
+void FunctionDotProduct::processOutput(Out output, Up u, void (FunctionDotProduct::*update)(), In... inputs)
+{
+  // We enable the output is all the required inputs are enabled for g and h
+  bool enableOutput = (... && (g_->isOutputEnabled(inputs) && h_->isOutputEnabled(inputs)));
+
+  if(enableOutput)
+  {
+    addInput(g_, inputs...);
+    addInput(h_, inputs...);
+    registerUpdates(u, update);
+    addInputDependency<FunctionDotProduct>(u, g_, inputs...);
+    addInputDependency<FunctionDotProduct>(u, h_, inputs...);
+    addOutputDependency<FunctionDotProduct>(output, u);
+  }
+  else
+    disableOutput(output);
+}
+} // namespace tvm::example
+
+// Let's run some quick tests to ensure these examples are not outdated and compile.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"
 
-#include<iostream>
-#include<tvm/function/IdentityFunction.h>
-#include<tvm/utils/graph.h>
+#include <iostream>
+#include <tvm/function/IdentityFunction.h>
+#include <tvm/utils/graph.h>
 
 using namespace tvm;
 using namespace tvm::example;
@@ -187,7 +184,7 @@ using namespace Eigen;
 
 TEST_CASE("DotProduct")
 {
-  //Creating and initializing variables
+  // Creating and initializing variables
   Space R3(3);
   VariablePtr x = R3.createVariable("x");
   x << 1, 2, 3;
@@ -239,7 +236,7 @@ public:
 
 TEST_CASE("FunctionDotProduct")
 {
-  //Creating and initializing variables
+  // Creating and initializing variables
   Space R3(3);
   VariablePtr x = R3.createVariable("x");
   x << 1, 2, 3;

--- a/examples/LeastSquaresExample.cpp
+++ b/examples/LeastSquaresExample.cpp
@@ -15,11 +15,13 @@ Matrix3d rotationFromZ(Vector3d v)
 {
   v.normalize();
   Matrix3d R;
-  if (v[2] + 1 < 1e-8)
+  if(v[2] + 1 < 1e-8)
   {
+    // clang-format off
     R << 1, 0, 0,
          0, 1, 0,
          0, 0, -1;
+    // clang-format on
   }
   else
   {
@@ -27,20 +29,24 @@ Matrix3d rotationFromZ(Vector3d v)
     double ax2 = a * v[0] * v[0];
     double ay2 = a * v[1] * v[1];
     double axy = a * v[0] * v[1];
+    // clang-format off
     R << 1 - ax2,   -axy , v[0],
          -axy   , 1 - ay2, v[1],
           -v[0] ,  -v[1] , v[2];
+    // clang-format on
   }
   return R;
 }
 
 // Returns the antisymmetric matrix S such that for a fector x, S*x = v.cross(x)
-Matrix3d hat(const Vector3d& v)
+Matrix3d hat(const Vector3d & v)
 {
   Matrix3d S;
+  // clang-format off
   S <<  0  , -v[2],  v[1],
        v[2],   0  , -v[0],
       -v[1],  v[0],   0  ;
+  // clang-format on
   return S;
 }
 
@@ -49,8 +55,10 @@ MatrixXd discretizedFrictionCone(double mu)
 {
   double mub = mu / std::sqrt(2);
   MatrixXd C(4, 3);
+  // clang-format off
   C << Matrix2d::Identity(), Vector2d::Constant(mub),
       -Matrix2d::Identity(), Vector2d::Constant(mub);
+  // clang-format on
   return C;
 }
 
@@ -60,11 +68,11 @@ bool leastSquares3points()
   Space S(3);
 
   // Data for first contact point
-  Vector3d p1(-1, -1, 0);                     // Contact point position
-  Vector3d n1(1, 1, 1);                       // Normal vector to contact surface
-  MatrixXd R1 = rotationFromZ(n1);            // Rotation between world frame and a local contact frame
-  Vector3d f1des = Vector3d::Zero();          // Desired force for f1
-  VariablePtr f1 = S.createVariable("f1");    // Variable creation
+  Vector3d p1(-1, -1, 0); // Contact point position
+  Vector3d n1(1, 1, 1); // Normal vector to contact surface
+  MatrixXd R1 = rotationFromZ(n1); // Rotation between world frame and a local contact frame
+  Vector3d f1des = Vector3d::Zero(); // Desired force for f1
+  VariablePtr f1 = S.createVariable("f1"); // Variable creation
 
   // Data for second contact point
   Vector3d p2(1, 0, 0.5);
@@ -80,26 +88,26 @@ bool leastSquares3points()
   Vector3d f3des = Vector3d::Zero();
   VariablePtr f3 = S.createVariable("f3");
 
-  const double m = 1;                       // Mass
-  const Vector3d g(0, 0, -9.81);            // Gravity vector
-  VariablePtr c = S.createVariable("c");    // Center of mass variable
+  const double m = 1; // Mass
+  const Vector3d g(0, 0, -9.81); // Gravity vector
+  VariablePtr c = S.createVariable("c"); // Center of mass variable
 
   MatrixXd C = discretizedFrictionCone(0.6); // Matrix of a discretized cone with friction coefficient 0.6
 
   // Creating the problem
   LinearizedControlProblem pb;
-  pb.add(R1 * f1 + R2 * f2 + R3 * f3 + m * g == 0., PriorityLevel(0));  // Newton equation
-  pb.add(hat(p1) * R1 * f1 + hat(p2) * R2 * f2 
-       + hat(p3) * R3 * f3 + m * hat(g) * c == 0. , PriorityLevel(0));  // Euler equation
-  pb.add(C * f1 >= 0.                             , PriorityLevel(0));  // Friction cone constraints
-  pb.add(C * f2 >= 0.                             , PriorityLevel(0));
-  pb.add(C * f3 >= 0.                             , PriorityLevel(0));
-  pb.add(f1 == f1des                              , PriorityLevel(1));  // Desired forces
-  pb.add(f2 == f2des                              , PriorityLevel(1));
-  pb.add(f3 == f3des                              , PriorityLevel(1));
-  pb.add(c == p1                                  , { PriorityLevel(1), Weight(1e-4) }); // Desired CoM position
-  pb.add(c == p2                                  , { PriorityLevel(1), Weight(1e-4) });
-  pb.add(c == p3                                  , { PriorityLevel(1), Weight(1e-4) });
+  pb.add(R1 * f1 + R2 * f2 + R3 * f3 + m * g == 0., PriorityLevel(0)); // Newton equation
+  pb.add(hat(p1) * R1 * f1 + hat(p2) * R2 * f2 + hat(p3) * R3 * f3 + m * hat(g) * c == 0.,
+         PriorityLevel(0)); // Euler equation
+  pb.add(C * f1 >= 0., PriorityLevel(0)); // Friction cone constraints
+  pb.add(C * f2 >= 0., PriorityLevel(0));
+  pb.add(C * f3 >= 0., PriorityLevel(0));
+  pb.add(f1 == f1des, PriorityLevel(1)); // Desired forces
+  pb.add(f2 == f2des, PriorityLevel(1));
+  pb.add(f3 == f3des, PriorityLevel(1));
+  pb.add(c == p1, {PriorityLevel(1), Weight(1e-4)}); // Desired CoM position
+  pb.add(c == p2, {PriorityLevel(1), Weight(1e-4)});
+  pb.add(c == p3, {PriorityLevel(1), Weight(1e-4)});
 
   // Creating the resolution scheme
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions().verbose(true));
@@ -109,7 +117,7 @@ bool leastSquares3points()
   return found;
 }
 
-//Let's run some quick tests to ensure this example is not outdated and compiles.
+// Let's run some quick tests to ensure this example is not outdated and compiles.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"

--- a/examples/LeastSquaresExample.cpp
+++ b/examples/LeastSquaresExample.cpp
@@ -68,10 +68,10 @@ bool leastSquares3points()
   Space S(3);
 
   // Data for first contact point
-  Vector3d p1(-1, -1, 0); // Contact point position
-  Vector3d n1(1, 1, 1); // Normal vector to contact surface
-  MatrixXd R1 = rotationFromZ(n1); // Rotation between world frame and a local contact frame
-  Vector3d f1des = Vector3d::Zero(); // Desired force for f1
+  Vector3d p1(-1, -1, 0);                  // Contact point position
+  Vector3d n1(1, 1, 1);                    // Normal vector to contact surface
+  MatrixXd R1 = rotationFromZ(n1);         // Rotation between world frame and a local contact frame
+  Vector3d f1des = Vector3d::Zero();       // Desired force for f1
   VariablePtr f1 = S.createVariable("f1"); // Variable creation
 
   // Data for second contact point
@@ -88,8 +88,8 @@ bool leastSquares3points()
   Vector3d f3des = Vector3d::Zero();
   VariablePtr f3 = S.createVariable("f3");
 
-  const double m = 1; // Mass
-  const Vector3d g(0, 0, -9.81); // Gravity vector
+  const double m = 1;                    // Mass
+  const Vector3d g(0, 0, -9.81);         // Gravity vector
   VariablePtr c = S.createVariable("c"); // Center of mass variable
 
   MatrixXd C = discretizedFrictionCone(0.6); // Matrix of a discretized cone with friction coefficient 0.6
@@ -98,7 +98,7 @@ bool leastSquares3points()
   LinearizedControlProblem pb;
   pb.add(R1 * f1 + R2 * f2 + R3 * f3 + m * g == 0., PriorityLevel(0)); // Newton equation
   pb.add(hat(p1) * R1 * f1 + hat(p2) * R2 * f2 + hat(p3) * R3 * f3 + m * hat(g) * c == 0.,
-         PriorityLevel(0)); // Euler equation
+         PriorityLevel(0));               // Euler equation
   pb.add(C * f1 >= 0., PriorityLevel(0)); // Friction cone constraints
   pb.add(C * f2 >= 0., PriorityLevel(0));
   pb.add(C * f3 >= 0., PriorityLevel(0));

--- a/examples/ProblemWritingExample.cpp
+++ b/examples/ProblemWritingExample.cpp
@@ -24,38 +24,38 @@ constexpr double dt = 0.1;
 
 VectorXd IKExample()
 {
-  //Creating variable x in R^2 and initialize it to [0.5, 0.5]
+  // Creating variable x in R^2 and initialize it to [0.5, 0.5]
   Space R2(2);
   VariablePtr x = R2.createVariable("x");
   x << 0.5, 0.5;
 
-  //Creating variable q in R^3 and initialize it to [0.4, -0.6, -0.1]
+  // Creating variable q in R^3 and initialize it to [0.4, -0.6, -0.1]
   Space R3(3);
   VariablePtr q = R3.createVariable("q");
   q->value(Vector3d(0.4, -0.6, -0.1));
 
-  //Creating the functions
+  // Creating the functions
   auto g = make_shared<Simple2dRobotEE>(q, Vector2d(-3, 0), Vector3d(1, 1, 1)); // g(q)
-  auto idx = make_shared<function::IdentityFunction>(x);                        // I x
-  auto e1 = make_shared<Difference>(g, idx);                                    // e_1(q,x) = g(q) - x
-  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1);                  // e_2(x)
+  auto idx = make_shared<function::IdentityFunction>(x); // I x
+  auto e1 = make_shared<Difference>(g, idx); // e_1(q,x) = g(q) - x
+  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1); // e_2(x)
 
-  Vector3d b = Vector3d::Constant(tvm::constant::pi/2);
+  Vector3d b = Vector3d::Constant(tvm::constant::pi / 2);
 
-  //Creating the problem
+  // Creating the problem
   ControlProblem pb;
-  auto t1 = pb.add(e1 == 0., Proportional(2),  PriorityLevel(0));
+  auto t1 = pb.add(e1 == 0., Proportional(2), PriorityLevel(0));
   auto t2 = pb.add(e2 == 0., Proportional(2), PriorityLevel(0));
-  auto t3 = pb.add(-b <= q <= b, VelocityDamper({ 1, 0.01, 0, 0.1 }), PriorityLevel(0));
-  auto t4 = pb.add(dot(q) == 0., { PriorityLevel(1), AnisotropicWeight(Vector3d(10,2,1)) });
+  auto t3 = pb.add(-b <= q <= b, VelocityDamper({1, 0.01, 0, 0.1}), PriorityLevel(0));
+  auto t4 = pb.add(dot(q) == 0., {PriorityLevel(1), AnisotropicWeight(Vector3d(10, 2, 1))});
 
-  //Linearization
+  // Linearization
   LinearizedControlProblem lpb(pb);
 
-  //Creating the resolution scheme
+  // Creating the resolution scheme
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions{});
 
-  //IK loop
+  // IK loop
   int i = 0;
   do
   {
@@ -63,7 +63,7 @@ VectorXd IKExample()
     x->value(x->value() + dot(x)->value() * dt);
     q->value(q->value() + dot(q)->value() * dt);
     ++i;
-  } while ((dot(q)->value().norm() > 1e-8 || dot(x)->value().norm() > 1e-8) && i < maxIt);
+  } while((dot(q)->value().norm() > 1e-8 || dot(x)->value().norm() > 1e-8) && i < maxIt);
 
   std::cout << "At q = " << q->value().transpose() << ",\n    e1 = " << e1->value().transpose() << "\n"
             << "   convergence in " << i << " iterations" << std::endl;
@@ -82,17 +82,17 @@ VectorXd IKSubstitutionExample()
   q->value(Vector3d(0.4, -0.6, -0.1));
 
   auto g = make_shared<Simple2dRobotEE>(q, Vector2d(-3, 0), Vector3d(1, 1, 1)); // g(q)
-  auto idx = make_shared<function::IdentityFunction>(x);                        // I x
-  auto e1 = make_shared<Difference>(g, idx);                                    // e_1(q,x) = g(q) - x
-  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1);                  // e_2(x)
+  auto idx = make_shared<function::IdentityFunction>(x); // I x
+  auto e1 = make_shared<Difference>(g, idx); // e_1(q,x) = g(q) - x
+  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1); // e_2(x)
 
-  Vector3d b = Vector3d::Constant(tvm::constant::pi/2);
+  Vector3d b = Vector3d::Constant(tvm::constant::pi / 2);
 
   ControlProblem pb;
   auto t1 = pb.add(e1 == 0., Proportional(2), PriorityLevel(0));
   auto t2 = pb.add(e2 == 0., Proportional(2), PriorityLevel(0));
-  auto t3 = pb.add(-b <= q <= b, VelocityDamper({ 1, 0.01, 0, 0.1 }), PriorityLevel(0));
-  auto t4 = pb.add(dot(q) == 0., { PriorityLevel(1), AnisotropicWeight(Vector3d(10,2,1)) });
+  auto t3 = pb.add(-b <= q <= b, VelocityDamper({1, 0.01, 0, 0.1}), PriorityLevel(0));
+  auto t4 = pb.add(dot(q) == 0., {PriorityLevel(1), AnisotropicWeight(Vector3d(10, 2, 1))});
 
   LinearizedControlProblem lpb(pb);
   lpb.add(hint::Substitution(lpb.constraint(t1.get()), dot(x)));
@@ -105,15 +105,15 @@ VectorXd IKSubstitutionExample()
     x->value(x->value() + dot(x)->value() * dt);
     q->value(q->value() + dot(q)->value() * dt);
     ++i;
-  } while ((dot(q)->value().norm() > 1e-8 || dot(x)->value().norm() > 1e-8) && i < maxIt);
+  } while((dot(q)->value().norm() > 1e-8 || dot(x)->value().norm() > 1e-8) && i < maxIt);
 
   std::cout << "At q = " << q->value().transpose() << ",\n    e1 = " << e1->value().transpose() << "\n"
-    << "   convergence in " << i << " iterations" << std::endl;
+            << "   convergence in " << i << " iterations" << std::endl;
 
   return q->value();
 }
 
-//Let's run some quick tests to ensure this example is not outdated and compiles.
+// Let's run some quick tests to ensure this example is not outdated and compiles.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"

--- a/examples/ProblemWritingExample.cpp
+++ b/examples/ProblemWritingExample.cpp
@@ -36,9 +36,9 @@ VectorXd IKExample()
 
   // Creating the functions
   auto g = make_shared<Simple2dRobotEE>(q, Vector2d(-3, 0), Vector3d(1, 1, 1)); // g(q)
-  auto idx = make_shared<function::IdentityFunction>(x); // I x
-  auto e1 = make_shared<Difference>(g, idx); // e_1(q,x) = g(q) - x
-  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1); // e_2(x)
+  auto idx = make_shared<function::IdentityFunction>(x);                        // I x
+  auto e1 = make_shared<Difference>(g, idx);                                    // e_1(q,x) = g(q) - x
+  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1);                  // e_2(x)
 
   Vector3d b = Vector3d::Constant(tvm::constant::pi / 2);
 
@@ -82,9 +82,9 @@ VectorXd IKSubstitutionExample()
   q->value(Vector3d(0.4, -0.6, -0.1));
 
   auto g = make_shared<Simple2dRobotEE>(q, Vector2d(-3, 0), Vector3d(1, 1, 1)); // g(q)
-  auto idx = make_shared<function::IdentityFunction>(x); // I x
-  auto e1 = make_shared<Difference>(g, idx); // e_1(q,x) = g(q) - x
-  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1); // e_2(x)
+  auto idx = make_shared<function::IdentityFunction>(x);                        // I x
+  auto e1 = make_shared<Difference>(g, idx);                                    // e_1(q,x) = g(q) - x
+  auto e2 = make_shared<SphereFunction>(x, Vector2d(0, 0), 1);                  // e_2(x)
 
   Vector3d b = Vector3d::Constant(tvm::constant::pi / 2);
 

--- a/examples/TaskDynamicsExample.cpp
+++ b/examples/TaskDynamicsExample.cpp
@@ -64,8 +64,7 @@ AdaptiveProportional::Impl::Impl(FunctionPtr f,
                                  double b,
                                  double c)
 : TaskDynamicsImpl(task_dynamics::Order::One, f, t, rhs), a_(a), b_(b), c_(c)
-{
-}
+{}
 
 void AdaptiveProportional::Impl::updateValue()
 {

--- a/examples/TaskDynamicsExample.cpp
+++ b/examples/TaskDynamicsExample.cpp
@@ -69,9 +69,9 @@ AdaptiveProportional::Impl::Impl(FunctionPtr f,
 
 void AdaptiveProportional::Impl::updateValue()
 {
-  value_ = function().value() - rhs(); // e = f - rhs
+  value_ = function().value() - rhs();            // e = f - rhs
   double kp = a_ * exp(-b_ * value_.norm()) + c_; // k_p = a exp(-b ||e||) + c
-  value_ *= -kp; // \dot{e} = -k_p e
+  value_ *= -kp;                                  // \dot{e} = -k_p e
 }
 } // namespace tvm::example
 

--- a/examples/TaskDynamicsExample.cpp
+++ b/examples/TaskDynamicsExample.cpp
@@ -4,76 +4,78 @@
 
 namespace tvm::example
 {
-  /** A class implementing the task dynamics
-    * \f$
-    *     \dot{e}^* = - (a \exp(-b \left\|e\right\|) + c) e
-    * \f$
-    */
-  class AdaptiveProportional : public task_dynamics::abstract::TaskDynamics
+/** A class implementing the task dynamics
+ * \f$
+ *     \dot{e}^* = - (a \exp(-b \left\|e\right\|) + c) e
+ * \f$
+ */
+class AdaptiveProportional : public task_dynamics::abstract::TaskDynamics
+{
+public:
+  class Impl : public task_dynamics::abstract::TaskDynamicsImpl
   {
-    public:
-      class Impl : public task_dynamics::abstract::TaskDynamicsImpl
-      {
-      public:
-        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, double a, double b, double c);
-        void updateValue() override;
+  public:
+    Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, double a, double b, double c);
+    void updateValue() override;
 
-      private:
-        double a_;
-        double b_;
-        double c_;
-      };
-
-      AdaptiveProportional(double a, double b, double c);
-
-    protected:
-      std::unique_ptr<task_dynamics::abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-      task_dynamics::Order order_() const override;
-
-      TASK_DYNAMICS_DERIVED_FACTORY(a_, b_, c_)
-
-    private:
-      double a_;
-      double b_;
-      double c_;
+  private:
+    double a_;
+    double b_;
+    double c_;
   };
-}
+
+  AdaptiveProportional(double a, double b, double c);
+
+protected:
+  std::unique_ptr<task_dynamics::abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                                   constraint::Type t,
+                                                                   const Eigen::VectorXd & rhs) const override;
+  task_dynamics::Order order_() const override;
+
+  TASK_DYNAMICS_DERIVED_FACTORY(a_, b_, c_)
+
+private:
+  double a_;
+  double b_;
+  double c_;
+};
+} // namespace tvm::example
 
 // So far tvm::function::abstract::Function was only forward-declared
-#include<tvm/function/abstract/Function.h>
+#include <tvm/function/abstract/Function.h>
 
 namespace tvm::example
 {
-  AdaptiveProportional::AdaptiveProportional(double a, double b, double c)
-    : a_(a), b_(b), c_(c)
-  {
-  }
+AdaptiveProportional::AdaptiveProportional(double a, double b, double c) : a_(a), b_(b), c_(c) {}
 
-  std::unique_ptr<task_dynamics::abstract::TaskDynamicsImpl> AdaptiveProportional::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
-  {
-    return std::make_unique<Impl>(f, t, rhs, a_, b_, c_);
-  }
-
-  task_dynamics::Order AdaptiveProportional::order_() const
-  {
-    return task_dynamics::Order::One;
-  }
-
-  AdaptiveProportional::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, double a, double b, double c)
-    : TaskDynamicsImpl(task_dynamics::Order::One, f,t,rhs), a_(a), b_(b), c_(c)
-  {
-  }
-
-  void AdaptiveProportional::Impl::updateValue()
-  {
-    value_ = function().value() - rhs();              // e = f - rhs
-    double kp = a_ * exp(-b_ * value_.norm()) + c_;   // k_p = a exp(-b ||e||) + c
-    value_ *= -kp;                                    // \dot{e} = -k_p e
-  }
+std::unique_ptr<task_dynamics::abstract::TaskDynamicsImpl> AdaptiveProportional::impl_(FunctionPtr f,
+                                                                                       constraint::Type t,
+                                                                                       const Eigen::VectorXd & rhs) const
+{
+  return std::make_unique<Impl>(f, t, rhs, a_, b_, c_);
 }
 
+task_dynamics::Order AdaptiveProportional::order_() const { return task_dynamics::Order::One; }
 
-//Let's run some quick tests to ensure this example is not outdated and compiles.
+AdaptiveProportional::Impl::Impl(FunctionPtr f,
+                                 constraint::Type t,
+                                 const Eigen::VectorXd & rhs,
+                                 double a,
+                                 double b,
+                                 double c)
+: TaskDynamicsImpl(task_dynamics::Order::One, f, t, rhs), a_(a), b_(b), c_(c)
+{
+}
+
+void AdaptiveProportional::Impl::updateValue()
+{
+  value_ = function().value() - rhs(); // e = f - rhs
+  double kp = a_ * exp(-b_ * value_.norm()) + c_; // k_p = a exp(-b ||e||) + c
+  value_ *= -kp; // \dot{e} = -k_p e
+}
+} // namespace tvm::example
+
+// Let's run some quick tests to ensure this example is not outdated and compiles.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"
@@ -85,28 +87,28 @@ using namespace Eigen;
 
 TEST_CASE("AdaptiveProportional test")
 {
-  //Creation of a variable of size 3 and initialization
+  // Creation of a variable of size 3 and initialization
   VariablePtr x = Space(3).createVariable("x");
   x << .1, -.2, .3;
 
-  //Creation of an identity function f and a rhs;
+  // Creation of an identity function f and a rhs;
   auto f = std::make_shared<function::IdentityFunction>(x);
-  VectorXd rhs = Vector3d(.1,.1,-.1);
+  VectorXd rhs = Vector3d(.1, .1, -.1);
 
-  //Creating the TaskDynamics object
+  // Creating the TaskDynamics object
   example::AdaptiveProportional ap(1, 2, 0.1);
 
-  //Getting the implementation (not usually done by the user)
-  //The type is not important here
+  // Getting the implementation (not usually done by the user)
+  // The type is not important here
   auto impl = ap.impl(f, constraint::Type::EQUAL, rhs);
 
-  //Usually, the computation graph is handled automatically, but here we need to
-  //trigger the updates manually.
+  // Usually, the computation graph is handled automatically, but here we need to
+  // trigger the updates manually.
   f->updateValue();
   impl->updateValue();
 
-  //We have e = f-rhs = (0,-.3,.4) and ||e|| = .5
-  //a exp(-b ||e||) + c = exp(-1) + 0.1
+  // We have e = f-rhs = (0,-.3,.4) and ||e|| = .5
+  // a exp(-b ||e||) + c = exp(-1) + 0.1
   double kp = exp(-1) + 0.1;
   FAST_CHECK_UNARY(impl->value().isApprox(-kp * Vector3d(0, -.3, .4)));
 }

--- a/include/tvm/Clock.h
+++ b/include/tvm/Clock.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/defs.h>
+
 #include <tvm/graph/abstract/Outputs.h>
 
 #include <cstdint>

--- a/include/tvm/Clock.h
+++ b/include/tvm/Clock.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/Clock.h
+++ b/include/tvm/Clock.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -37,46 +37,49 @@
 namespace tvm
 {
 
-  class ControlProblem;
+class ControlProblem;
 
-  /** Represent a clock for the ControlProblem
+/** Represent a clock for the ControlProblem
+ *
+ * The current iteration of the problem can be accessed by time-dependant
+ * data to trigger computations
+ *
+ * Outputs:
+ *
+ *   - Time is moved along as the iterations go on
+ *
+ */
+class TVM_DLLAPI Clock : public graph::abstract::Outputs
+{
+  friend class ControlProblem;
+
+public:
+  SET_OUTPUTS(Clock, Time)
+
+  /** Constructor
    *
-   * The current iteration of the problem can be accessed by time-dependant
-   * data to trigger computations
-   *
-   * Outputs:
-   *
-   *   - Time is moved along as the iterations go on
+   * \param dt Timestep of the ControlProblem
    *
    */
-  class TVM_DLLAPI Clock: public graph::abstract::Outputs
-  {
-    friend class ControlProblem;
-  public:
-    SET_OUTPUTS(Clock, Time)
+  Clock(double dt);
 
-    /** Constructor
-     *
-     * \param dt Timestep of the ControlProblem
-     *
-     */
-    Clock(double dt);
+  /** Returns the number of ticks elapsed since the start of the problem */
+  inline uint64_t ticks() const { return ticks_; }
 
-    /** Returns the number of ticks elapsed since the start of the problem */
-    inline uint64_t ticks() const { return ticks_; }
+  /** Returns the timestep of the problem */
+  inline double dt() const { return dt_; }
 
-    /** Returns the timestep of the problem */
-    inline double dt() const { return dt_; }
+  /** Advance the clock by one tick */
+  void advance();
 
-    /** Advance the clock by one tick */
-    void advance();
-  protected:
-    Clock(const Clock &) = default;
-    Clock & operator=(const Clock &) = default;
-    Clock(Clock &&) = default;
-    Clock & operator=(Clock &&) = default;
-  private:
-    const double dt_;
-    uint64_t ticks_ = 0;
-  };
-}  // namespace tvm
+protected:
+  Clock(const Clock &) = default;
+  Clock & operator=(const Clock &) = default;
+  Clock(Clock &&) = default;
+  Clock & operator=(Clock &&) = default;
+
+private:
+  const double dt_;
+  uint64_t ticks_ = 0;
+};
+} // namespace tvm

--- a/include/tvm/ControlProblem.h
+++ b/include/tvm/ControlProblem.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/ControlProblem.h
+++ b/include/tvm/ControlProblem.h
@@ -1,43 +1,43 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/Task.h>
 #include <tvm/graph/CallGraph.h>
 #include <tvm/requirements/SolvingRequirements.h>
-#include <tvm/scheme/internal/helpers.h>
 #include <tvm/scheme/internal/ProblemComputationData.h>
-#include <tvm/scheme/internal/ResolutionSchemeBase.h>
 #include <tvm/scheme/internal/ProblemDefinitionEvent.h>
-#include <tvm/task_dynamics/abstract/TaskDynamics.h>
+#include <tvm/scheme/internal/ResolutionSchemeBase.h>
+#include <tvm/scheme/internal/helpers.h>
 #include <tvm/task_dynamics/None.h>
+#include <tvm/task_dynamics/abstract/TaskDynamics.h>
 #include <tvm/utils/ProtoTask.h>
 
 #include <memory>
@@ -45,134 +45,143 @@
 
 namespace tvm
 {
-  class TVM_DLLAPI TaskWithRequirements : public tvm::internal::ObjWithId
+class TVM_DLLAPI TaskWithRequirements : public tvm::internal::ObjWithId
+{
+public:
+  TaskWithRequirements(const Task & task, requirements::SolvingRequirements req);
+
+  Task task;
+  requirements::SolvingRequirementsWithCallbacks requirements;
+};
+
+using TaskWithRequirementsPtr = std::shared_ptr<TaskWithRequirements>;
+
+class TVM_DLLAPI ControlProblem
+{
+  friend class LinearizedControlProblem;
+
+public:
+  ControlProblem() = default;
+  /** \internal We delete these functions because they would require by
+   * default a copy of the unique_ptr in the computationData_ map.
+   * There is no problem in implementing them as long as there is a real
+   * deep copy of the ProblemComputationData. If making this copy, care must
+   * be taken that the objects pointed to by the unique_ptr are instances of
+   * classes derived from ProblemComputationData.
+   */
+  ControlProblem(const ControlProblem &) = delete;
+  ControlProblem & operator=(const ControlProblem &) = delete;
+
+  TaskWithRequirementsPtr add(const Task & task, const requirements::SolvingRequirements & req = {});
+  template<constraint::Type T>
+  TaskWithRequirementsPtr add(utils::ProtoTask<T> proto,
+                              const task_dynamics::abstract::TaskDynamics & td,
+                              const requirements::SolvingRequirements & req = {});
+  template<constraint::Type T>
+  TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto,
+                              const task_dynamics::abstract::TaskDynamics & td,
+                              const requirements::SolvingRequirements & req = {});
+  template<constraint::Type T>
+  TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements & req = {});
+  void add(TaskWithRequirementsPtr tr);
+  void remove(TaskWithRequirements * tr);
+  const std::vector<TaskWithRequirementsPtr> & tasks() const;
+
+  /** Number of tasks in the problem.*/
+  int size() const;
+
+  /** Compute all quantities necessary for solving the problem.*/
+  void update();
+
+  /** Finalize the data of the solver*/
+  void finalize();
+
+protected:
+  class Updater
   {
   public:
-    TaskWithRequirements(const Task& task, requirements::SolvingRequirements req);
+    Updater();
 
-    Task task;
-    requirements::SolvingRequirementsWithCallbacks requirements;
-  };
+    template<typename T, typename... Args>
+    void addInput(std::shared_ptr<T> source, Args... args);
+    template<typename T>
+    void removeInput(T * source);
 
-  using TaskWithRequirementsPtr = std::shared_ptr<TaskWithRequirements>;
-
-  class TVM_DLLAPI ControlProblem
-  {
-    friend class LinearizedControlProblem;
-  public:
-    ControlProblem() = default;
-    /** \internal We delete these functions because they would require by
-      * default a copy of the unique_ptr in the computationData_ map.
-      * There is no problem in implementing them as long as there is a real
-      * deep copy of the ProblemComputationData. If making this copy, care must
-      * be taken that the objects pointed to by the unique_ptr are instances of
-      * classes derived from ProblemComputationData.
-      */
-    ControlProblem(const ControlProblem&) = delete;
-    ControlProblem& operator=(const ControlProblem &) = delete;
-
-    TaskWithRequirementsPtr add(const Task& task, const requirements::SolvingRequirements& req = {});
-    template<constraint::Type T>
-    TaskWithRequirementsPtr add(utils::ProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req = {});
-    template<constraint::Type T>
-    TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req = {});
-    template<constraint::Type T>
-    TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements& req = {});
-    void add(TaskWithRequirementsPtr tr);
-    void remove(TaskWithRequirements* tr);
-    const std::vector<TaskWithRequirementsPtr>& tasks() const;
-
-    /** Number of tasks in the problem.*/
-    int size() const;
-
-    /** Compute all quantities necessary for solving the problem.*/
-    void update();
-
-    /** Finalize the data of the solver*/
-    void finalize();
-
-  protected:
-    class Updater
-    {
-    public:
-      Updater();
-
-      template<typename T, typename ... Args>
-      void addInput(std::shared_ptr<T> source, Args... args);
-      template<typename T>
-      void removeInput(T* source);
-
-      /** Manually calls for an update of the call graph, if needed.*/
-      void refresh();
-      /** Execute the call graph.*/
-      void run();
-
-    private:
-      bool upToDate_;
-      std::shared_ptr<graph::internal::Inputs> inputs_;
-      graph::CallGraph updateGraph_;
-    };
-
-    virtual void update_() {}
-    virtual void finalize_() {}
-
-    Updater updater_;
+    /** Manually calls for an update of the call graph, if needed.*/
+    void refresh();
+    /** Execute the call graph.*/
+    void run();
 
   private:
-    void notify(const scheme::internal::ProblemDefinitionEvent& e);
-    void addCallBackToTask(TaskWithRequirementsPtr tr);
-
-    //Note: we want to keep the tasks in the order they were introduced, mostly
-    //for human understanding and debugging purposes, so that we take a
-    //std::vector.
-    //If this induces too much overhead when adding/removing a constraint, then
-    //we should consider std::set.
-    std::vector<TaskWithRequirementsPtr> tr_;
-
-    // Tokens to identify and keep callbacks alive
-    tvm::utils::internal::map<TaskWithRequirements*, std::vector<internal::PairElementToken> > callbackTokens_;
-
-    //Computation data for the resolution schemes
-    std::map<scheme::identifier, std::unique_ptr<scheme::internal::ProblemComputationData>> computationData_;
-    
-    bool finalized_ = false;
-
-    template<typename Problem, typename Scheme>
-    friend scheme::internal::ProblemComputationData*
-      scheme::internal::getComputationData(Problem& problem, const Scheme& resolutionScheme);
+    bool upToDate_;
+    std::shared_ptr<graph::internal::Inputs> inputs_;
+    graph::CallGraph updateGraph_;
   };
 
-  template<constraint::Type T>
-  TaskWithRequirementsPtr ControlProblem::add(utils::ProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req)
-  {
-    return add({ proto,td }, req);
-  }
+  virtual void update_() {}
+  virtual void finalize_() {}
 
-  template<constraint::Type T>
-  TaskWithRequirementsPtr ControlProblem::add(utils::LinearProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req)
-  {
-    return add({ proto,td }, req);
-  }
+  Updater updater_;
 
-  template<constraint::Type T>
-  TaskWithRequirementsPtr ControlProblem::add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements& req)
-  {
-    return add({ proto, task_dynamics::None() }, req);
-  }
+private:
+  void notify(const scheme::internal::ProblemDefinitionEvent & e);
+  void addCallBackToTask(TaskWithRequirementsPtr tr);
 
+  // Note: we want to keep the tasks in the order they were introduced, mostly
+  // for human understanding and debugging purposes, so that we take a
+  // std::vector.
+  // If this induces too much overhead when adding/removing a constraint, then
+  // we should consider std::set.
+  std::vector<TaskWithRequirementsPtr> tr_;
 
+  // Tokens to identify and keep callbacks alive
+  tvm::utils::internal::map<TaskWithRequirements *, std::vector<internal::PairElementToken>> callbackTokens_;
 
-  template<typename T, typename ... Args>
-  inline void ControlProblem::Updater::addInput(std::shared_ptr<T> source, Args... args)
-  {
-    inputs_->addInput(source, args...);
-    upToDate_ = false;
-  }
+  // Computation data for the resolution schemes
+  std::map<scheme::identifier, std::unique_ptr<scheme::internal::ProblemComputationData>> computationData_;
 
-  template<typename T>
-  inline void ControlProblem::Updater::removeInput(T* source)
-  {
-    inputs_->removeInput(source);
-    upToDate_ = false;
-  }
-}  // namespace tvm
+  bool finalized_ = false;
+
+  template<typename Problem, typename Scheme>
+  friend scheme::internal::ProblemComputationData * scheme::internal::getComputationData(
+      Problem & problem,
+      const Scheme & resolutionScheme);
+};
+
+template<constraint::Type T>
+TaskWithRequirementsPtr ControlProblem::add(utils::ProtoTask<T> proto,
+                                            const task_dynamics::abstract::TaskDynamics & td,
+                                            const requirements::SolvingRequirements & req)
+{
+  return add({proto, td}, req);
+}
+
+template<constraint::Type T>
+TaskWithRequirementsPtr ControlProblem::add(utils::LinearProtoTask<T> proto,
+                                            const task_dynamics::abstract::TaskDynamics & td,
+                                            const requirements::SolvingRequirements & req)
+{
+  return add({proto, td}, req);
+}
+
+template<constraint::Type T>
+TaskWithRequirementsPtr ControlProblem::add(utils::LinearProtoTask<T> proto,
+                                            const requirements::SolvingRequirements & req)
+{
+  return add({proto, task_dynamics::None()}, req);
+}
+
+template<typename T, typename... Args>
+inline void ControlProblem::Updater::addInput(std::shared_ptr<T> source, Args... args)
+{
+  inputs_->addInput(source, args...);
+  upToDate_ = false;
+}
+
+template<typename T>
+inline void ControlProblem::Updater::removeInput(T * source)
+{
+  inputs_->removeInput(source);
+  upToDate_ = false;
+}
+} // namespace tvm

--- a/include/tvm/LinearizedControlProblem.h
+++ b/include/tvm/LinearizedControlProblem.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <tvm/ControlProblem.h>
 #include <tvm/defs.h>
+
+#include <tvm/ControlProblem.h>
 #include <tvm/hint/Substitution.h>
 #include <tvm/hint/internal/Substitutions.h>
 

--- a/include/tvm/LinearizedControlProblem.h
+++ b/include/tvm/LinearizedControlProblem.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <tvm/defs.h>
 #include <tvm/ControlProblem.h>
+#include <tvm/defs.h>
 #include <tvm/hint/Substitution.h>
 #include <tvm/hint/internal/Substitutions.h>
 
@@ -11,102 +11,111 @@
 
 namespace tvm
 {
-  class TVM_DLLAPI LinearConstraintWithRequirements
-  {
-  public:
-    LinearConstraintPtr constraint;
-    SolvingRequirementsPtr requirements;
-    bool bound;
-  };
+class TVM_DLLAPI LinearConstraintWithRequirements
+{
+public:
+  LinearConstraintPtr constraint;
+  SolvingRequirementsPtr requirements;
+  bool bound;
+};
 
-  class TVM_DLLAPI LinearizedControlProblem : public ControlProblem
-  {
-  public:
-    LinearizedControlProblem();
-    LinearizedControlProblem(const ControlProblem& pb);
+class TVM_DLLAPI LinearizedControlProblem : public ControlProblem
+{
+public:
+  LinearizedControlProblem();
+  LinearizedControlProblem(const ControlProblem & pb);
 
-    TaskWithRequirementsPtr add(const Task& task, const requirements::SolvingRequirements& req = {});
-    template<constraint::Type T>
-    TaskWithRequirementsPtr add(utils::ProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req = {});
-    template<constraint::Type T>
-    TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req = {});
-    template<constraint::Type T>
-    TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements& req = {});
-    void add(TaskWithRequirementsPtr tr);
-    void remove(TaskWithRequirements* tr);
-
-    void add(const hint::Substitution& s);
-    const hint::internal::Substitutions& substitutions() const;
-
-    /** Access to the variables
-      *
-      * \note The result is not cached, i.e. it is recomputed at each call.
-      */
-    VariableVector variables() const;
-
-    /** Access to constraints*/
-    std::vector<LinearConstraintWithRequirements> constraints() const;
-
-    /** Access to the linear constraint corresponding to the task \p t
-      *
-      * \param t TaskWithRequirements object as return by add.
-      */
-    LinearConstraintPtr constraint(TaskWithRequirements* t) const;
-
-    /** Access to the linear constraint corresponding to the task \p t
-      *
-      * \param t TaskWithRequirements object as return by add.
-      *
-      * \return A shared_ptr that can be null if \p t is not in the problem.
-      */
-    LinearConstraintPtr constraintNoThrow(TaskWithRequirements* t) const;
-
-    /** Access to the linear constraint and requirements corresponding to the task \p t
-     *
-     * \param t TaskWithRequirements object as return by add.
-     */
-    const LinearConstraintWithRequirements& constraintWithRequirements(TaskWithRequirements* t) const;
-
-    /** Access to the linear constraint and requirements corresponding to the task \p t
-     *
-     * \param t TaskWithRequirements object as return by add.
-     *
-     * \return An std::optional containing a const reference on LinearConstraintWithRequirements
-     * if \p t is in the problem.
-     */
-    std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>> constraintWithRequirementsNoThrow(TaskWithRequirements* t) const;
-
-    /** Return the map task -> constraint*/
-    const tvm::utils::internal::map<TaskWithRequirements*, LinearConstraintWithRequirements>& constraintMap() const;
-
-  protected:
-    /** Compute all quantities necessary for solving the problem.*/
-    void update_() override;
-
-    /** Finalize the data of the solver*/
-    void finalize_() override;
-
-  private:
-    utils::internal::map<TaskWithRequirements*, LinearConstraintWithRequirements> constraints_;
-    hint::internal::Substitutions substitutions_;
-  };
-
-
+  TaskWithRequirementsPtr add(const Task & task, const requirements::SolvingRequirements & req = {});
   template<constraint::Type T>
-  TaskWithRequirementsPtr LinearizedControlProblem::add(utils::ProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req)
-  {
-    return add({ proto, td }, req);
-  }
-
+  TaskWithRequirementsPtr add(utils::ProtoTask<T> proto,
+                              const task_dynamics::abstract::TaskDynamics & td,
+                              const requirements::SolvingRequirements & req = {});
   template<constraint::Type T>
-  TaskWithRequirementsPtr LinearizedControlProblem::add(utils::LinearProtoTask<T> proto, const task_dynamics::abstract::TaskDynamics& td, const requirements::SolvingRequirements& req)
-  {
-    return add({ proto, td }, req);
-  }
-
+  TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto,
+                              const task_dynamics::abstract::TaskDynamics & td,
+                              const requirements::SolvingRequirements & req = {});
   template<constraint::Type T>
-  TaskWithRequirementsPtr LinearizedControlProblem::add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements& req)
-  {
-    return add({ proto, task_dynamics::None() }, req);
-  }
-}  // namespace tvm
+  TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements & req = {});
+  void add(TaskWithRequirementsPtr tr);
+  void remove(TaskWithRequirements * tr);
+
+  void add(const hint::Substitution & s);
+  const hint::internal::Substitutions & substitutions() const;
+
+  /** Access to the variables
+   *
+   * \note The result is not cached, i.e. it is recomputed at each call.
+   */
+  VariableVector variables() const;
+
+  /** Access to constraints*/
+  std::vector<LinearConstraintWithRequirements> constraints() const;
+
+  /** Access to the linear constraint corresponding to the task \p t
+   *
+   * \param t TaskWithRequirements object as return by add.
+   */
+  LinearConstraintPtr constraint(TaskWithRequirements * t) const;
+
+  /** Access to the linear constraint corresponding to the task \p t
+   *
+   * \param t TaskWithRequirements object as return by add.
+   *
+   * \return A shared_ptr that can be null if \p t is not in the problem.
+   */
+  LinearConstraintPtr constraintNoThrow(TaskWithRequirements * t) const;
+
+  /** Access to the linear constraint and requirements corresponding to the task \p t
+   *
+   * \param t TaskWithRequirements object as return by add.
+   */
+  const LinearConstraintWithRequirements & constraintWithRequirements(TaskWithRequirements * t) const;
+
+  /** Access to the linear constraint and requirements corresponding to the task \p t
+   *
+   * \param t TaskWithRequirements object as return by add.
+   *
+   * \return An std::optional containing a const reference on LinearConstraintWithRequirements
+   * if \p t is in the problem.
+   */
+  std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>> constraintWithRequirementsNoThrow(
+      TaskWithRequirements * t) const;
+
+  /** Return the map task -> constraint*/
+  const tvm::utils::internal::map<TaskWithRequirements *, LinearConstraintWithRequirements> & constraintMap() const;
+
+protected:
+  /** Compute all quantities necessary for solving the problem.*/
+  void update_() override;
+
+  /** Finalize the data of the solver*/
+  void finalize_() override;
+
+private:
+  utils::internal::map<TaskWithRequirements *, LinearConstraintWithRequirements> constraints_;
+  hint::internal::Substitutions substitutions_;
+};
+
+template<constraint::Type T>
+TaskWithRequirementsPtr LinearizedControlProblem::add(utils::ProtoTask<T> proto,
+                                                      const task_dynamics::abstract::TaskDynamics & td,
+                                                      const requirements::SolvingRequirements & req)
+{
+  return add({proto, td}, req);
+}
+
+template<constraint::Type T>
+TaskWithRequirementsPtr LinearizedControlProblem::add(utils::LinearProtoTask<T> proto,
+                                                      const task_dynamics::abstract::TaskDynamics & td,
+                                                      const requirements::SolvingRequirements & req)
+{
+  return add({proto, td}, req);
+}
+
+template<constraint::Type T>
+TaskWithRequirementsPtr LinearizedControlProblem::add(utils::LinearProtoTask<T> proto,
+                                                      const requirements::SolvingRequirements & req)
+{
+  return add({proto, task_dynamics::None()}, req);
+}
+} // namespace tvm

--- a/include/tvm/Range.h
+++ b/include/tvm/Range.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/Range.h
+++ b/include/tvm/Range.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -34,31 +34,25 @@
 #include <Eigen/Core>
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace tvm
 {
-  /** A pair \p (start, dim) representing the integer range from \p start 
-    * (included) to \p start+dim (excluded).
-    */
-  class TVM_DLLAPI Range
-  {
-  public:
-    Range() : start(0), dim(0) {}
-    Range(int s, int d) : start(s), dim(d) {}
-    int start;
-    int dim;
+/** A pair \p (start, dim) representing the integer range from \p start
+ * (included) to \p start+dim (excluded).
+ */
+class TVM_DLLAPI Range
+{
+public:
+  Range() : start(0), dim(0) {}
+  Range(int s, int d) : start(s), dim(d) {}
+  int start;
+  int dim;
 
-    bool operator==(const Range& other) const
-    {
-      return this->dim == other.dim && this->start == other.start;
-    }
+  bool operator==(const Range & other) const { return this->dim == other.dim && this->start == other.start; }
 
-    bool operator!=(const Range& other) const
-    {
-      return !operator==(other);
-    }
-  };
+  bool operator!=(const Range & other) const { return !operator==(other); }
+};
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/Robot.h
+++ b/include/tvm/Robot.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -44,186 +44,191 @@
 namespace tvm
 {
 
-  /** Represent a Robot
+/** Represent a Robot
+ *
+ * A robot is constructed by providing instances of MultiBodyGraph, MultiBody
+ * and MultiBodyConfig that are created from each other. It provides signals
+ * that are relevant for computing quantities related to a robot.
+ *
+ * Variables:
+ * - q (split between free-flyer and joints)
+ * - tau (see Outputs)
+ *
+ * Individual outputs:
+ *
+ * - FK: forward kinematics (computed by RBDyn::FK)
+ * - FV: forward velocity (computed by RBDyn::FV), depends on FK
+ * - FA: forward acceleration (computed by RBDyn::FA), depends on FV
+ * - NormalAcceleration: update bodies' normal acceleration, depends on FA
+ * - tau: generalized torque vector, this output isn't currently linked to
+ *   any computation
+ * - CoM: center of mass signal, depends on FK
+ * - H: inertia matrix signal, depends on FV
+ * - C: non-linear effect vector signal (Coriolis, gravity, external forces), depends on FV
+ *
+ * Meta outputs:
+ *   These outputs are provided for convenience sake
+ * - Geometry: depends on CoM (i.e. CoM + FK)
+ * - Dynamics: depends on FA + normalAcceleration (i.e. everything)
+ *
+ */
+class TVM_DLLAPI Robot : public graph::abstract::Node<Robot>
+{
+public:
+  SET_OUTPUTS(Robot, FK, FV, FA, NormalAcceleration, tau, CoM, H, C, Geometry, Dynamics)
+  SET_UPDATES(Robot, Time, FK, FV, FA, NormalAcceleration, CoM, H, C)
+
+  /** Constructor
    *
-   * A robot is constructed by providing instances of MultiBodyGraph, MultiBody
-   * and MultiBodyConfig that are created from each other. It provides signals
-   * that are relevant for computing quantities related to a robot.
+   * \param clock Clock used in the ControlProblem
    *
-   * Variables:
-   * - q (split between free-flyer and joints)
-   * - tau (see Outputs)
+   * \param name Name of the robot
    *
-   * Individual outputs:
+   * \param mbg MultiBodyGraph used to create mb/mbc
    *
-   * - FK: forward kinematics (computed by RBDyn::FK)
-   * - FV: forward velocity (computed by RBDyn::FV), depends on FK
-   * - FA: forward acceleration (computed by RBDyn::FA), depends on FV
-   * - NormalAcceleration: update bodies' normal acceleration, depends on FA
-   * - tau: generalized torque vector, this output isn't currently linked to
-   *   any computation
-   * - CoM: center of mass signal, depends on FK
-   * - H: inertia matrix signal, depends on FV
-   * - C: non-linear effect vector signal (Coriolis, gravity, external forces), depends on FV
+   * \param mb MultiBody representing the robot's kinematic structure
    *
-   * Meta outputs:
-   *   These outputs are provided for convenience sake
-   * - Geometry: depends on CoM (i.e. CoM + FK)
-   * - Dynamics: depends on FA + normalAcceleration (i.e. everything)
+   * \param mbc MultiBodyConfig giving the robot's initial configuration
+   *
+   * \param limits Joint limits
    *
    */
-  class TVM_DLLAPI Robot : public graph::abstract::Node<Robot>
-  {
-  public:
-    SET_OUTPUTS(Robot, FK, FV, FA, NormalAcceleration, tau, CoM, H, C, Geometry, Dynamics)
-    SET_UPDATES(Robot, Time, FK, FV, FA, NormalAcceleration, CoM, H, C)
+  Robot(Clock & clock,
+        const std::string & name,
+        rbd::MultiBodyGraph & mbg,
+        rbd::MultiBody mb,
+        rbd::MultiBodyConfig mbc,
+        const rbd::parsers::Limits & limits = {{}, {}, {}, {}});
 
-    /** Constructor
-     *
-     * \param clock Clock used in the ControlProblem
-     *
-     * \param name Name of the robot
-     *
-     * \param mbg MultiBodyGraph used to create mb/mbc
-     *
-     * \param mb MultiBody representing the robot's kinematic structure
-     *
-     * \param mbc MultiBodyConfig giving the robot's initial configuration
-     *
-     * \param limits Joint limits
-     *
-     */
-    Robot(Clock & clock, const std::string & name,
-          rbd::MultiBodyGraph & mbg, rbd::MultiBody mb, rbd::MultiBodyConfig mbc,
-          const rbd::parsers::Limits & limits = {{},{},{},{}});
+  /** Access the robot's name */
+  inline const std::string & name() const { return name_; }
 
-    /** Access the robot's name */
-    inline const std::string & name() const { return name_; }
+  /** Returns the robot's mass */
+  inline double mass() const { return mass_; }
 
-    /** Returns the robot's mass */
-    inline double mass() const { return mass_; }
+  /** Access q variable (const) */
+  inline const VariableVector & q() const { return q_; }
+  /** Access q variable */
+  inline VariableVector & q() { return q_; }
 
-    /** Access q variable (const) */
-    inline const VariableVector & q() const { return q_; }
-    /** Access q variable */
-    inline VariableVector & q() { return q_; }
+  /** Access free-flyer variable (const) */
+  inline const VariablePtr & qFreeFlyer() const { return q_ff_; }
+  /** Access free-flyer variable */
+  inline VariablePtr & qFreeFlyer() { return q_ff_; }
 
-    /** Access free-flyer variable (const) */
-    inline const VariablePtr & qFreeFlyer() const { return q_ff_; }
-    /** Access free-flyer variable */
-    inline VariablePtr & qFreeFlyer() { return q_ff_; }
+  /** Access joints variable (const) */
+  inline const VariablePtr & qJoints() const { return q_joints_; }
+  /** Access joints variable */
+  inline VariablePtr & qJoints() { return q_joints_; }
 
-    /** Access joints variable (const) */
-    inline const VariablePtr & qJoints() const { return q_joints_; }
-    /** Access joints variable */
-    inline VariablePtr & qJoints() { return q_joints_; }
+  /** Access tau variable (const) */
+  inline const VariablePtr & tau() const { return tau_; }
+  /** Access tau variable */
+  inline VariablePtr & tau() { return tau_; }
 
-    /** Access tau variable (const) */
-    inline const VariablePtr & tau() const { return tau_; }
-    /** Access tau variable */
-    inline VariablePtr & tau() { return tau_; }
+  /** Access the robot's related rbd::MultiBody (const) */
+  inline const rbd::MultiBody & mb() const { return mb_; }
+  /** Access the robot's related rbd::MultiBody */
+  inline rbd::MultiBody & mb() { return mb_; }
 
-    /** Access the robot's related rbd::MultiBody (const) */
-    inline const rbd::MultiBody & mb() const { return mb_; }
-    /** Access the robot's related rbd::MultiBody */
-    inline rbd::MultiBody & mb() { return mb_; }
+  /** Access the robot's related rbd::MultiBodyConfig (const) */
+  inline const rbd::MultiBodyConfig & mbc() const { return mbc_; }
+  /** Access the robot's related rbd::MultiBodyConfig */
+  inline rbd::MultiBodyConfig & mbc() { return mbc_; }
 
-    /** Access the robot's related rbd::MultiBodyConfig (const) */
-    inline const rbd::MultiBodyConfig & mbc() const { return mbc_; }
-    /** Access the robot's related rbd::MultiBodyConfig */
-    inline rbd::MultiBodyConfig & mbc() { return mbc_; }
+  /** Access the vector of normal acceleration expressed in the body's frame (const) */
+  inline const std::vector<sva::MotionVecd> & normalAccB() const { return normalAccB_; }
+  /** Access the vector of normal acceleration expressed in the body's frame */
+  inline std::vector<sva::MotionVecd> & normalAccB() { return normalAccB_; }
 
-    /** Access the vector of normal acceleration expressed in the body's frame (const) */
-    inline const std::vector<sva::MotionVecd> & normalAccB() const { return normalAccB_; }
-    /** Access the vector of normal acceleration expressed in the body's frame */
-    inline std::vector<sva::MotionVecd> & normalAccB() { return normalAccB_; }
+  /** Access the joints' lower position limit (const) */
+  inline const Eigen::VectorXd & lQBound() const { return lQBound_; }
+  /** Access the joints' lower position limit */
+  inline Eigen::VectorXd & lQBound() { return lQBound_; }
 
-    /** Access the joints' lower position limit (const) */
-    inline const Eigen::VectorXd & lQBound() const { return lQBound_; }
-    /** Access the joints' lower position limit */
-    inline Eigen::VectorXd & lQBound() { return lQBound_; }
+  /** Access the joints' upper position limit (const) */
+  inline const Eigen::VectorXd & uQBound() const { return uQBound_; }
+  /** Access the joints' upper position limit */
+  inline Eigen::VectorXd & uQBound() { return uQBound_; }
 
-    /** Access the joints' upper position limit (const) */
-    inline const Eigen::VectorXd & uQBound() const { return uQBound_; }
-    /** Access the joints' upper position limit */
-    inline Eigen::VectorXd & uQBound() { return uQBound_; }
+  /** Access the joints' lower velocity limit (const) */
+  inline const Eigen::VectorXd & lVelBound() const { return lVelBound_; }
+  /** Access the joints' lower velocity limit */
+  inline Eigen::VectorXd & lVelBound() { return lVelBound_; }
 
-    /** Access the joints' lower velocity limit (const) */
-    inline const Eigen::VectorXd & lVelBound() const { return lVelBound_; }
-    /** Access the joints' lower velocity limit */
-    inline Eigen::VectorXd & lVelBound() { return lVelBound_; }
+  /** Access the joints' upper velocity limit (const) */
+  inline const Eigen::VectorXd & uVelBound() const { return uVelBound_; }
+  /** Access the joints' upper velocity limit */
+  inline Eigen::VectorXd & uVelBound() { return uVelBound_; }
 
-    /** Access the joints' upper velocity limit (const) */
-    inline const Eigen::VectorXd & uVelBound() const { return uVelBound_; }
-    /** Access the joints' upper velocity limit */
-    inline Eigen::VectorXd & uVelBound() { return uVelBound_; }
+  /** Access the robot's lower torque limit (const) */
+  inline const Eigen::VectorXd & lTauBound() const { return lTauBound_; }
+  /** Access the robot's lower torque limit */
+  inline Eigen::VectorXd & lTauBound() { return lTauBound_; }
 
-    /** Access the robot's lower torque limit (const) */
-    inline const Eigen::VectorXd & lTauBound() const { return lTauBound_; }
-    /** Access the robot's lower torque limit */
-    inline Eigen::VectorXd & lTauBound() { return lTauBound_; }
+  /** Access the robot's upper torque limit (const) */
+  inline const Eigen::VectorXd & uTauBound() const { return uTauBound_; }
+  /** Access the robot's upper torque limit */
+  inline Eigen::VectorXd & uTauBound() { return uTauBound_; }
 
-    /** Access the robot's upper torque limit (const) */
-    inline const Eigen::VectorXd & uTauBound() const { return uTauBound_; }
-    /** Access the robot's upper torque limit */
-    inline Eigen::VectorXd & uTauBound() { return uTauBound_; }
+  /** Access the inertia matrix */
+  inline const Eigen::MatrixXd & H() const { return fd_.H(); }
+  /** Access the non-linear effect vector */
+  /** Access the non-linear effect vector (coriolis, gravity, external force).*/
+  inline const Eigen::VectorXd & C() const { return fd_.C(); }
 
-    /** Access the inertia matrix */
-    inline const Eigen::MatrixXd & H() const { return fd_.H(); }
-    /** Access the non-linear effect vector */
-    /** Access the non-linear effect vector (coriolis, gravity, external force).*/
-    inline const Eigen::VectorXd & C() const { return fd_.C(); }
+  /** Access the CoM position */
+  inline const Eigen::Vector3d & com() const { return com_; }
 
-    /** Access the CoM position */
-    inline const Eigen::Vector3d & com() const { return com_; }
+  /** Access the transformation that allows to retrieve the original base of a body */
+  inline const sva::PTransformd & bodyTransform(const std::string & b) const { return bodyTransforms_.at(b); }
 
-    /** Access the transformation that allows to retrieve the original base of a body */
-    inline const sva::PTransformd & bodyTransform(const std::string & b) const { return bodyTransforms_.at(b); }
-  private:
-    Clock & clock_;
-    uint64_t last_tick_ = 0;
-    std::string name_;
-    double mass_;
-    rbd::MultiBody mb_;
-    rbd::MultiBodyConfig mbc_;
-    std::vector<sva::MotionVecd> normalAccB_;
-    Eigen::VectorXd lQBound_;
-    Eigen::VectorXd uQBound_;
-    Eigen::VectorXd lVelBound_;
-    Eigen::VectorXd uVelBound_;
-    Eigen::VectorXd lTauBound_;
-    Eigen::VectorXd uTauBound_;
-    rbd::ForwardDynamics fd_;
-    std::map<std::string, sva::PTransformd> bodyTransforms_;
-    VariablePtr q_ff_;
-    VariablePtr q_joints_;
-    VariableVector q_;
-    VariableVector dq_;
-    VariableVector ddq_;
-    VariablePtr tau_;
-    Eigen::Vector3d com_;
-  private:
-    void computeNormalAccB();
+private:
+  Clock & clock_;
+  uint64_t last_tick_ = 0;
+  std::string name_;
+  double mass_;
+  rbd::MultiBody mb_;
+  rbd::MultiBodyConfig mbc_;
+  std::vector<sva::MotionVecd> normalAccB_;
+  Eigen::VectorXd lQBound_;
+  Eigen::VectorXd uQBound_;
+  Eigen::VectorXd lVelBound_;
+  Eigen::VectorXd uVelBound_;
+  Eigen::VectorXd lTauBound_;
+  Eigen::VectorXd uTauBound_;
+  rbd::ForwardDynamics fd_;
+  std::map<std::string, sva::PTransformd> bodyTransforms_;
+  VariablePtr q_ff_;
+  VariablePtr q_joints_;
+  VariableVector q_;
+  VariableVector dq_;
+  VariableVector ddq_;
+  VariablePtr tau_;
+  Eigen::Vector3d com_;
 
-    /** Update the Robot's variables based on the output of the solver
-     *
-     * It will:
-     * 1. Put dot(q,2) into mbc.alphaD
-     * 2. Run rbd::eulerIntegration with dt
-     * 3. Output mbc.alpha into dot(q)
-     * 4. Output mbc.q into q
-     *
-     * \param dt Integration timestep
-     *
-     */
-    void updateTimeDependency();
-    void updateFK();
-    void updateFV();
-    void updateFA();
-    void updateNormalAcceleration();
-    void updateH();
-    void updateC();
-    void updateCoM();
-  };
+private:
+  void computeNormalAccB();
 
-}
+  /** Update the Robot's variables based on the output of the solver
+   *
+   * It will:
+   * 1. Put dot(q,2) into mbc.alphaD
+   * 2. Run rbd::eulerIntegration with dt
+   * 3. Output mbc.alpha into dot(q)
+   * 4. Output mbc.q into q
+   *
+   * \param dt Integration timestep
+   *
+   */
+  void updateTimeDependency();
+  void updateFK();
+  void updateFV();
+  void updateFA();
+  void updateNormalAcceleration();
+  void updateH();
+  void updateC();
+  void updateCoM();
+};
+
+} // namespace tvm

--- a/include/tvm/Robot.h
+++ b/include/tvm/Robot.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/Space.h
+++ b/include/tvm/Space.h
@@ -35,9 +35,9 @@ public:
   /** Predifined space types.*/
   enum class Type
   {
-    Euclidean, /** Euclidean space \f$ \mathbb{R}^n \f$.*/
-    SO3, /** Space of 3d rotations, represented by unit quaternions.*/
-    SE3, /** Space of 3d transformation, represented by a quaternion and a 3d-vector.*/
+    Euclidean,  /** Euclidean space \f$ \mathbb{R}^n \f$.*/
+    SO3,        /** Space of 3d rotations, represented by unit quaternions.*/
+    SE3,        /** Space of 3d transformation, represented by a quaternion and a 3d-vector.*/
     Unspecified /** Non-euclidean space of unknown type.*/
   };
 

--- a/include/tvm/Space.h
+++ b/include/tvm/Space.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/Space.h
+++ b/include/tvm/Space.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -35,95 +35,92 @@
 #include <Eigen/Core>
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace tvm
 {
-  /** Description of a variable space, and factory for Variable.
-   *
-   * The space can have up to 3 different sizes, although Euclidean spaces will
-   * have only one :
-   * - the size of the space as a manifold,
-   * - the size of the vector needed to represent one variable (point) in this
-   *   space (representation space, rsize),
-   * - the size of the vector needed to represent a derivative (velocity,
-   *   acceleration, ...) of this variable (tangent space, tsize).
-   *
-   * Here are a few examples:
-   * - R^n has a size, rsize and tsize of n,
-   * - SO(3), the 3d rotation space, when represented by quaternions, has a
-   *   size of 3, a rsize of 4 and a tsize of 3,
-   * - S(2), the sphere in dimension 3 has a size of 2, and rsize and tsize of 3.
-   */
-  class TVM_DLLAPI Space
+/** Description of a variable space, and factory for Variable.
+ *
+ * The space can have up to 3 different sizes, although Euclidean spaces will
+ * have only one :
+ * - the size of the space as a manifold,
+ * - the size of the vector needed to represent one variable (point) in this
+ *   space (representation space, rsize),
+ * - the size of the vector needed to represent a derivative (velocity,
+ *   acceleration, ...) of this variable (tangent space, tsize).
+ *
+ * Here are a few examples:
+ * - R^n has a size, rsize and tsize of n,
+ * - SO(3), the 3d rotation space, when represented by quaternions, has a
+ *   size of 3, a rsize of 4 and a tsize of 3,
+ * - S(2), the sphere in dimension 3 has a size of 2, and rsize and tsize of 3.
+ */
+class TVM_DLLAPI Space
+{
+public:
+  /** Predifined space types.*/
+  enum class Type
   {
-  public:
-    /** Predifined space types.*/
-    enum class Type
-    {
-      Euclidean,    /** Euclidean space \f$ \mathbb{R}^n \f$.*/
-      SO3,          /** Space of 3d rotations, represented by unit quaternions.*/
-      SE3,          /** Space of 3d transformation, represented by a quaternion and a 3d-vector.*/
-      Unspecified   /** Non-euclidean space of unknown type.*/
-    };
-
-    /** Constructor for an Euclidean space
-      *
-      * \param size size of the space
-      */
-    Space(int size);
-    /** Constructor for a manifold with tsize = size
-      *
-      * \param size size of the space
-      * \param representationSize size of the vector needed to represent a variable
-      */
-    Space(int size, int representationSize);
-    /** Constructor for a manifold where tsize != size
-      *
-      * \param size size of the space
-      * \param representationSize size of the vector needed to represent a variable
-      * \param tangentRepresentationSize size of the vector needed to represent a derivative
-      */
-    Space(int size, int representationSize, int tangentRepresentationSize);
-
-    /** Constructor for a given space type
-      *
-      * \param type type of space
-      * \param size size of the space. Only for space types whose size is not fixed.
-      */
-    Space(Type type, int size=-1);
-
-    /** Factory function to create a variable.*/
-    std::unique_ptr<Variable> createVariable(const std::string& name) const;
-
-    /** Size of the space (as a manifold) */
-    int size() const;
-    /** Size of the vector needed to represent a variable in this space.*/
-    int rSize() const;
-    /** Size of the vector needed to represent a derivative in this space.*/
-    int tSize() const;
-    /** Type of the space. */
-    Type type() const;
-    /** Check if this is an Euclidean space.*/
-    bool isEuclidean() const;
-
-    bool operator==(const Space& other) const
-    {
-      return this->mSize_ == other.mSize_ && this->rSize_ == other.rSize_ 
-        && this->tSize_ == other.tSize_ && this->type_ == other.type_;
-    }
-
-    bool operator!=(const Space& other) const
-    {
-      return !operator==(other);
-    }
-
-  private:
-    int  mSize_;   //size of this space (as a manifold)
-    int  rSize_;   //size of a vector representing a point in this space
-    int  tSize_;   //size of a vector representing a velocity in this space
-    Type type_;    //the space type
+    Euclidean, /** Euclidean space \f$ \mathbb{R}^n \f$.*/
+    SO3, /** Space of 3d rotations, represented by unit quaternions.*/
+    SE3, /** Space of 3d transformation, represented by a quaternion and a 3d-vector.*/
+    Unspecified /** Non-euclidean space of unknown type.*/
   };
 
-}  // namespace tvm
+  /** Constructor for an Euclidean space
+   *
+   * \param size size of the space
+   */
+  Space(int size);
+  /** Constructor for a manifold with tsize = size
+   *
+   * \param size size of the space
+   * \param representationSize size of the vector needed to represent a variable
+   */
+  Space(int size, int representationSize);
+  /** Constructor for a manifold where tsize != size
+   *
+   * \param size size of the space
+   * \param representationSize size of the vector needed to represent a variable
+   * \param tangentRepresentationSize size of the vector needed to represent a derivative
+   */
+  Space(int size, int representationSize, int tangentRepresentationSize);
+
+  /** Constructor for a given space type
+   *
+   * \param type type of space
+   * \param size size of the space. Only for space types whose size is not fixed.
+   */
+  Space(Type type, int size = -1);
+
+  /** Factory function to create a variable.*/
+  std::unique_ptr<Variable> createVariable(const std::string & name) const;
+
+  /** Size of the space (as a manifold) */
+  int size() const;
+  /** Size of the vector needed to represent a variable in this space.*/
+  int rSize() const;
+  /** Size of the vector needed to represent a derivative in this space.*/
+  int tSize() const;
+  /** Type of the space. */
+  Type type() const;
+  /** Check if this is an Euclidean space.*/
+  bool isEuclidean() const;
+
+  bool operator==(const Space & other) const
+  {
+    return this->mSize_ == other.mSize_ && this->rSize_ == other.rSize_ && this->tSize_ == other.tSize_
+           && this->type_ == other.type_;
+  }
+
+  bool operator!=(const Space & other) const { return !operator==(other); }
+
+private:
+  int mSize_; // size of this space (as a manifold)
+  int rSize_; // size of a vector representing a point in this space
+  int tSize_; // size of a vector representing a velocity in this space
+  Type type_; // the space type
+};
+
+} // namespace tvm

--- a/include/tvm/Task.h
+++ b/include/tvm/Task.h
@@ -3,68 +3,73 @@
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/defs.h>
 #include <tvm/constraint/enums.h>
 #include <tvm/constraint/internal/RHSVectors.h>
-#include <tvm/utils/ProtoTask.h>
+#include <tvm/defs.h>
 #include <tvm/task_dynamics/abstract/TaskDynamics.h>
+#include <tvm/utils/ProtoTask.h>
 
 #include <memory>
 
 namespace tvm
 {
-  /** A task is a triplet (Function, operator, TaskDynamics) where operator is
-    * ==, >= or <=*/
-  class TVM_DLLAPI Task
-  {
-  public:
-    Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td);
-    Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, double rhs);
-    Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td,
-         const Eigen::VectorXd& rhs);
-    Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, double l, double u);
-    Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td,
-         const Eigen::VectorXd& l, const Eigen::VectorXd& u);
-    Task(utils::ProtoTaskEQ proto, const task_dynamics::abstract::TaskDynamics& td);
-    Task(utils::ProtoTaskLT proto, const task_dynamics::abstract::TaskDynamics& td);
-    Task(utils::ProtoTaskGT proto, const task_dynamics::abstract::TaskDynamics& td);
-    Task(utils::ProtoTaskDS proto, const task_dynamics::abstract::TaskDynamics& td);
+/** A task is a triplet (Function, operator, TaskDynamics) where operator is
+ * ==, >= or <=*/
+class TVM_DLLAPI Task
+{
+public:
+  Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td);
+  Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td, double rhs);
+  Task(FunctionPtr f,
+       constraint::Type t,
+       const task_dynamics::abstract::TaskDynamics & td,
+       const Eigen::VectorXd & rhs);
+  Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td, double l, double u);
+  Task(FunctionPtr f,
+       constraint::Type t,
+       const task_dynamics::abstract::TaskDynamics & td,
+       const Eigen::VectorXd & l,
+       const Eigen::VectorXd & u);
+  Task(utils::ProtoTaskEQ proto, const task_dynamics::abstract::TaskDynamics & td);
+  Task(utils::ProtoTaskLT proto, const task_dynamics::abstract::TaskDynamics & td);
+  Task(utils::ProtoTaskGT proto, const task_dynamics::abstract::TaskDynamics & td);
+  Task(utils::ProtoTaskDS proto, const task_dynamics::abstract::TaskDynamics & td);
 
-    FunctionPtr function() const;
-    constraint::Type type() const;
-    TaskDynamicsPtr taskDynamics() const;
-    TaskDynamicsPtr secondBoundTaskDynamics() const;  //the dynamics of the upper bound, in the case of double-sided task only.
+  FunctionPtr function() const;
+  constraint::Type type() const;
+  TaskDynamicsPtr taskDynamics() const;
+  TaskDynamicsPtr secondBoundTaskDynamics()
+      const; // the dynamics of the upper bound, in the case of double-sided task only.
 
-    template<typename T, typename TDImpl = typename T::Impl>
-    std::shared_ptr<TDImpl> taskDynamics() const;
+  template<typename T, typename TDImpl = typename T::Impl>
+  std::shared_ptr<TDImpl> taskDynamics() const;
 
-    template<typename T, typename TDImpl = typename T::Impl>
-    std::shared_ptr<TDImpl> secondBoundTaskDynamics() const;
+  template<typename T, typename TDImpl = typename T::Impl>
+  std::shared_ptr<TDImpl> secondBoundTaskDynamics() const;
 
-  private:
-    FunctionPtr f_;
-    constraint::Type type_;
-    TaskDynamicsPtr td_;
-    TaskDynamicsPtr td2_ = nullptr;             //used only for double sided tasks, as dynamics for upper bound.
-  };
+private:
+  FunctionPtr f_;
+  constraint::Type type_;
+  TaskDynamicsPtr td_;
+  TaskDynamicsPtr td2_ = nullptr; // used only for double sided tasks, as dynamics for upper bound.
+};
 
+template<typename T, typename TDImpl>
+std::shared_ptr<TDImpl> Task::taskDynamics() const
+{
+  if(td_->checkType<TDImpl>())
+    return std::static_pointer_cast<TDImpl>(td_);
+  else
+    throw std::runtime_error("Unable to cast the task dynamics into the desired type.");
+}
 
-  template<typename T, typename TDImpl>
-  std::shared_ptr<TDImpl> Task::taskDynamics() const
-  {
-    if (td_->checkType<TDImpl>())
-      return std::static_pointer_cast<TDImpl>(td_);
-    else
-      throw std::runtime_error("Unable to cast the task dynamics into the desired type.");
-  }
+template<typename T, typename TDImpl>
+std::shared_ptr<TDImpl> Task::secondBoundTaskDynamics() const
+{
+  if(td2_->checkType<TDImpl>())
+    return std::static_pointer_cast<TDImpl>(td2_);
+  else
+    throw std::runtime_error("Unable to cast the task dynamics into the desired type.");
+}
 
-  template<typename T, typename TDImpl>
-  std::shared_ptr<TDImpl> Task::secondBoundTaskDynamics() const
-  {
-    if (td2_->checkType<TDImpl>())
-      return std::static_pointer_cast<TDImpl>(td2_);
-    else
-      throw std::runtime_error("Unable to cast the task dynamics into the desired type.");
-  }
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/Task.h
+++ b/include/tvm/Task.h
@@ -3,9 +3,10 @@
 #pragma once
 
 #include <tvm/api.h>
+#include <tvm/defs.h>
+
 #include <tvm/constraint/enums.h>
 #include <tvm/constraint/internal/RHSVectors.h>
-#include <tvm/defs.h>
 #include <tvm/task_dynamics/abstract/TaskDynamics.h>
 #include <tvm/utils/ProtoTask.h>
 

--- a/include/tvm/Variable.h
+++ b/include/tvm/Variable.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/Variable.h
+++ b/include/tvm/Variable.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -37,218 +37,209 @@
 #include <Eigen/Core>
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace tvm
 {
-  class Variable;
-  class VariableVector;
+class Variable;
+class VariableVector;
 
-  /** Get the ndiff-th time derivative of a variable
-    *
-    * \param var the variable to be derived
-    * \param ndiff the order of the derivation
-    */
-  VariablePtr TVM_DLLAPI dot(VariablePtr var, int ndiff=1);
+/** Get the ndiff-th time derivative of a variable
+ *
+ * \param var the variable to be derived
+ * \param ndiff the order of the derivation
+ */
+VariablePtr TVM_DLLAPI dot(VariablePtr var, int ndiff = 1);
 
+/** Representation of a Variable, i.e. a point in a space.
+ *
+ * A variable can only be constructed from a Space, in which case we say it
+ * is a base primitive, or from an other variable, by derivation with the
+ * dot() operator.
+ */
+class TVM_DLLAPI Variable : public tvm::internal::ObjWithId, public std::enable_shared_from_this<Variable>
+{
+public:
+  /** Copying variables is illicit. To get a different variable with the same
+   * caracteristics, see \ref duplicate.
+   */
+  Variable(const Variable &) = delete;
+  /** Copying variables is illicit. To get a different variable with the same
+   * caracteristics, see \ref duplicate.
+   */
+  Variable & operator=(const Variable &) = delete;
+  /** Create a variable based on the same space, with the same derivative
+   * number and value.
+   * \param name the name of the new variable. If the default value is kept,
+   * a ' will be appened to the current name. If the variable being
+   * duplicated is not a base variable, the name is given to the base
+   * variable.
+   */
+  VariablePtr duplicate(const std::string & name = "") const;
+  /** Return the name of the variable*/
+  const std::string & name() const;
+  /** Return the size of the variable, i.e. the size of the vector needed to
+   * represent it.
+   */
+  int size() const;
+  /** Return the space to which this variable is linked. It is either the
+   * space the variable was obtained from (for a variable that is a
+   * primitive), or the space of its primitive (for a variable which is
+   * derived from an other).
+   */
+  const Space & space() const;
+  /** Check if the variable lives in a Euclidean space.
+   * Pay attention that for a variable v, v.isEuclidean() is not necessarily
+   * equal to v.space().isEuclidean(): if v is a derivative of a variable linked
+   * to a non-Euclidean space, it lives in the tangent space which is Euclidean.
+   */
+  bool isEuclidean() const;
+  /** Return the current value of the variable.*/
+  const Eigen::VectorXd & value() const;
+  /** Set the value of the variable.*/
+  void value(const VectorConstRef & x);
+  /** Set the value of the variable to 0*/
+  void setZero();
+  /** If this variable is a base primitive (i.e. built from a space), return 0.
+   * Otherwise, return the number of time a base primitive variable had to be
+   * derived to get to this variable.
+   */
+  int derivativeNumber() const;
+  /** Check if this variable is a derivative of \p v
+   * This is in a strict sense: v.isDerivativeOf(v) si false.
+   */
+  bool isDerivativeOf(const Variable & v) const;
+  /** Check if this variable is a primitive of \p v
+   * This is in a strict sense: v.isPrimitiveOf(v) si false.
+   */
+  bool isPrimitiveOf(const Variable & v) const;
+  /** Return true if this variable is a base primitive (derivativeNumber() == 0),
+   * false otherwise.
+   */
+  bool isBasePrimitive() const;
+  /** Get the n-th primitive of the variable*/
+  template<int n = 1>
+  VariablePtr primitive() const;
+  /** Get the base primitive of this variable. Equivalent to primitive<d>()
+   * where d = derivativeNumber().
+   */
+  VariablePtr basePrimitive() const;
 
-  /** Representation of a Variable, i.e. a point in a space.
-    *
-    * A variable can only be constructed from a Space, in which case we say it
-    * is a base primitive, or from an other variable, by derivation with the
-    * dot() operator.
-    */
-  class TVM_DLLAPI Variable : public tvm::internal::ObjWithId, public std::enable_shared_from_this<Variable>
+  /** Get the mapping of this variable, within a vector of variables: if all
+   * variables values are stacked in one vector v, the returned Range
+   * specifies the segment of v corresponding to this variable.
+   */
+  Range getMappingIn(const VariableVector & variables) const;
+
+  /** Helper to initialize a variable like an Eigen vector.*/
+  Eigen::CommaInitializer<Eigen::VectorXd> operator<<(double d);
+
+  /** Helper to initialize a variable like an Eigen vector.*/
+  template<typename Derived>
+  Eigen::CommaInitializer<Eigen::VectorXd> operator<<(const Eigen::DenseBase<Derived> & other);
+
+protected:
+private:
+  struct MappingHelper
   {
-  public:
-    /** Copying variables is illicit. To get a different variable with the same
-      * caracteristics, see \ref duplicate.
-      */
-    Variable(const Variable&) = delete;
-    /** Copying variables is illicit. To get a different variable with the same
-      * caracteristics, see \ref duplicate.
-      */
-    Variable& operator=(const Variable&) = delete;
-    /** Create a variable based on the same space, with the same derivative
-      * number and value.
-      * \param name the name of the new variable. If the default value is kept,
-      * a ' will be appened to the current name. If the variable being
-      * duplicated is not a base variable, the name is given to the base
-      * variable.
-      */
-    VariablePtr duplicate(const std::string& name = "") const;
-    /** Return the name of the variable*/
-    const std::string& name() const;
-    /** Return the size of the variable, i.e. the size of the vector needed to
-      * represent it.
-      */
-    int size() const;
-    /** Return the space to which this variable is linked. It is either the
-      * space the variable was obtained from (for a variable that is a
-      * primitive), or the space of its primitive (for a variable which is
-      * derived from an other).
-      */
-    const Space& space() const;
-    /** Check if the variable lives in a Euclidean space.
-      * Pay attention that for a variable v, v.isEuclidean() is not necessarily
-      * equal to v.space().isEuclidean(): if v is a derivative of a variable linked
-      * to a non-Euclidean space, it lives in the tangent space which is Euclidean.
-      */
-    bool isEuclidean() const;
-    /** Return the current value of the variable.*/
-    const Eigen::VectorXd& value() const;
-    /** Set the value of the variable.*/
-    void value(const VectorConstRef& x);
-    /** Set the value of the variable to 0*/
-    void setZero();
-    /** If this variable is a base primitive (i.e. built from a space), return 0.
-      * Otherwise, return the number of time a base primitive variable had to be
-      * derived to get to this variable.
-      */
-    int derivativeNumber() const;
-    /** Check if this variable is a derivative of \p v
-      * This is in a strict sense: v.isDerivativeOf(v) si false.
-      */
-    bool isDerivativeOf(const Variable& v) const;
-    /** Check if this variable is a primitive of \p v
-      * This is in a strict sense: v.isPrimitiveOf(v) si false.
-      */
-    bool isPrimitiveOf(const Variable& v) const;
-    /** Return true if this variable is a base primitive (derivativeNumber() == 0),
-      * false otherwise.
-      */
-    bool isBasePrimitive() const;
-    /** Get the n-th primitive of the variable*/
-    template <int n=1>
-    VariablePtr primitive() const;
-    /** Get the base primitive of this variable. Equivalent to primitive<d>()
-      * where d = derivativeNumber().
-      */
-    VariablePtr basePrimitive() const;
-
-    /** Get the mapping of this variable, within a vector of variables: if all
-      * variables values are stacked in one vector v, the returned Range
-      * specifies the segment of v corresponding to this variable.
-      */
-    Range getMappingIn(const VariableVector& variables) const;
-
-    /** Helper to initialize a variable like an Eigen vector.*/
-    Eigen::CommaInitializer<Eigen::VectorXd> operator<<(double d);
-
-    /** Helper to initialize a variable like an Eigen vector.*/
-    template<typename Derived>
-    Eigen::CommaInitializer<Eigen::VectorXd> operator<<(const Eigen::DenseBase<Derived>& other);
-
-  protected:
-
-  private:
-    struct MappingHelper
-    {
-      int start;
-      int stamp;
-    };
-
-    /** Constructor for a new variable */
-    Variable(const Space& s, const std::string& name);
-
-    /** Constructor for the derivative of var */
-    Variable(Variable* var);
-
-    /** Same as primitive<n> but without checking if n is valid.*/
-    template <int n>
-    VariablePtr primitiveNoCheck() const;
-
-    /** Name */
-    std::string name_;
-
-    /** Data of the space from which the variable was created */
-    Space space_;
-
-    /** Value of the variable */
-    Eigen::VectorXd value_;
-
-    /** Number of derivation since the base primitive. 0 a variable which is
-      * not a derivative.
-      */
-    int derivativeNumber_;
-
-    /** If the variable is the time derivative of another one, primitive_ is a
-      * reference to the latter, otherwise it is a nullptr.
-      */
-    Variable* primitive_;
-
-    /** If the variable has a time derivative, keep a pointer on it */
-    std::unique_ptr<Variable> derivative_;
-
-    /** A helper structure for mapping purpose*/
-    mutable MappingHelper mappingHelper_;
-
-    /** friendship declaration */
-    friend class Space;
-    friend VariablePtr TVM_DLLAPI dot(VariablePtr, int);
-    friend class VariableVector;
+    int start;
+    int stamp;
   };
 
-  template <int n>
-  inline VariablePtr Variable::primitive() const
-  {
-    if (n <= derivativeNumber_)
-      return primitiveNoCheck<n>();
-    else
-      throw std::runtime_error("This variable is not the n-th derivative of an other variable.");
-  }
+  /** Constructor for a new variable */
+  Variable(const Space & s, const std::string & name);
 
-  template <int n>
-  inline VariablePtr Variable::primitiveNoCheck() const
-  {
-    static_assert(n > 0, "Works only for non-negative numbers.");
-    return primitive_->primitive<n - 1>();
-  }
+  /** Constructor for the derivative of var */
+  Variable(Variable * var);
 
-  template <>
-  inline VariablePtr Variable::primitiveNoCheck<1>() const
-  {
-    if (derivativeNumber_ > 1)
-      return { basePrimitive(), primitive_ };
-    else
-      return primitive_->shared_from_this();
-  }
+  /** Same as primitive<n> but without checking if n is valid.*/
+  template<int n>
+  VariablePtr primitiveNoCheck() const;
 
-  inline Eigen::CommaInitializer<Eigen::VectorXd> Variable::operator<<(double d)
-  {
-    return { value_,d };
-  }
+  /** Name */
+  std::string name_;
 
-  template<typename Derived>
-  inline Eigen::CommaInitializer<Eigen::VectorXd> Variable::operator<<(const Eigen::DenseBase<Derived>& other)
-  {
-    return { value_, other };
-  }
-}  // namespace tvm
+  /** Data of the space from which the variable was created */
+  Space space_;
 
-/** Helper to initialize a variable like an Eigen vector, with a coma separated list.*/
-inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr& v, double d)
+  /** Value of the variable */
+  Eigen::VectorXd value_;
+
+  /** Number of derivation since the base primitive. 0 a variable which is
+   * not a derivative.
+   */
+  int derivativeNumber_;
+
+  /** If the variable is the time derivative of another one, primitive_ is a
+   * reference to the latter, otherwise it is a nullptr.
+   */
+  Variable * primitive_;
+
+  /** If the variable has a time derivative, keep a pointer on it */
+  std::unique_ptr<Variable> derivative_;
+
+  /** A helper structure for mapping purpose*/
+  mutable MappingHelper mappingHelper_;
+
+  /** friendship declaration */
+  friend class Space;
+  friend VariablePtr TVM_DLLAPI dot(VariablePtr, int);
+  friend class VariableVector;
+};
+
+template<int n>
+inline VariablePtr Variable::primitive() const
 {
-  return *v.get() << d;
+  if(n <= derivativeNumber_)
+    return primitiveNoCheck<n>();
+  else
+    throw std::runtime_error("This variable is not the n-th derivative of an other variable.");
 }
 
-/** Helper to initialize a variable like an Eigen vector, with a coma separated list.*/
-inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr&& v, double d)
+template<int n>
+inline VariablePtr Variable::primitiveNoCheck() const
 {
-  return *v.get() << d;
+  static_assert(n > 0, "Works only for non-negative numbers.");
+  return primitive_->primitive<n - 1>();
 }
+
+template<>
+inline VariablePtr Variable::primitiveNoCheck<1>() const
+{
+  if(derivativeNumber_ > 1)
+    return {basePrimitive(), primitive_};
+  else
+    return primitive_->shared_from_this();
+}
+
+inline Eigen::CommaInitializer<Eigen::VectorXd> Variable::operator<<(double d) { return {value_, d}; }
+
+template<typename Derived>
+inline Eigen::CommaInitializer<Eigen::VectorXd> Variable::operator<<(const Eigen::DenseBase<Derived> & other)
+{
+  return {value_, other};
+}
+} // namespace tvm
+
+/** Helper to initialize a variable like an Eigen vector, with a coma separated list.*/
+inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr & v, double d) { return *v.get() << d; }
+
+/** Helper to initialize a variable like an Eigen vector, with a coma separated list.*/
+inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr && v, double d) { return *v.get() << d; }
 
 /** Helper to initialize a variable like an Eigen vector, with a coma separated list.*/
 template<typename Derived>
-inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr& v, const Eigen::DenseBase<Derived>& other)
+inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr & v,
+                                                           const Eigen::DenseBase<Derived> & other)
 {
   return *v.get() << other;
 }
 
 /** Helper to initialize a variable like an Eigen vector, with a coma separated list.*/
 template<typename Derived>
-inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr&& v, const Eigen::DenseBase<Derived>& other)
+inline Eigen::CommaInitializer<Eigen::VectorXd> operator<<(tvm::VariablePtr && v,
+                                                           const Eigen::DenseBase<Derived> & other)
 {
   return *v.get() << other;
 }

--- a/include/tvm/VariableVector.h
+++ b/include/tvm/VariableVector.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/VariableVector.h
+++ b/include/tvm/VariableVector.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/internal/MatrixWithProperties.h>
 
 #include <map>

--- a/include/tvm/VariableVector.h
+++ b/include/tvm/VariableVector.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -40,187 +40,180 @@
 
 namespace tvm
 {
-  /** A vector of variables, with some useful manipulation/analysis functions.
-    *
-    * One of the main use of this class is to determine variable mapping, i.e.
-    * given a vector aggregating all variables, which section of this vector
-    * would correspond to a given variable.
-    * There is two approaches for that: either build a map with
-    * computeMappingMap or use the method Variable::getMappingIn. The latter
-    * uses a cache in Variable in a way that if one invoke Variable::getMappingIn
-    * on any variable contained in a VariableVector, the mapping of all other
-    * contained variables will be computed and cached. For repeatedly querying
-    * the mapping of those variable w.r.t the same VariableVector, this is the
-    * fastest option. However it will be slow if querying alternatively
-    * mapping w.r.t different VariableVector on the same variable or set of
-    * variables.
-    *
-    * A given variable can only appear once in a vector. Variables appear in the
-    * order they were added, ignoring duplicates.
-    *
-    * FIXME would it make sense to derive from std::vector<std::shared_ptr<Variable>> ?
-    */
-  class TVM_DLLAPI VariableVector
-  {
-  public:
-    /** Construct an empty vector*/
-    VariableVector();
-    /** General construction
-      *
-      * \tparam Can be any list from the following type:
-      *   * VariablePtr
-      *   * std::unique_ptr<Variable>
-      *   * VariableVector
-      *   * std::vector<VariablePtr>
-      *
-      * \param variables A coma-separated list of instances of the above types.
-      *   Variables will be added in the order they appear.
-      */
-    template <typename... VarPtr>
-    VariableVector(VarPtr&&... variables);
+/** A vector of variables, with some useful manipulation/analysis functions.
+ *
+ * One of the main use of this class is to determine variable mapping, i.e.
+ * given a vector aggregating all variables, which section of this vector
+ * would correspond to a given variable.
+ * There is two approaches for that: either build a map with
+ * computeMappingMap or use the method Variable::getMappingIn. The latter
+ * uses a cache in Variable in a way that if one invoke Variable::getMappingIn
+ * on any variable contained in a VariableVector, the mapping of all other
+ * contained variables will be computed and cached. For repeatedly querying
+ * the mapping of those variable w.r.t the same VariableVector, this is the
+ * fastest option. However it will be slow if querying alternatively
+ * mapping w.r.t different VariableVector on the same variable or set of
+ * variables.
+ *
+ * A given variable can only appear once in a vector. Variables appear in the
+ * order they were added, ignoring duplicates.
+ *
+ * FIXME would it make sense to derive from std::vector<std::shared_ptr<Variable>> ?
+ */
+class TVM_DLLAPI VariableVector
+{
+public:
+  /** Construct an empty vector*/
+  VariableVector();
+  /** General construction
+   *
+   * \tparam Can be any list from the following type:
+   *   * VariablePtr
+   *   * std::unique_ptr<Variable>
+   *   * VariableVector
+   *   * std::vector<VariablePtr>
+   *
+   * \param variables A coma-separated list of instances of the above types.
+   *   Variables will be added in the order they appear.
+   */
+  template<typename... VarPtr>
+  VariableVector(VarPtr &&... variables);
 
-    /** Add a variable to the vector if not already present.
-      *
-      * \param v The variable to be added.
-      *
-      * \returns True if the variable was added, false otherwise.
-      */
-    bool add(VariablePtr v);
-    /** Add a variable to the vector. This version is mostly to be used directly
-      * with the output of tvm::Space::createVariable.
-      *
-      * \param v The variable to be added.
-      *
-      * \returns True if the variable was added, false otherwise
-      *
-      * \internal This version is meant to disembiguate between add(VariablePtr v)
-      * and add(const VariableVector& variables) when passing a std::unique_ptr<Variable>.
-      */
-    bool add(std::unique_ptr<Variable> v);
-    /** Same as add(VariablePtr), but for adding a vector of variables.*/
-    void add(const std::vector<VariablePtr>& variables);
-    /** Same as add(VariablePtr), but for adding a vector of variables.*/
-    void add(const VariableVector& variables);
-    /** Add a variable to the vector, if not already present and return the index
-      * of the variable in the vector whether it was added or not.
-      *
-      * \param v The variable to be added.
-      *
-      * \returns Index of variable \p v in the vector.
-      */
-    int addAndGetIndex(VariablePtr v);
+  /** Add a variable to the vector if not already present.
+   *
+   * \param v The variable to be added.
+   *
+   * \returns True if the variable was added, false otherwise.
+   */
+  bool add(VariablePtr v);
+  /** Add a variable to the vector. This version is mostly to be used directly
+   * with the output of tvm::Space::createVariable.
+   *
+   * \param v The variable to be added.
+   *
+   * \returns True if the variable was added, false otherwise
+   *
+   * \internal This version is meant to disembiguate between add(VariablePtr v)
+   * and add(const VariableVector& variables) when passing a std::unique_ptr<Variable>.
+   */
+  bool add(std::unique_ptr<Variable> v);
+  /** Same as add(VariablePtr), but for adding a vector of variables.*/
+  void add(const std::vector<VariablePtr> & variables);
+  /** Same as add(VariablePtr), but for adding a vector of variables.*/
+  void add(const VariableVector & variables);
+  /** Add a variable to the vector, if not already present and return the index
+   * of the variable in the vector whether it was added or not.
+   *
+   * \param v The variable to be added.
+   *
+   * \returns Index of variable \p v in the vector.
+   */
+  int addAndGetIndex(VariablePtr v);
 
-    /** Remove a variable from the vector, if present.
-      *
-      * \param v the variable to be removed.
-      *
-      * \returns True if the variable was removed, false otherwise.
-      */
-    bool remove(const Variable& v);
-    /** Remove the variable with the given index.
-      *
-      * \param i Index of the variable to be removed.
-      *
-      * \throws std::out_of_range if i is smaller than 0 or greater than the
-      * number of variables.
-      */
-    void remove(int i);
+  /** Remove a variable from the vector, if present.
+   *
+   * \param v the variable to be removed.
+   *
+   * \returns True if the variable was removed, false otherwise.
+   */
+  bool remove(const Variable & v);
+  /** Remove the variable with the given index.
+   *
+   * \param i Index of the variable to be removed.
+   *
+   * \throws std::out_of_range if i is smaller than 0 or greater than the
+   * number of variables.
+   */
+  void remove(int i);
 
-    /** Sum of the sizes of all the variables.*/
-    int totalSize() const;
-    /** Number of variables*/
-    int numberOfVariables() const;
-    /** Elementwise access*/
-    const VariablePtr operator[](int i) const;
-    /** whole vector access*/
-    const std::vector<VariablePtr>& variables() const;
+  /** Sum of the sizes of all the variables.*/
+  int totalSize() const;
+  /** Number of variables*/
+  int numberOfVariables() const;
+  /** Elementwise access*/
+  const VariablePtr operator[](int i) const;
+  /** whole vector access*/
+  const std::vector<VariablePtr> & variables() const;
 
-    /** Get the concatenation of all variables' value, in the order of the
-      * variables as given by variables().
-      */
-    const Eigen::VectorXd& value() const;
-    /** Set the value of all variables from a concatenated vector
-      *
-      * \param val The concatenated value of all the variables, in the order of
-      * the variables as given by variables().
-      */
-    void value(const VectorConstRef& val);
-    /** Set the value of all variables to 0.*/
-    void setZero();
-    /** Compute the mapping for all variables in this vector. The result is
-      * stored in each variable and can be queried by Variable::getMappingIn.
-      */
-    void computeMapping() const;
+  /** Get the concatenation of all variables' value, in the order of the
+   * variables as given by variables().
+   */
+  const Eigen::VectorXd & value() const;
+  /** Set the value of all variables from a concatenated vector
+   *
+   * \param val The concatenated value of all the variables, in the order of
+   * the variables as given by variables().
+   */
+  void value(const VectorConstRef & val);
+  /** Set the value of all variables to 0.*/
+  void setZero();
+  /** Compute the mapping for all variables in this vector. The result is
+   * stored in each variable and can be queried by Variable::getMappingIn.
+   */
+  void computeMapping() const;
 
-    /** Compute the mapping for every variabe and return it.*/
-    std::map<const Variable*, Range> computeMappingMap() const;
-    /** Check if this vector contains variable \p v or not. */
-    bool contains(const Variable& v) const;
+  /** Compute the mapping for every variabe and return it.*/
+  std::map<const Variable *, Range> computeMappingMap() const;
+  /** Check if this vector contains variable \p v or not. */
+  bool contains(const Variable & v) const;
 
-    /** Find the index of variable \p v in the vector. Returns -1 if \p v is not
-      * present.
-      */
-    int indexOf(const Variable& v) const;
+  /** Find the index of variable \p v in the vector. Returns -1 if \p v is not
+   * present.
+   */
+  int indexOf(const Variable & v) const;
 
-    /** A timestamp, used internally to determine if a mapping needs to be
-      * recomputed or not.
-      */
-    int stamp() const;
+  /** A timestamp, used internally to determine if a mapping needs to be
+   * recomputed or not.
+   */
+  int stamp() const;
 
-    /** Iterator to the first variable. This enable to use VariableVector
-      * directly in range-based for loops
-      */
-    std::vector<VariablePtr>::const_iterator begin() const;
-    /** Iterator past the last variable. This enable to use VariableVector
-      * directly in range-based for loops
-      */
-    std::vector<VariablePtr>::const_iterator end() const;
+  /** Iterator to the first variable. This enable to use VariableVector
+   * directly in range-based for loops
+   */
+  std::vector<VariablePtr>::const_iterator begin() const;
+  /** Iterator past the last variable. This enable to use VariableVector
+   * directly in range-based for loops
+   */
+  std::vector<VariablePtr>::const_iterator end() const;
 
-  private:
-    void add_(VariablePtr v);
-    void remove_(std::vector<VariablePtr>::const_iterator it);
-    void getNewStamp() const;
+private:
+  void add_(VariablePtr v);
+  void remove_(std::vector<VariablePtr>::const_iterator it);
+  void getNewStamp() const;
 
-    static int counter;
+  static int counter;
 
-    mutable int stamp_;
-    int size_;
-    std::vector<VariablePtr> variables_;
+  mutable int stamp_;
+  int size_;
+  std::vector<VariablePtr> variables_;
 
-    mutable Eigen::VectorXd value_;
-  };
+  mutable Eigen::VectorXd value_;
+};
 
-
-  template <typename... VarPtr>
-  VariableVector::VariableVector(VarPtr&&... variables)
-    : VariableVector()
-  {
-    static_assert((... && (std::is_same_v<typename std::decay_t<VarPtr>, VariablePtr> 
+template<typename... VarPtr>
+VariableVector::VariableVector(VarPtr &&... variables) : VariableVector()
+{
+  // clang-format off
+    static_assert((... && (std::is_same_v<typename std::decay_t<VarPtr>, VariablePtr>
                         || std::is_same_v<typename std::decay_t<VarPtr>, std::unique_ptr<Variable>>
                         || std::is_same_v<typename std::decay_t<VarPtr>, VariableVector>
                         || std::is_same_v<typename std::decay_t<VarPtr>, std::vector<VariablePtr>>)));
-    (add(std::forward<VarPtr>(variables)), ...);
-  }
+  // clang-format on
+  (add(std::forward<VarPtr>(variables)), ...);
+}
 
-  /** Get the vector of ndiff-th time derivatives of the variables of the input
-    * vector.
-    *
-    * \param var the variable to be derived
-    * \param ndiff the order of the derivation
-    *
-    * \warning This recreates a vector from scratch each time
-    */
-  VariableVector TVM_DLLAPI dot(const VariableVector& vars, int ndiff=1);
+/** Get the vector of ndiff-th time derivatives of the variables of the input
+ * vector.
+ *
+ * \param var the variable to be derived
+ * \param ndiff the order of the derivation
+ *
+ * \warning This recreates a vector from scratch each time
+ */
+VariableVector TVM_DLLAPI dot(const VariableVector & vars, int ndiff = 1);
 
+inline std::vector<VariablePtr>::const_iterator tvm::VariableVector::begin() const { return variables_.begin(); }
 
-  inline std::vector<VariablePtr>::const_iterator tvm::VariableVector::begin() const
-  {
-    return variables_.begin();
-  }
+inline std::vector<VariablePtr>::const_iterator tvm::VariableVector::end() const { return variables_.end(); }
 
-  inline std::vector<VariablePtr>::const_iterator tvm::VariableVector::end() const
-  {
-    return variables_.end();
-  }
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/api.h
+++ b/include/tvm/api.h
@@ -1,65 +1,65 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-# if defined _WIN32 || defined __CYGWIN__
+#if defined _WIN32 || defined __CYGWIN__
 // On Microsoft Windows, use dllimport and dllexport to tag symbols.
 #  define TVM_DLLIMPORT __declspec(dllimport)
 #  define TVM_DLLEXPORT __declspec(dllexport)
 #  define TVM_DLLLOCAL
-# else
+#else
 // On Linux, for GCC >= 4, tag symbols using GCC extension.
 #  if __GNUC__ >= 4
-#   define TVM_DLLIMPORT __attribute__ ((visibility("default")))
-#   define TVM_DLLEXPORT __attribute__ ((visibility("default")))
-#   define TVM_DLLLOCAL  __attribute__ ((visibility("hidden")))
+#    define TVM_DLLIMPORT __attribute__((visibility("default")))
+#    define TVM_DLLEXPORT __attribute__((visibility("default")))
+#    define TVM_DLLLOCAL __attribute__((visibility("hidden")))
 #  else
 // Otherwise (GCC < 4 or another compiler is used), export everything.
-#   define TVM_DLLIMPORT
-#   define TVM_DLLEXPORT
-#   define TVM_DLLLOCAL
+#    define TVM_DLLIMPORT
+#    define TVM_DLLEXPORT
+#    define TVM_DLLLOCAL
 #  endif // __GNUC__ >= 4
-# endif // defined _WIN32 || defined __CYGWIN__
+#endif // defined _WIN32 || defined __CYGWIN__
 
-# ifdef TVM_STATIC
+#ifdef TVM_STATIC
 // If one is using the library statically, get rid of
 // extra information.
 #  define TVM_DLLAPI
 #  define TVM_LOCAL
-# else
+#else
 // Depending on whether one is building or using the
 // library define DLLAPI to import or export.
 #  ifdef TVM_EXPORTS
-#   define TVM_DLLAPI TVM_DLLEXPORT
+#    define TVM_DLLAPI TVM_DLLEXPORT
 #  else
-#   define TVM_DLLAPI TVM_DLLIMPORT
+#    define TVM_DLLAPI TVM_DLLIMPORT
 #  endif // TVM_EXPORTS
 #  define TVM_LOCAL TVM_DLLLOCAL
-# endif // TVM_STATIC
+#endif // TVM_STATIC

--- a/include/tvm/api.h
+++ b/include/tvm/api.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/api.h
+++ b/include/tvm/api.h
@@ -19,7 +19,7 @@
 #    define TVM_DLLEXPORT
 #    define TVM_DLLLOCAL
 #  endif // __GNUC__ >= 4
-#endif // defined _WIN32 || defined __CYGWIN__
+#endif   // defined _WIN32 || defined __CYGWIN__
 
 #ifdef TVM_STATIC
 // If one is using the library statically, get rid of

--- a/include/tvm/constraint/BasicLinearConstraint.h
+++ b/include/tvm/constraint/BasicLinearConstraint.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,75 +38,75 @@ namespace tvm
 namespace constraint
 {
 
-  /** The most basic linear constraint where the matrix and the vector(s)
-    * are constant.
-    */
-  class TVM_DLLAPI BasicLinearConstraint : public abstract::LinearConstraint
-  {
-  public:
-    /** Ax = 0, Ax <= 0 or Ax >= 0. */
-    BasicLinearConstraint(const MatrixConstRef& A, VariablePtr x, Type ct);
+/** The most basic linear constraint where the matrix and the vector(s)
+ * are constant.
+ */
+class TVM_DLLAPI BasicLinearConstraint : public abstract::LinearConstraint
+{
+public:
+  /** Ax = 0, Ax <= 0 or Ax >= 0. */
+  BasicLinearConstraint(const MatrixConstRef & A, VariablePtr x, Type ct);
 
-    /** A_{i}x_{i} = 0, A_{i}x_{i} <= 0 or A_{i}x_{i} >= 0 */
-    BasicLinearConstraint(const std::vector<MatrixConstRef>& A,
-                          const std::vector<VariablePtr>& x,
-                          Type ct);
+  /** A_{i}x_{i} = 0, A_{i}x_{i} <= 0 or A_{i}x_{i} >= 0 */
+  BasicLinearConstraint(const std::vector<MatrixConstRef> & A, const std::vector<VariablePtr> & x, Type ct);
 
-    /** Ax = +/-b, Ax <= +/-b or Ax >= +/-b */
-    BasicLinearConstraint(const MatrixConstRef& A,
-                          VariablePtr x,
-                          const VectorConstRef& b,
-                          Type ct, RHS cr = RHS::AS_GIVEN);
+  /** Ax = +/-b, Ax <= +/-b or Ax >= +/-b */
+  BasicLinearConstraint(const MatrixConstRef & A,
+                        VariablePtr x,
+                        const VectorConstRef & b,
+                        Type ct,
+                        RHS cr = RHS::AS_GIVEN);
 
-    /** A_{i}x_{i} = +/-b, A_{i}x_{i} <= +/-b or A_{i}x_{i} >= +/-b */
-    BasicLinearConstraint(const std::vector<MatrixConstRef>& A,
-                          const std::vector<VariablePtr>& x,
-                          const VectorConstRef& b,
-                          Type ct, RHS cr = RHS::AS_GIVEN);
+  /** A_{i}x_{i} = +/-b, A_{i}x_{i} <= +/-b or A_{i}x_{i} >= +/-b */
+  BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
+                        const std::vector<VariablePtr> & x,
+                        const VectorConstRef & b,
+                        Type ct,
+                        RHS cr = RHS::AS_GIVEN);
 
-    /** l <= Ax <= u */
-    BasicLinearConstraint(const MatrixConstRef& A,
-                          VariablePtr x,
-                          const VectorConstRef& l,
-                          const VectorConstRef& u,
-                          RHS cr = RHS::AS_GIVEN);
+  /** l <= Ax <= u */
+  BasicLinearConstraint(const MatrixConstRef & A,
+                        VariablePtr x,
+                        const VectorConstRef & l,
+                        const VectorConstRef & u,
+                        RHS cr = RHS::AS_GIVEN);
 
-    /** l <= A_{i}x_{i} <= u */
-    BasicLinearConstraint(const std::vector<MatrixConstRef>& A,
-                          const std::vector<VariablePtr>& x,
-                          const VectorConstRef& l,
-                          const VectorConstRef& u,
-                          RHS cr = RHS::AS_GIVEN);
+  /** l <= A_{i}x_{i} <= u */
+  BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
+                        const std::vector<VariablePtr> & x,
+                        const VectorConstRef & l,
+                        const VectorConstRef & u,
+                        RHS cr = RHS::AS_GIVEN);
 
-    /** Uninitialized data. Allocate memory for a constraint with \p m rows. */
-    BasicLinearConstraint(int m, VariablePtr x,
-                          Type ct, RHS cr = RHS::AS_GIVEN);
-    /** Uninitialized data. Allocate memory for a constraint with \p m rows. */
-    BasicLinearConstraint(int m, std::vector<VariablePtr>& x,
-                          Type ct, RHS cr = RHS::AS_GIVEN);
+  /** Uninitialized data. Allocate memory for a constraint with \p m rows. */
+  BasicLinearConstraint(int m, VariablePtr x, Type ct, RHS cr = RHS::AS_GIVEN);
+  /** Uninitialized data. Allocate memory for a constraint with \p m rows. */
+  BasicLinearConstraint(int m, std::vector<VariablePtr> & x, Type ct, RHS cr = RHS::AS_GIVEN);
 
-    /** Set the matrix \p A corresponding to variable \p x.
-      * Optionally set the properties of \p A with \p p
-      */
-    void A(const MatrixConstRef& A, const Variable& x, 
-           const tvm::internal::MatrixProperties& p = tvm::internal::MatrixProperties());
-    /** Shortcut for 
-      *void A(const MatrixConstRef&, const Variable&, const tvm::internal::MatrixProperties&)
-      * when there is a single variable.
-      */
-    void A(const MatrixConstRef& A, const tvm::internal::MatrixProperties& p = tvm::internal::MatrixProperties());
-    /** Set \p b */
-    void b(const VectorConstRef& b);
-    using abstract::LinearConstraint::l;
-    /** Set \p l */
-    void l(const VectorConstRef& l);
-    using abstract::LinearConstraint::u;
-    /** Set \p u */
-    void u(const VectorConstRef& u);
-  private:
-    void add(const Eigen::MatrixXd& A, VariablePtr x);
-  };
+  /** Set the matrix \p A corresponding to variable \p x.
+   * Optionally set the properties of \p A with \p p
+   */
+  void A(const MatrixConstRef & A,
+         const Variable & x,
+         const tvm::internal::MatrixProperties & p = tvm::internal::MatrixProperties());
+  /** Shortcut for
+   *void A(const MatrixConstRef&, const Variable&, const tvm::internal::MatrixProperties&)
+   * when there is a single variable.
+   */
+  void A(const MatrixConstRef & A, const tvm::internal::MatrixProperties & p = tvm::internal::MatrixProperties());
+  /** Set \p b */
+  void b(const VectorConstRef & b);
+  using abstract::LinearConstraint::l;
+  /** Set \p l */
+  void l(const VectorConstRef & l);
+  using abstract::LinearConstraint::u;
+  /** Set \p u */
+  void u(const VectorConstRef & u);
 
-}  // namespace constraint
+private:
+  void add(const Eigen::MatrixXd & A, VariablePtr x);
+};
 
-}  // namespace tvm
+} // namespace constraint
+
+} // namespace tvm

--- a/include/tvm/constraint/BasicLinearConstraint.h
+++ b/include/tvm/constraint/BasicLinearConstraint.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/constraint/abstract/Constraint.h
+++ b/include/tvm/constraint/abstract/Constraint.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/constraint/abstract/Constraint.h
+++ b/include/tvm/constraint/abstract/Constraint.h
@@ -1,38 +1,38 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/constraint/enums.h>
 #include <tvm/constraint/internal/RHSVectors.h>
-#include <tvm/internal/FirstOrderProvider.h>
 #include <tvm/graph/abstract/OutputSelector.h>
+#include <tvm/internal/FirstOrderProvider.h>
 
 #include <Eigen/Core>
 
@@ -47,130 +47,112 @@ namespace constraint
 namespace abstract
 {
 
-  /** Base class for representing a constraint.
-    *
-    * It manages the enabling/disabling of the outputs L, U and E (depending
-    * on its type and rhs convention).
-    *
-    * FIXME: have the updateValue here and add an output check()
-    *
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   {
-    *     rank = same; node [shape=hexagon];
-    *     Value; Jacobian; L; U; E;
-    *   }
-    *   {
-    *     rank = same; node [style=invis, label=""];
-    *     outValue; outJacobian; outL; outU; outE;
-    *   }
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    *   L -> outL [label="l()"];
-    *   U -> outU [label="u()"];
-    *   E -> outE [label="e()"];
-    * }
-    * \enddot
-    */
-  class TVM_DLLAPI Constraint : public tvm::internal::ObjWithId, public graph::abstract::OutputSelector<Constraint, tvm::internal::FirstOrderProvider>
-  {
-  public:
-    SET_OUTPUTS(Constraint, L, U, E)
+/** Base class for representing a constraint.
+ *
+ * It manages the enabling/disabling of the outputs L, U and E (depending
+ * on its type and rhs convention).
+ *
+ * FIXME: have the updateValue here and add an output check()
+ *
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   {
+ *     rank = same; node [shape=hexagon];
+ *     Value; Jacobian; L; U; E;
+ *   }
+ *   {
+ *     rank = same; node [style=invis, label=""];
+ *     outValue; outJacobian; outL; outU; outE;
+ *   }
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ *   L -> outL [label="l()"];
+ *   U -> outU [label="u()"];
+ *   E -> outE [label="e()"];
+ * }
+ * \enddot
+ */
+class TVM_DLLAPI Constraint : public tvm::internal::ObjWithId,
+                              public graph::abstract::OutputSelector<Constraint, tvm::internal::FirstOrderProvider>
+{
+public:
+  SET_OUTPUTS(Constraint, L, U, E)
 
-    /** \internal by default, these methods return the cached value.
-      * However, they are virtual in case the user might want to bypass the cache.
-      * This would be typically the case if he/she wants to directly return the
-      * output of another method.
-      */
-    /** Return the vector \p l
-      * \warning the call is valid only if \p l exists for the given constraint
-      * conventions, but the method does not throw if it is not the case.
-      */
-    virtual const Eigen::VectorXd& l() const;
-    /** Return the vector \p u
-      * \warning the call is valid only if \p l exists for the given constraint
-      * conventions, but the method does not throw if it is not the case.
-      */
-    virtual const Eigen::VectorXd& u() const;
-    /** Return the vector \p e
-      * \warning the call is valid only if \p l exists for the given constraint
-      * conventions, but the method does not throw if it is not the case.
-      */
-    virtual const Eigen::VectorXd& e() const;
+  /** \internal by default, these methods return the cached value.
+   * However, they are virtual in case the user might want to bypass the cache.
+   * This would be typically the case if he/she wants to directly return the
+   * output of another method.
+   */
+  /** Return the vector \p l
+   * \warning the call is valid only if \p l exists for the given constraint
+   * conventions, but the method does not throw if it is not the case.
+   */
+  virtual const Eigen::VectorXd & l() const;
+  /** Return the vector \p u
+   * \warning the call is valid only if \p l exists for the given constraint
+   * conventions, but the method does not throw if it is not the case.
+   */
+  virtual const Eigen::VectorXd & u() const;
+  /** Return the vector \p e
+   * \warning the call is valid only if \p l exists for the given constraint
+   * conventions, but the method does not throw if it is not the case.
+   */
+  virtual const Eigen::VectorXd & e() const;
 
-    /** Return the type of the constraint.*/
-    Type type() const;
+  /** Return the type of the constraint.*/
+  Type type() const;
 
-    /** Check whether this is an equality constraint. */
-    bool isEquality() const;
+  /** Check whether this is an equality constraint. */
+  bool isEquality() const;
 
-    /** Return the convention for the right-hand side \p e, \p l, \p u or both
-      * \p l and \p u of the constraint.
-      */
-    RHS rhs() const;
+  /** Return the convention for the right-hand side \p e, \p l, \p u or both
+   * \p l and \p u of the constraint.
+   */
+  RHS rhs() const;
 
-  protected:
-    /** Constructor. Only available to derived classes.
-      * \param ct The constraint type
-      * \param cr The rhs convention
-      * \param The (output) size of the constraint
-      */
-    Constraint(Type ct, RHS cr, int m=0);
+protected:
+  /** Constructor. Only available to derived classes.
+   * \param ct The constraint type
+   * \param cr The rhs convention
+   * \param The (output) size of the constraint
+   */
+  Constraint(Type ct, RHS cr, int m = 0);
 
-    /** Resize the cache (rhs vector(s), jacobian matrices,...) for the current
-      * size of the constraint.
-      */
-    void resizeCache() override;
+  /** Resize the cache (rhs vector(s), jacobian matrices,...) for the current
+   * size of the constraint.
+   */
+  void resizeCache() override;
 
-    /** Direct (non-const) access to \p l for derived classes */
-    Eigen::VectorXd& lRef();
-    /** Direct (non-const) access to \p u for derived classes */
-    Eigen::VectorXd& uRef();
-    /** Direct (non-const) access to \p e for derived classes */
-    Eigen::VectorXd& eRef();
+  /** Direct (non-const) access to \p l for derived classes */
+  Eigen::VectorXd & lRef();
+  /** Direct (non-const) access to \p u for derived classes */
+  Eigen::VectorXd & uRef();
+  /** Direct (non-const) access to \p e for derived classes */
+  Eigen::VectorXd & eRef();
 
-    /** Cache for l, u and e */
-    internal::RHSVectors vectors_;
+  /** Cache for l, u and e */
+  internal::RHSVectors vectors_;
 
-  private:
-    Type  cstrType_;      // The constraint type
-    RHS   constraintRhs_; // The rhs convention
-  };
+private:
+  Type cstrType_; // The constraint type
+  RHS constraintRhs_; // The rhs convention
+};
 
+inline const Eigen::VectorXd & Constraint::l() const { return vectors_.l(); }
 
-  inline const Eigen::VectorXd& Constraint::l() const
-  {
-    return vectors_.l();
-  }
+inline const Eigen::VectorXd & Constraint::u() const { return vectors_.u(); }
 
-  inline const Eigen::VectorXd& Constraint::u() const
-  {
-    return vectors_.u();
-  }
+inline const Eigen::VectorXd & Constraint::e() const { return vectors_.e(); }
 
-  inline const Eigen::VectorXd& Constraint::e() const
-  {
-    return vectors_.e();
-  }
+inline Eigen::VectorXd & Constraint::lRef() { return vectors_.l(); }
 
-  inline Eigen::VectorXd& Constraint::lRef()
-  {
-    return vectors_.l();
-  }
+inline Eigen::VectorXd & Constraint::uRef() { return vectors_.u(); }
 
-  inline Eigen::VectorXd& Constraint::uRef()
-  {
-    return vectors_.u();
-  }
+inline Eigen::VectorXd & Constraint::eRef() { return vectors_.e(); }
 
-  inline Eigen::VectorXd& Constraint::eRef()
-  {
-    return vectors_.e();
-  }
+} // namespace abstract
 
-}  // namespace abstract
+} // namespace constraint
 
-}  // namespace constraint
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/constraint/abstract/Constraint.h
+++ b/include/tvm/constraint/abstract/Constraint.h
@@ -108,7 +108,7 @@ protected:
   internal::RHSVectors vectors_;
 
 private:
-  Type cstrType_; // The constraint type
+  Type cstrType_;     // The constraint type
   RHS constraintRhs_; // The rhs convention
 };
 

--- a/include/tvm/constraint/abstract/LinearConstraint.h
+++ b/include/tvm/constraint/abstract/LinearConstraint.h
@@ -1,36 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/defs.h>
 #include <tvm/constraint/abstract/Constraint.h>
+#include <tvm/defs.h>
 
 #include <Eigen/Core>
 
@@ -46,59 +46,59 @@ namespace constraint
 namespace abstract
 {
 
-  /** Note: if you intend to use the Value output and your jacobian matrices
-    * are not constant, you need to tie updateValue to the update of those
-    * matrices.
-    *
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   {
-    *     rank=same; node [shape=circle];
-    *     x_i;
-    *   }
-    *   {
-    *     uValue [label=Value];
-    *   }
-    *   {
-    *     rank = same; node [shape=hexagon];
-    *     Value; Jacobian; L; U; E;
-    *   }
-    *   {
-    *     rank = same; node [style=invis, label=""];
-    *     outValue; outJacobian; outL; outU; outE;
-    *   }
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    *   L -> outL [label="l()"];
-    *   U -> outU [label="u()"];
-    *   E -> outE [label="e()"];
-    *   x_i -> uValue [label="value()"];
-    *   uValue -> Value;
-    * }
-    * \enddot
-    */
-  class TVM_DLLAPI LinearConstraint : public Constraint
-  {
-  public:
-    SET_UPDATES(LinearConstraint, Value)
+/** Note: if you intend to use the Value output and your jacobian matrices
+ * are not constant, you need to tie updateValue to the update of those
+ * matrices.
+ *
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   {
+ *     rank=same; node [shape=circle];
+ *     x_i;
+ *   }
+ *   {
+ *     uValue [label=Value];
+ *   }
+ *   {
+ *     rank = same; node [shape=hexagon];
+ *     Value; Jacobian; L; U; E;
+ *   }
+ *   {
+ *     rank = same; node [style=invis, label=""];
+ *     outValue; outJacobian; outL; outU; outE;
+ *   }
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ *   L -> outL [label="l()"];
+ *   U -> outU [label="u()"];
+ *   E -> outE [label="e()"];
+ *   x_i -> uValue [label="value()"];
+ *   uValue -> Value;
+ * }
+ * \enddot
+ */
+class TVM_DLLAPI LinearConstraint : public Constraint
+{
+public:
+  SET_UPDATES(LinearConstraint, Value)
 
-    /** Update the value of the constraint (i.e.) f(x) for a constraint
-      * f(x) op rhs.
-      */
-    void updateValue();
+  /** Update the value of the constraint (i.e.) f(x) for a constraint
+   * f(x) op rhs.
+   */
+  void updateValue();
 
-  protected:
-    /** Constructor. Only available to derived classes.
-      * \param ct The constraint type
-      * \param cr The rhs convention
-      * \param The (output) size of the constraint
-      */
-    LinearConstraint(Type ct, RHS cr, int m);
-  };
+protected:
+  /** Constructor. Only available to derived classes.
+   * \param ct The constraint type
+   * \param cr The rhs convention
+   * \param The (output) size of the constraint
+   */
+  LinearConstraint(Type ct, RHS cr, int m);
+};
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace constraint
+} // namespace constraint
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/constraint/abstract/LinearConstraint.h
+++ b/include/tvm/constraint/abstract/LinearConstraint.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <tvm/constraint/abstract/Constraint.h>
 #include <tvm/defs.h>
+
+#include <tvm/constraint/abstract/Constraint.h>
 
 #include <Eigen/Core>
 

--- a/include/tvm/constraint/abstract/LinearConstraint.h
+++ b/include/tvm/constraint/abstract/LinearConstraint.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/constraint/enums.h
+++ b/include/tvm/constraint/enums.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -35,33 +35,33 @@ namespace tvm
 namespace constraint
 {
 
-  /** For a function f(x), and a right hand side rhs (and rhs2), gives the type
-    * of the constraint.
-    */
-  enum class Type
-  {
-    /** f(x) =  rhs */
-    EQUAL,
-    /** f(x) >= rhs */
-    GREATER_THAN,
-    /** f(x) <= rhs */
-    LOWER_THAN,
-    /** rhs <= f(x) <= rhs2 */
-    DOUBLE_SIDED
-  };
+/** For a function f(x), and a right hand side rhs (and rhs2), gives the type
+ * of the constraint.
+ */
+enum class Type
+{
+  /** f(x) =  rhs */
+  EQUAL,
+  /** f(x) >= rhs */
+  GREATER_THAN,
+  /** f(x) <= rhs */
+  LOWER_THAN,
+  /** rhs <= f(x) <= rhs2 */
+  DOUBLE_SIDED
+};
 
-  /** Tell how a vector \p u should be considered as a right hand side of a
-    * constraint.
-    */
-  enum class RHS
-  {
-    /** rhs = 0 */
-    ZERO,
-    /** rhs = u */
-    AS_GIVEN,
-    /** rhs = -u */
-    OPPOSITE
-  };
+/** Tell how a vector \p u should be considered as a right hand side of a
+ * constraint.
+ */
+enum class RHS
+{
+  /** rhs = 0 */
+  ZERO,
+  /** rhs = u */
+  AS_GIVEN,
+  /** rhs = -u */
+  OPPOSITE
+};
 
 } // namespace constraint
 

--- a/include/tvm/constraint/enums.h
+++ b/include/tvm/constraint/enums.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/constraint/internal/LinearizedTaskConstraint.h
+++ b/include/tvm/constraint/internal/LinearizedTaskConstraint.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/constraint/internal/LinearizedTaskConstraint.h
+++ b/include/tvm/constraint/internal/LinearizedTaskConstraint.h
@@ -186,8 +186,7 @@ template<constraint::Type T>
 LinearizedTaskConstraint::LinearizedTaskConstraint(const utils::ProtoTask<T> & pt,
                                                    const task_dynamics::abstract::TaskDynamics & td)
 : LinearizedTaskConstraint(Task(pt, td))
-{
-}
+{}
 
 } // namespace internal
 

--- a/include/tvm/constraint/internal/LinearizedTaskConstraint.h
+++ b/include/tvm/constraint/internal/LinearizedTaskConstraint.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,182 +42,182 @@ namespace constraint
 namespace internal
 {
 
-  /** Given a task \f$(e, op, rhs, e^*)\f$, this class derives the constraint
-    * \f$d^k e/dt^k\ op\  e^*(e,de/dt,...de^{k-1}/dt^{k-1}, rhs [,g])\f$, where e is an
-    * error function, op is ==, >= or <= and \f$e^*\f$ is a desired error dynamics. 
-    * k is specified by \f$e^*\f$ and (optional) g is any other quantities.
-    *
-    * EQUAL (E) \ GREATER_THAN (L) \ LOWER_THAN (U) cases. Dotted dependencies
-    * correspond by default to the second order dynamics case (k=2), unless
-    * specified otherwise by the task dynamics used.
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   subgraph cluster1 {
-    *     label="f"
-    *     {
-    *       rank=same; node [shape=diamond];
-    *       fValue [label="Value"]; 
-    *       fJacobian [label="Jacobian"]; 
-    *       fVelocity [label="Velocity",style=dotted];
-    *       fNormalAcceleration [label="NormalAcceleration",style=dotted];
-    *     }
-    *   }
-    *   subgraph cluster2 {
-    *     label="td"
-    *     {
-    *       tdValue [label="Value", shape=Mdiamond];
-    *       tdUpdate [label="UpdateValue"];
-    *     }
-    *   }
-    *   {
-    *     rank=same;
-    *     uValue [label=Value];
-    *     updateRHS;
-    *   }
-    *   {
-    *     rank = same; node [shape=hexagon];
-    *     Value; Jacobian; 
-    *     E [label="E \\ L \\ U"];
-    *   }
-    *   {
-    *     rank = same; node [style=invis, label=""];
-    *     outValue; outJacobian; outE;
-    *   }
-    *   x_i [shape=box]
-    *   fValue -> tdUpdate
-    *   fVelocity -> tdUpdate [style=dotted]
-    *   tdUpdate -> tdValue
-    *   tdValue -> updateRHS
-    *   updateRHS -> E
-    *   fJacobian -> Jacobian
-    *   fJacobian -> uValue
-    *   fNormalAcceleration -> updateRHS [style=dotted]
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    *   E -> outE [label="e() \\ l() \\ u()"];
-    *   x_i -> uValue [label="value()"];
-    *   uValue -> Value;
-    * }
-    * \enddot
-    *
-    * DOUBLE_SIDED case. Dotted dependencies correspond by default to the second
-    * order dynamics case (k=2), unless specified otherwise by the task dynamics
-    * used.
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   subgraph cluster1 {
-    *     label="f"
-    *     {
-    *       rank=same; node [shape=diamond];
-    *       fValue [label="Value"];
-    *       fJacobian [label="Jacobian"];
-    *       fVelocity [label="Velocity",style=dotted];
-    *       fNormalAcceleration [label="NormalAcceleration",style=dotted];
-    *     }
-    *   }
-    *   subgraph cluster2 {
-    *     label="td"
-    *     {
-    *       td1Value [label="Value", shape=Mdiamond];
-    *       td1Update [label="UpdateValue"];
-    *     }
-    *   }
-    *   subgraph cluster3 {
-    *     label="td2"
-    *     {
-    *       td2Value [label="Value", shape=Mdiamond];
-    *       td2Update [label="UpdateValue"];
-    *     }
-    *   }
-    *   {
-    *     rank=same;
-    *     uValue [label=Value];
-    *     updateRHS;
-    *     updateRHS2;
-    *   }
-    *   {
-    *     rank = same; node [shape=hexagon];
-    *     Value; Jacobian; L; U
-    *   }
-    *   {
-    *     rank = same; node [style=invis, label=""];
-    *     outValue; outJacobian; outL; outU
-    *   }
-    *   x_i [shape=box]
-    *   fValue -> td1Update
-    *   fVelocity -> td1Update [style=dotted]
-    *   td1Update -> td1Value
-    *   td1Value -> updateRHS
-    *   fValue -> td2Update
-    *   fVelocity -> td2Update [style=dotted]
-    *   td2Update -> td2Value
-    *   td2Value -> updateRHS2
-    *   updateRHS -> L
-    *   updateRHS2 -> U
-    *   fJacobian -> Jacobian
-    *   fJacobian -> uValue
-    *   fNormalAcceleration -> updateRHS [style=dotted]
-    *   fNormalAcceleration -> updateRHS2 [style=dotted]
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    *   L -> outL [label="l()"];
-    *   U -> outU [label="u()"];
-    *   x_i -> uValue [label="value()"];
-    *   uValue -> Value;
-    * }
-    * \enddot
-    *
-    * \internal FIXME Consider the case where the TaskDynamics has its own variables?
-    */
-  class TVM_DLLAPI LinearizedTaskConstraint : public abstract::LinearConstraint
-  {
-  public:
-    SET_UPDATES(LinearizedTaskConstraint, UpdateRHS, UpdateRHS2)
+/** Given a task \f$(e, op, rhs, e^*)\f$, this class derives the constraint
+ * \f$d^k e/dt^k\ op\  e^*(e,de/dt,...de^{k-1}/dt^{k-1}, rhs [,g])\f$, where e is an
+ * error function, op is ==, >= or <= and \f$e^*\f$ is a desired error dynamics.
+ * k is specified by \f$e^*\f$ and (optional) g is any other quantities.
+ *
+ * EQUAL (E) \ GREATER_THAN (L) \ LOWER_THAN (U) cases. Dotted dependencies
+ * correspond by default to the second order dynamics case (k=2), unless
+ * specified otherwise by the task dynamics used.
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   subgraph cluster1 {
+ *     label="f"
+ *     {
+ *       rank=same; node [shape=diamond];
+ *       fValue [label="Value"];
+ *       fJacobian [label="Jacobian"];
+ *       fVelocity [label="Velocity",style=dotted];
+ *       fNormalAcceleration [label="NormalAcceleration",style=dotted];
+ *     }
+ *   }
+ *   subgraph cluster2 {
+ *     label="td"
+ *     {
+ *       tdValue [label="Value", shape=Mdiamond];
+ *       tdUpdate [label="UpdateValue"];
+ *     }
+ *   }
+ *   {
+ *     rank=same;
+ *     uValue [label=Value];
+ *     updateRHS;
+ *   }
+ *   {
+ *     rank = same; node [shape=hexagon];
+ *     Value; Jacobian;
+ *     E [label="E \\ L \\ U"];
+ *   }
+ *   {
+ *     rank = same; node [style=invis, label=""];
+ *     outValue; outJacobian; outE;
+ *   }
+ *   x_i [shape=box]
+ *   fValue -> tdUpdate
+ *   fVelocity -> tdUpdate [style=dotted]
+ *   tdUpdate -> tdValue
+ *   tdValue -> updateRHS
+ *   updateRHS -> E
+ *   fJacobian -> Jacobian
+ *   fJacobian -> uValue
+ *   fNormalAcceleration -> updateRHS [style=dotted]
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ *   E -> outE [label="e() \\ l() \\ u()"];
+ *   x_i -> uValue [label="value()"];
+ *   uValue -> Value;
+ * }
+ * \enddot
+ *
+ * DOUBLE_SIDED case. Dotted dependencies correspond by default to the second
+ * order dynamics case (k=2), unless specified otherwise by the task dynamics
+ * used.
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   subgraph cluster1 {
+ *     label="f"
+ *     {
+ *       rank=same; node [shape=diamond];
+ *       fValue [label="Value"];
+ *       fJacobian [label="Jacobian"];
+ *       fVelocity [label="Velocity",style=dotted];
+ *       fNormalAcceleration [label="NormalAcceleration",style=dotted];
+ *     }
+ *   }
+ *   subgraph cluster2 {
+ *     label="td"
+ *     {
+ *       td1Value [label="Value", shape=Mdiamond];
+ *       td1Update [label="UpdateValue"];
+ *     }
+ *   }
+ *   subgraph cluster3 {
+ *     label="td2"
+ *     {
+ *       td2Value [label="Value", shape=Mdiamond];
+ *       td2Update [label="UpdateValue"];
+ *     }
+ *   }
+ *   {
+ *     rank=same;
+ *     uValue [label=Value];
+ *     updateRHS;
+ *     updateRHS2;
+ *   }
+ *   {
+ *     rank = same; node [shape=hexagon];
+ *     Value; Jacobian; L; U
+ *   }
+ *   {
+ *     rank = same; node [style=invis, label=""];
+ *     outValue; outJacobian; outL; outU
+ *   }
+ *   x_i [shape=box]
+ *   fValue -> td1Update
+ *   fVelocity -> td1Update [style=dotted]
+ *   td1Update -> td1Value
+ *   td1Value -> updateRHS
+ *   fValue -> td2Update
+ *   fVelocity -> td2Update [style=dotted]
+ *   td2Update -> td2Value
+ *   td2Value -> updateRHS2
+ *   updateRHS -> L
+ *   updateRHS2 -> U
+ *   fJacobian -> Jacobian
+ *   fJacobian -> uValue
+ *   fNormalAcceleration -> updateRHS [style=dotted]
+ *   fNormalAcceleration -> updateRHS2 [style=dotted]
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ *   L -> outL [label="l()"];
+ *   U -> outU [label="u()"];
+ *   x_i -> uValue [label="value()"];
+ *   uValue -> Value;
+ * }
+ * \enddot
+ *
+ * \internal FIXME Consider the case where the TaskDynamics has its own variables?
+ */
+class TVM_DLLAPI LinearizedTaskConstraint : public abstract::LinearConstraint
+{
+public:
+  SET_UPDATES(LinearizedTaskConstraint, UpdateRHS, UpdateRHS2)
 
-    /** Constructor from a task*/
-    LinearizedTaskConstraint(const Task& task);
+  /** Constructor from a task*/
+  LinearizedTaskConstraint(const Task & task);
 
-    /** Constructor from a ProtoTask and a TaskDynamics*/
-    template<constraint::Type T>
-    LinearizedTaskConstraint(const utils::ProtoTask<T>& pt, const task_dynamics::abstract::TaskDynamics& td);
-
-    /** Update the \p l vector, for kinematic tasks.*/
-    void updateLKin();
-    /** Update the \p l vector, for dynamic tasks.*/
-    void updateLDyn();
-    /** Update the \p u vector, for kinematic, single-sided tasks.*/
-    void updateUKin();
-    /** Update the \p u vector, for dynamic, single-sided tasks.*/
-    void updateUDyn();
-    /** Update the \p e vector, for kinematic tasks.*/
-    void updateEKin();
-    /** Update the \p e vector, for dynamic tasks.*/
-    void updateEDyn();
-    /** Update the \p u vector, for kinematic, double-sided tasks.*/
-    void updateU2Kin();
-    /** Update the \p u vector, for dynamic, double-sided tasks.*/
-    void updateU2Dyn();
-
-    /** Return the jacobian matrix corresponding to \p x */
-    const tvm::internal::MatrixWithProperties& jacobian(const Variable& x) const override;
-
-  private:
-    FunctionPtr f_;
-    TaskDynamicsPtr td_;
-    TaskDynamicsPtr td2_; // for double sided constraints only;
-  };
-
-
+  /** Constructor from a ProtoTask and a TaskDynamics*/
   template<constraint::Type T>
-  LinearizedTaskConstraint::LinearizedTaskConstraint(const utils::ProtoTask<T>& pt, const task_dynamics::abstract::TaskDynamics& td)
-    : LinearizedTaskConstraint(Task(pt, td))
-  {
-  }
+  LinearizedTaskConstraint(const utils::ProtoTask<T> & pt, const task_dynamics::abstract::TaskDynamics & td);
 
-}  // namespace internal
+  /** Update the \p l vector, for kinematic tasks.*/
+  void updateLKin();
+  /** Update the \p l vector, for dynamic tasks.*/
+  void updateLDyn();
+  /** Update the \p u vector, for kinematic, single-sided tasks.*/
+  void updateUKin();
+  /** Update the \p u vector, for dynamic, single-sided tasks.*/
+  void updateUDyn();
+  /** Update the \p e vector, for kinematic tasks.*/
+  void updateEKin();
+  /** Update the \p e vector, for dynamic tasks.*/
+  void updateEDyn();
+  /** Update the \p u vector, for kinematic, double-sided tasks.*/
+  void updateU2Kin();
+  /** Update the \p u vector, for dynamic, double-sided tasks.*/
+  void updateU2Dyn();
 
-}  // namespace constraint
+  /** Return the jacobian matrix corresponding to \p x */
+  const tvm::internal::MatrixWithProperties & jacobian(const Variable & x) const override;
 
-}  // namespace tvm
+private:
+  FunctionPtr f_;
+  TaskDynamicsPtr td_;
+  TaskDynamicsPtr td2_; // for double sided constraints only;
+};
+
+template<constraint::Type T>
+LinearizedTaskConstraint::LinearizedTaskConstraint(const utils::ProtoTask<T> & pt,
+                                                   const task_dynamics::abstract::TaskDynamics & td)
+: LinearizedTaskConstraint(Task(pt, td))
+{
+}
+
+} // namespace internal
+
+} // namespace constraint
+
+} // namespace tvm

--- a/include/tvm/constraint/internal/RHSVectors.h
+++ b/include/tvm/constraint/internal/RHSVectors.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/constraint/internal/RHSVectors.h
+++ b/include/tvm/constraint/internal/RHSVectors.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -43,155 +43,133 @@ namespace constraint
 namespace internal
 {
 
-  /** This class manages the vectors \p l, \p u and \p e that appear in the
-    * various types of constraints.
-    */
-  class RHSVectors
+/** This class manages the vectors \p l, \p u and \p e that appear in the
+ * various types of constraints.
+ */
+class RHSVectors
+{
+public:
+  /** Create a instance for the given conventions
+   * \param ct The constraint type
+   * \param cr The type of "right hand side"
+   */
+  RHSVectors(Type ct, RHS cr);
+
+  /** Resize the vectors used to size \p n.*/
+  void resize(int n);
+
+  /** Return vector \p l
+   * \attention This does not check if \p l is in use
+   */
+  Eigen::VectorXd & l();
+
+  /** Return vector \p l (const version)
+   * \attention This does not check if \p l is in use
+   */
+  const Eigen::VectorXd & l() const;
+
+  /** Return vector \p u
+   * \attention This does not check if \p u is in use
+   */
+  Eigen::VectorXd & u();
+
+  /** Return vector \p  u(const version)
+   * \attention This does not check if \p u is in use
+   */
+  const Eigen::VectorXd & u() const;
+
+  /** Return vector \p e
+   * \attention This does not check if \p e is in use
+   */
+  Eigen::VectorXd & e();
+
+  /** Return vector \p e (const version)
+   * \attention This does not check if \p e is in use
+   */
+  const Eigen::VectorXd & e() const;
+
+  /** Return the vector specified by t:
+   * - l if t == Type::GREATER_THAN
+   * - u if t == Type::LOWER_THAN
+   * - e if t == Type::EQUAL
+   * If t == Type::DOUBLE_SIDED, throw an exception
+   */
+  Eigen::VectorXd & rhs(Type t);
+
+  /** Return the vector specified by t (const version):
+   * - l if t == Type::GREATER_THAN
+   * - u if t == Type::LOWER_THAN
+   * - e if t == Type::EQUAL
+   * If t == Type::DOUBLE_SIDED, throw an exception
+   */
+  const Eigen::VectorXd & rhs(Type t) const;
+
+  /** Check if \p l is used.*/
+  bool use_l() const;
+
+  /** Check if \p u is used.*/
+  bool use_u() const;
+
+  /** Check if \p e is used.*/
+  bool use_e() const;
+
+private:
+  Eigen::VectorXd l_;
+  Eigen::VectorXd u_;
+  Eigen::VectorXd e_;
+
+  const bool use_l_;
+  const bool use_u_;
+  const bool use_e_;
+};
+
+inline Eigen::VectorXd & RHSVectors::l() { return l_; }
+
+inline const Eigen::VectorXd & RHSVectors::l() const { return l_; }
+
+inline Eigen::VectorXd & RHSVectors::u() { return u_; }
+
+inline const Eigen::VectorXd & RHSVectors::u() const { return u_; }
+
+inline Eigen::VectorXd & RHSVectors::e() { return e_; }
+
+inline const Eigen::VectorXd & RHSVectors::e() const { return e_; }
+
+inline Eigen::VectorXd & RHSVectors::rhs(Type t)
+{
+  switch(t)
   {
-  public:
-    /** Create a instance for the given conventions
-      * \param ct The constraint type
-      * \param cr The type of "right hand side"
-      */
-    RHSVectors(Type ct, RHS cr);
-
-    /** Resize the vectors used to size \p n.*/
-    void resize(int n);
-
-    /** Return vector \p l
-      * \attention This does not check if \p l is in use
-      */
-    Eigen::VectorXd& l();
-
-    /** Return vector \p l (const version)
-      * \attention This does not check if \p l is in use
-      */
-    const Eigen::VectorXd& l() const;
-
-    /** Return vector \p u
-      * \attention This does not check if \p u is in use
-      */
-    Eigen::VectorXd& u();
-
-    /** Return vector \p  u(const version)
-      * \attention This does not check if \p u is in use
-      */
-    const Eigen::VectorXd& u() const;
-
-    /** Return vector \p e
-      * \attention This does not check if \p e is in use
-      */
-    Eigen::VectorXd& e();
-
-    /** Return vector \p e (const version)
-      * \attention This does not check if \p e is in use
-      */
-    const Eigen::VectorXd& e() const;
-
-    /** Return the vector specified by t:
-      * - l if t == Type::GREATER_THAN
-      * - u if t == Type::LOWER_THAN
-      * - e if t == Type::EQUAL
-      * If t == Type::DOUBLE_SIDED, throw an exception
-      */
-    Eigen::VectorXd& rhs(Type t);
-
-    /** Return the vector specified by t (const version):
-      * - l if t == Type::GREATER_THAN
-      * - u if t == Type::LOWER_THAN
-      * - e if t == Type::EQUAL
-      * If t == Type::DOUBLE_SIDED, throw an exception
-      */
-    const Eigen::VectorXd& rhs(Type t) const;
-
-    /** Check if \p l is used.*/
-    bool use_l() const;
-
-    /** Check if \p u is used.*/
-    bool use_u() const;
-    
-    /** Check if \p e is used.*/
-    bool use_e() const;
-
-  private:
-    Eigen::VectorXd l_;
-    Eigen::VectorXd u_;
-    Eigen::VectorXd e_;
-
-    const bool use_l_;
-    const bool use_u_;
-    const bool use_e_;
-  };
-
-
-
-  inline Eigen::VectorXd& RHSVectors::l()
-  {
-    return l_;
+    case Type::LOWER_THAN:
+      return u_;
+    case Type::GREATER_THAN:
+      return l_;
+    case Type::EQUAL:
+      return e_;
+    case Type::DOUBLE_SIDED:
+      throw std::runtime_error("This methods is not available for DOUBLE_SIDED");
   }
+}
 
-  inline const Eigen::VectorXd& RHSVectors::l() const
+inline const Eigen::VectorXd & RHSVectors::rhs(Type t) const
+{
+  switch(t)
   {
-    return l_;
+    case Type::LOWER_THAN:
+      return u_;
+    case Type::GREATER_THAN:
+      return l_;
+    case Type::EQUAL:
+      return e_;
+    case Type::DOUBLE_SIDED:
+      throw std::runtime_error("This methods is not available for DOUBLE_SIDED");
   }
+}
 
-  inline Eigen::VectorXd& RHSVectors::u()
-  {
-    return u_;
-  }
+inline bool RHSVectors::use_l() const { return use_l_; }
 
-  inline const Eigen::VectorXd& RHSVectors::u() const
-  {
-    return u_;
-  }
+inline bool RHSVectors::use_u() const { return use_u_; }
 
-  inline Eigen::VectorXd& RHSVectors::e()
-  {
-    return e_;
-  }
-
-  inline const Eigen::VectorXd& RHSVectors::e() const
-  {
-    return e_;
-  }
-
-
-  inline Eigen::VectorXd& RHSVectors::rhs(Type t)
-  {
-    switch (t)
-    {
-    case Type::LOWER_THAN: return u_;
-    case Type::GREATER_THAN: return l_;
-    case Type::EQUAL: return e_;
-    case Type::DOUBLE_SIDED: throw std::runtime_error("This methods is not available for DOUBLE_SIDED");
-    }
-  }
-
-  inline const Eigen::VectorXd& RHSVectors::rhs(Type t) const
-  {
-    switch (t)
-    {
-    case Type::LOWER_THAN: return u_;
-    case Type::GREATER_THAN: return l_;
-    case Type::EQUAL: return e_;
-    case Type::DOUBLE_SIDED: throw std::runtime_error("This methods is not available for DOUBLE_SIDED");
-    }
-  }
-
-  inline bool RHSVectors::use_l() const
-  {
-    return use_l_;
-  }
-
-  inline bool RHSVectors::use_u() const
-  {
-    return use_u_;
-  }
-
-  inline bool RHSVectors::use_e() const
-  {
-    return use_e_;
-  }
+inline bool RHSVectors::use_e() const { return use_e_; }
 
 } // namespace internal
 

--- a/include/tvm/constraint/internal/RHSVectors.h
+++ b/include/tvm/constraint/internal/RHSVectors.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/constraint/enums.h>
 
 #include <Eigen/Core>

--- a/include/tvm/defs.h
+++ b/include/tvm/defs.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/defs.h
+++ b/include/tvm/defs.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -36,110 +36,110 @@
 
 namespace tvm
 {
-  //forward declarations
-  namespace constraint
-  {
-    namespace abstract
-    {
-      class Constraint;
-      class LinearConstraint;
-    }
-  }
-  namespace function
-  {
-    namespace abstract
-    {
-      class Function;
-      class LinearFunction;
-    }
-  }
-  namespace requirements
-  {
-    class SolvingRequirements;
-    class SolvingRequirementsWithCallbacks;
-  }
-  namespace task_dynamics
-  {
-    namespace abstract
-    {
-      class TaskDynamicsImpl;
-    }
-  }
-  class Clock;
-  class Range;
-  class Robot;
-  class Variable;
-  class VariableVector;
+// forward declarations
+namespace constraint
+{
+namespace abstract
+{
+class Constraint;
+class LinearConstraint;
+} // namespace abstract
+} // namespace constraint
+namespace function
+{
+namespace abstract
+{
+class Function;
+class LinearFunction;
+} // namespace abstract
+} // namespace function
+namespace requirements
+{
+class SolvingRequirements;
+class SolvingRequirementsWithCallbacks;
+} // namespace requirements
+namespace task_dynamics
+{
+namespace abstract
+{
+class TaskDynamicsImpl;
+}
+} // namespace task_dynamics
+class Clock;
+class Range;
+class Robot;
+class Variable;
+class VariableVector;
 
-  //definitions
-  using MatrixConstRef = Eigen::Ref<const Eigen::MatrixXd>;
-  using MatrixRef = Eigen::Ref<Eigen::MatrixXd>;
-  using VectorConstRef = Eigen::Ref<const Eigen::VectorXd>;
-  using VectorRef = Eigen::Ref<Eigen::VectorXd>;
+// definitions
+using MatrixConstRef = Eigen::Ref<const Eigen::MatrixXd>;
+using MatrixRef = Eigen::Ref<Eigen::MatrixXd>;
+using VectorConstRef = Eigen::Ref<const Eigen::VectorXd>;
+using VectorRef = Eigen::Ref<Eigen::VectorXd>;
 
-  using MatrixPtr = std::shared_ptr<Eigen::MatrixXd>;
-  using VectorPtr = std::shared_ptr<Eigen::VectorXd>;
+using MatrixPtr = std::shared_ptr<Eigen::MatrixXd>;
+using VectorPtr = std::shared_ptr<Eigen::VectorXd>;
 
-  using ConstraintPtr = std::shared_ptr<constraint::abstract::Constraint>;
-  using FunctionPtr = std::shared_ptr<function::abstract::Function>;
-  using LinearFunctionPtr = std::shared_ptr<function::abstract::LinearFunction>;
-  using LinearConstraintPtr = std::shared_ptr<constraint::abstract::LinearConstraint>;
-  using ClockPtr = std::shared_ptr<Clock>;
-  using RangePtr = std::shared_ptr<Range>;
-  using RobotPtr = std::shared_ptr<Robot>;
-  using SolvingRequirementsPtr = std::shared_ptr<requirements::SolvingRequirementsWithCallbacks>;
-  using TaskDynamicsPtr = std::shared_ptr<task_dynamics::abstract::TaskDynamicsImpl>;
-  using VariablePtr = std::shared_ptr<Variable>;
+using ConstraintPtr = std::shared_ptr<constraint::abstract::Constraint>;
+using FunctionPtr = std::shared_ptr<function::abstract::Function>;
+using LinearFunctionPtr = std::shared_ptr<function::abstract::LinearFunction>;
+using LinearConstraintPtr = std::shared_ptr<constraint::abstract::LinearConstraint>;
+using ClockPtr = std::shared_ptr<Clock>;
+using RangePtr = std::shared_ptr<Range>;
+using RobotPtr = std::shared_ptr<Robot>;
+using SolvingRequirementsPtr = std::shared_ptr<requirements::SolvingRequirementsWithCallbacks>;
+using TaskDynamicsPtr = std::shared_ptr<task_dynamics::abstract::TaskDynamicsImpl>;
+using VariablePtr = std::shared_ptr<Variable>;
 
-  //constants
-  namespace constant
-  {
-    namespace internal
-    {
-      /** Constexpr integer power base^exp
-        * Adapted from https://stackoverflow.com/a/17728525
-        */
-      template <typename T>
-      constexpr T pow(T base, unsigned int exp, T result = 1)
-      {
-        return exp <= 1 ? (exp==0?1:result*base) : pow(base*base, exp / 2, (exp % 2) ? result*base : result);
-      }
+// constants
+namespace constant
+{
+namespace internal
+{
+/** Constexpr integer power base^exp
+ * Adapted from https://stackoverflow.com/a/17728525
+ */
+template<typename T>
+constexpr T pow(T base, unsigned int exp, T result = 1)
+{
+  return exp <= 1 ? (exp == 0 ? 1 : result * base) : pow(base * base, exp / 2, (exp % 2) ? result * base : result);
+}
 
-      /* Constexpr version of the square root of x
-       * curr is the initial guess for the square root
-       * Adapted from https://gist.github.com/alexshtf/eb5128b3e3e143187794
-       */
-      constexpr double sqrtNewtonRaphson(double x, double curr, double prev = 0)
-      {
-        return curr == prev ? curr : sqrtNewtonRaphson(x, 0.5 * (curr + x / curr), curr);
-      }
+/* Constexpr version of the square root of x
+ * curr is the initial guess for the square root
+ * Adapted from https://gist.github.com/alexshtf/eb5128b3e3e143187794
+ */
+constexpr double sqrtNewtonRaphson(double x, double curr, double prev = 0)
+{
+  return curr == prev ? curr : sqrtNewtonRaphson(x, 0.5 * (curr + x / curr), curr);
+}
 
-      /** \internal We compute the square root of std::numeric_limits<double>::max()
-        * We start with an approximation 2^{max_exponent/2}
-        */
-      static constexpr double sqrtGuess = pow(2., std::numeric_limits<double>::max_exponent / 2);
-      static constexpr double sqrtOfMax = sqrtNewtonRaphson(std::numeric_limits<double>::max(), sqrtGuess, 0);
-    } // namespace internal
+/** \internal We compute the square root of std::numeric_limits<double>::max()
+ * We start with an approximation 2^{max_exponent/2}
+ */
+static constexpr double sqrtGuess = pow(2., std::numeric_limits<double>::max_exponent / 2);
+static constexpr double sqrtOfMax = sqrtNewtonRaphson(std::numeric_limits<double>::max(), sqrtGuess, 0);
+} // namespace internal
 
-    /** We take as a default big number sqrt(std::numeric_limits<double>::max())/2 */
-    static constexpr double big_number = internal::sqrtOfMax/2;
-    //assert that the big_number value is correct (no std::abs here because it is not constexpr)
-    static_assert(-(big_number * big_number - std::numeric_limits<double>::max() / 4)
-                   < (2 * std::numeric_limits<double>::epsilon()) * std::numeric_limits<double>::max()
-                && (big_number * big_number - std::numeric_limits<double>::max() / 4)
-                   < (2 * std::numeric_limits<double>::epsilon()) * std::numeric_limits<double>::max(),
-                  "big_number was not computed at compile time or its value was not correct");
+/** We take as a default big number sqrt(std::numeric_limits<double>::max())/2 */
+static constexpr double big_number = internal::sqrtOfMax / 2;
+// assert that the big_number value is correct (no std::abs here because it is not constexpr)
+static_assert(-(big_number * big_number - std::numeric_limits<double>::max() / 4)
+                      < (2 * std::numeric_limits<double>::epsilon()) * std::numeric_limits<double>::max()
+                  && (big_number * big_number - std::numeric_limits<double>::max() / 4)
+                         < (2 * std::numeric_limits<double>::epsilon()) * std::numeric_limits<double>::max(),
+              "big_number was not computed at compile time or its value was not correct");
 
-    /** Pi (from boost/math/constant)*/
-    constexpr double pi = 3.141592653589793238462643383279502884e+00;
+/** Pi (from boost/math/constant)*/
+constexpr double pi = 3.141592653589793238462643383279502884e+00;
 
-    /** Constant for specifying that the matrix in front of the variable is full
-      * rank.
-      */
-    constexpr int fullRank = -1;
+/** Constant for specifying that the matrix in front of the variable is full
+ * rank.
+ */
+constexpr int fullRank = -1;
 
-    /** Default gravity vector */
-    static const Eigen::Vector3d gravity {0, 0, 9.81};
-  } // namespace constant
+/** Default gravity vector */
+static const Eigen::Vector3d gravity{0, 0, 9.81};
+} // namespace constant
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/event/Listener.h
+++ b/include/tvm/event/Listener.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/event/Listener.h
+++ b/include/tvm/event/Listener.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -41,17 +41,18 @@ namespace tvm
 namespace event
 {
 
-  class TVM_DLLAPI Listener
-  {
-  public:
-    virtual ~Listener() = default;
+class TVM_DLLAPI Listener
+{
+public:
+  virtual ~Listener() = default;
 
-    void receive(Type evt, const Source& notifier);  //TODO: should it be const? -> would surely require mutable in derived classes
+  void receive(Type evt,
+               const Source & notifier); // TODO: should it be const? -> would surely require mutable in derived classes
 
-  protected:
-    virtual void process(Type evt, const Source& notifier) = 0;
-  };
+protected:
+  virtual void process(Type evt, const Source & notifier) = 0;
+};
 
-}  // namespace event
+} // namespace event
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/event/Source.h
+++ b/include/tvm/event/Source.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,30 +42,30 @@ namespace tvm
 namespace event
 {
 
-  class Listener;
+class Listener;
 
-  /* todo or to consider:
-    - delayed notify in case the same notification might be issue several time in a row
-      (for example, several contacts are added/remove at several point in the code)
-    - time-stamped events or lazy processing, so that a same event arriving by two
-      different way to a listener is not processed twice.*/
+/* todo or to consider:
+  - delayed notify in case the same notification might be issue several time in a row
+    (for example, several contacts are added/remove at several point in the code)
+  - time-stamped events or lazy processing, so that a same event arriving by two
+    different way to a listener is not processed twice.*/
 
-  class TVM_DLLAPI Source
-  {
-  public:
-    virtual ~Source() = default;
+class TVM_DLLAPI Source
+{
+public:
+  virtual ~Source() = default;
 
-    void regist(std::shared_ptr<Listener> user, Type evt);
-    void notify(Type evt);
+  void regist(std::shared_ptr<Listener> user, Type evt);
+  void notify(Type evt);
 
-  private:
-    /** internal we use weak_ptr here to avoid creating cyclic dependencies when a class
-      * inheriting from both EventSource and DataSource refers to and is refered by a
-      * class inheriting from DataNode and EventListener.
-      */
-    std::map<Type, std::vector<std::weak_ptr<Listener>>> registrations_;
-  };
+private:
+  /** internal we use weak_ptr here to avoid creating cyclic dependencies when a class
+   * inheriting from both EventSource and DataSource refers to and is refered by a
+   * class inheriting from DataNode and EventListener.
+   */
+  std::map<Type, std::vector<std::weak_ptr<Listener>>> registrations_;
+};
 
-}  // namespace event
+} // namespace event
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/event/Source.h
+++ b/include/tvm/event/Source.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/event/enums.h
+++ b/include/tvm/event/enums.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/event/enums.h
+++ b/include/tvm/event/enums.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -35,11 +35,10 @@ namespace tvm
 namespace event
 {
 
-  enum class Type
-  {
-    CONTACT_NUMBER_CHANGED,
-  };
-
+enum class Type
+{
+  CONTACT_NUMBER_CHANGED,
+};
 }
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/exception/exceptions.h
+++ b/include/tvm/exception/exceptions.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,40 +38,69 @@ namespace tvm
 namespace exception
 {
 
-  /** Base exception class for TVM specific exceptions */
-  class Exception : public std::exception
-  {
-  public:
-    Exception() : std::exception() {}
-    Exception(const std::string & what) : what_(what) {}
-    Exception(const char * what) : what_(what) {}
-    const char * what() const noexcept override { return what_.c_str(); }
-  private:
-    std::string what_;
-  };
+/** Base exception class for TVM specific exceptions */
+class Exception : public std::exception
+{
+public:
+  Exception() : std::exception() {}
+  Exception(const std::string & what) : what_(what) {}
+  Exception(const char * what) : what_(what) {}
+  const char * what() const noexcept override { return what_.c_str(); }
 
-  /** General data-related exception */
-  class DataException : public Exception { public: using Exception::Exception; };
+private:
+  std::string what_;
+};
 
-  /** Thrown when attempting to use unused output */
-  class UnusedOutput : public DataException { public: using DataException::DataException; };
+/** General data-related exception */
+class DataException : public Exception
+{
+public:
+  using Exception::Exception;
+};
 
-  /** General function-related exception */
-  class FunctionException : public Exception { public: using Exception::Exception; };
+/** Thrown when attempting to use unused output */
+class UnusedOutput : public DataException
+{
+public:
+  using DataException::DataException;
+};
 
-  /** Thrown when attempting to call an output without an implementation */
-  class UnimplementedOutput : public FunctionException { public: using FunctionException::FunctionException; };
+/** General function-related exception */
+class FunctionException : public Exception
+{
+public:
+  using Exception::Exception;
+};
 
-  /** Thrown when adding a variable already present */
-  class DuplicateVariable : public FunctionException { public: using FunctionException::FunctionException; };
+/** Thrown when attempting to call an output without an implementation */
+class UnimplementedOutput : public FunctionException
+{
+public:
+  using FunctionException::FunctionException;
+};
 
-  /** Thrown when attempting to access a non-existing variable */
-  class NonExistingVariable : public FunctionException { public: using FunctionException::FunctionException; };
+/** Thrown when adding a variable already present */
+class DuplicateVariable : public FunctionException
+{
+public:
+  using FunctionException::FunctionException;
+};
 
-  /** Thrown when attempting to use a feature that is not implemented in the
-   * framework yet */
-  class NotImplemented : public Exception { public: using Exception::Exception; };
+/** Thrown when attempting to access a non-existing variable */
+class NonExistingVariable : public FunctionException
+{
+public:
+  using FunctionException::FunctionException;
+};
 
-}  // namespace exception
+/** Thrown when attempting to use a feature that is not implemented in the
+ * framework yet */
+class NotImplemented : public Exception
+{
+public:
+  using Exception::Exception;
+};
 
-}  // namespace tvm
+} // namespace exception
+
+} // namespace tvm

--- a/include/tvm/exception/exceptions.h
+++ b/include/tvm/exception/exceptions.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/function/BasicLinearFunction.h
+++ b/include/tvm/function/BasicLinearFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/function/BasicLinearFunction.h
+++ b/include/tvm/function/BasicLinearFunction.h
@@ -1,34 +1,33 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
-
 
 #include <tvm/function/abstract/LinearFunction.h>
 #include <tvm/internal/MatrixProperties.h>
@@ -42,138 +41,137 @@ namespace tvm
 namespace function
 {
 
-  /** The most basic linear function f(x_1, ..., x_k) = sum A_i x_i + b
-   * where the matrices are constant.
+/** The most basic linear function f(x_1, ..., x_k) = sum A_i x_i + b
+ * where the matrices are constant.
+ */
+class TVM_DLLAPI BasicLinearFunction : public abstract::LinearFunction
+{
+public:
+  /** A x (b = 0) */
+  BasicLinearFunction(const MatrixConstRef & A, VariablePtr x);
+  /** A1 x1 + ... An xn (b = 0) */
+  BasicLinearFunction(const std::vector<MatrixConstRef> & A, const std::vector<VariablePtr> & x);
+
+  /** A x + b */
+  BasicLinearFunction(const MatrixConstRef & A, VariablePtr x, const VectorConstRef & b);
+  /** A1 x1 + ... An xn + b*/
+  BasicLinearFunction(const std::vector<MatrixConstRef> & A,
+                      const std::vector<VariablePtr> & x,
+                      const VectorConstRef & b);
+
+  /** Uninitialized version for a function of size \p m with a single variable
+   * \p x
+   * Don't forget to initialize A \b and b
    */
-  class TVM_DLLAPI BasicLinearFunction : public abstract::LinearFunction
-  {
-  public:
-    /** A x (b = 0) */
-    BasicLinearFunction(const MatrixConstRef& A, VariablePtr x);
-    /** A1 x1 + ... An xn (b = 0) */
-    BasicLinearFunction(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x);
+  BasicLinearFunction(int m, VariablePtr x);
 
-    /** A x + b */
-    BasicLinearFunction(const MatrixConstRef& A, VariablePtr x, const VectorConstRef& b);
-    /** A1 x1 + ... An xn + b*/
-    BasicLinearFunction(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x, const VectorConstRef& b);
+  /** Uninitialized version for a function of size \p m with multiple
+   * variables \p x1 ... \p xn
+   * Don't forget to initialize the Ai \b and b
+   */
+  BasicLinearFunction(int m, const std::vector<VariablePtr> & x);
 
-    /** Uninitialized version for a function of size \p m with a single variable
-      * \p x
-      * Don't forget to initialize A \b and b
-      */
-    BasicLinearFunction(int m, VariablePtr x);
-
-    /** Uninitialized version for a function of size \p m with multiple
-      * variables \p x1 ... \p xn
-      * Don't forget to initialize the Ai \b and b
-      */
-    BasicLinearFunction(int m, const std::vector<VariablePtr>& x);
-
-    /** Initialization from a utils::LinearExpr. Meant to be used by operators in 
-      * ProtoTasks.h
-      */
-    template<typename Derived>
-    BasicLinearFunction(const utils::LinearExpr<Derived>& lin);
-
-    /** Initialization from a utils::AffineExpr. Meant to be used by operators in
-      * ProtoTasks.h
-      */
-    template<typename CstDerived, typename... Derived>
-    BasicLinearFunction(const utils::AffineExpr<CstDerived, Derived...>& aff);
-
-    /** Set the matrix \p A corresponding to variable \p x and optionally the
-      * properties \p p of \p A.*/
-    virtual void A(const MatrixConstRef& A, const Variable& x,
-                   const internal::MatrixProperties& p = internal::MatrixProperties());
-    /** Shortcut for when there is a single variable.*/
-    virtual void A(const MatrixConstRef& A, 
-                   const internal::MatrixProperties& p = internal::MatrixProperties());
-    /** Set the constant term \p b, and optionally its properties \p p.*/
-    virtual void b(const VectorConstRef& b, const internal::MatrixProperties& p = internal::MatrixProperties());
-
-    using LinearFunction::b;
-
-  private:
-    template<typename Derived>
-    void add(const Eigen::MatrixBase<Derived>& A, VariablePtr x);
-
-    template<typename Tuple, size_t ... Indices>
-    void add(const Tuple& tuple, std::index_sequence<Indices...>);
-
-    template<typename Derived>
-    void add(const utils::LinearExpr<Derived>& lin);
-  };
-
+  /** Initialization from a utils::LinearExpr. Meant to be used by operators in
+   * ProtoTasks.h
+   */
   template<typename Derived>
-  BasicLinearFunction::BasicLinearFunction(const utils::LinearExpr<Derived>& lin)
-    : LinearFunction(static_cast<int>(lin.matrix().rows()))
-  {
-    add(lin);
-    this->b(Eigen::VectorXd::Zero(size()),
-            { tvm::internal::MatrixProperties::Constness(true),
-              tvm::internal::MatrixProperties::ZERO });
-    setDerivativesToZero();
-  }
+  BasicLinearFunction(const utils::LinearExpr<Derived> & lin);
 
+  /** Initialization from a utils::AffineExpr. Meant to be used by operators in
+   * ProtoTasks.h
+   */
   template<typename CstDerived, typename... Derived>
-  BasicLinearFunction::BasicLinearFunction(const utils::AffineExpr<CstDerived, Derived...>& aff)
-    : LinearFunction(static_cast<int>(std::get<0>(aff.linear()).matrix().rows()))
-  {
-    add(aff.linear(), std::make_index_sequence<sizeof...(Derived)>{});
-    if constexpr (std::is_same_v<CstDerived, utils::internal::NoConstant>)
-    {
-      this->b(Eigen::VectorXd::Zero(size()),
-              { tvm::internal::MatrixProperties::Constness(true),
-                tvm::internal::MatrixProperties::ZERO });
-    }
-    else
-    {
-      this->b(aff.constant(), { tvm::internal::MatrixProperties::Constness(true) });
-    }
-    setDerivativesToZero();
-  }
+  BasicLinearFunction(const utils::AffineExpr<CstDerived, Derived...> & aff);
+
+  /** Set the matrix \p A corresponding to variable \p x and optionally the
+   * properties \p p of \p A.*/
+  virtual void A(const MatrixConstRef & A,
+                 const Variable & x,
+                 const internal::MatrixProperties & p = internal::MatrixProperties());
+  /** Shortcut for when there is a single variable.*/
+  virtual void A(const MatrixConstRef & A, const internal::MatrixProperties & p = internal::MatrixProperties());
+  /** Set the constant term \p b, and optionally its properties \p p.*/
+  virtual void b(const VectorConstRef & b, const internal::MatrixProperties & p = internal::MatrixProperties());
+
+  using LinearFunction::b;
+
+private:
+  template<typename Derived>
+  void add(const Eigen::MatrixBase<Derived> & A, VariablePtr x);
+
+  template<typename Tuple, size_t... Indices>
+  void add(const Tuple & tuple, std::index_sequence<Indices...>);
 
   template<typename Derived>
-  inline void BasicLinearFunction::add(const Eigen::MatrixBase<Derived>& A, VariablePtr x)
+  void add(const utils::LinearExpr<Derived> & lin);
+};
+
+template<typename Derived>
+BasicLinearFunction::BasicLinearFunction(const utils::LinearExpr<Derived> & lin)
+: LinearFunction(static_cast<int>(lin.matrix().rows()))
+{
+  add(lin);
+  this->b(Eigen::VectorXd::Zero(size()),
+          {tvm::internal::MatrixProperties::Constness(true), tvm::internal::MatrixProperties::ZERO});
+  setDerivativesToZero();
+}
+
+template<typename CstDerived, typename... Derived>
+BasicLinearFunction::BasicLinearFunction(const utils::AffineExpr<CstDerived, Derived...> & aff)
+: LinearFunction(static_cast<int>(std::get<0>(aff.linear()).matrix().rows()))
+{
+  add(aff.linear(), std::make_index_sequence<sizeof...(Derived)>{});
+  if constexpr(std::is_same_v<CstDerived, utils::internal::NoConstant>)
   {
-    if (!x->space().isEuclidean() && x->isBasePrimitive())
-      throw std::runtime_error("We allow linear function only on Euclidean variables.");
-    if (A.rows() != size())
-      throw std::runtime_error("Matrix A doesn't have coherent row size.");
-    if (A.cols() != x->size())
-      throw std::runtime_error("Matrix A doesn't have its column size coherent with its corresponding variable.");
-    
-    if (variables().contains(*x))
-    {
-      jacobian_.at(x.get()).noalias() += A;
-    }
-    else
-    {
-      addVariable(x, true);
-      jacobian_.at(x.get()) = A;
-      jacobian_.at(x.get()).properties({ tvm::internal::MatrixProperties::Constness(true) });
-    }
+    this->b(Eigen::VectorXd::Zero(size()),
+            {tvm::internal::MatrixProperties::Constness(true), tvm::internal::MatrixProperties::ZERO});
   }
-
-  template<typename Tuple, size_t ... Indices>
-  inline void BasicLinearFunction::add(const Tuple& tuple, std::index_sequence<Indices...>)
+  else
   {
-    // trick to call add on each element indexed by Indices:
-    // - ( add(std::get<I>(tuple)), 42 ) for any integer I returns 42 (second element of (X, 42), 
-    //   X is evaluated but is then ignored).
-    // - We create an initializer_list by pack expansion where each expanded element is a pair as
-    //   above. This evaluates add(std::get<I>(tuple)) for each I in Indices in turn.
-    auto l = { (add(std::get<Indices>(tuple)), 42)... };
+    this->b(aff.constant(), {tvm::internal::MatrixProperties::Constness(true)});
   }
+  setDerivativesToZero();
+}
 
-  template<typename Derived>
-  inline void BasicLinearFunction::add(const utils::LinearExpr<Derived>& lin)
+template<typename Derived>
+inline void BasicLinearFunction::add(const Eigen::MatrixBase<Derived> & A, VariablePtr x)
+{
+  if(!x->space().isEuclidean() && x->isBasePrimitive())
+    throw std::runtime_error("We allow linear function only on Euclidean variables.");
+  if(A.rows() != size())
+    throw std::runtime_error("Matrix A doesn't have coherent row size.");
+  if(A.cols() != x->size())
+    throw std::runtime_error("Matrix A doesn't have its column size coherent with its corresponding variable.");
+
+  if(variables().contains(*x))
   {
-    add(lin.matrix(), lin.variable());
+    jacobian_.at(x.get()).noalias() += A;
   }
+  else
+  {
+    addVariable(x, true);
+    jacobian_.at(x.get()) = A;
+    jacobian_.at(x.get()).properties({tvm::internal::MatrixProperties::Constness(true)});
+  }
+}
 
+template<typename Tuple, size_t... Indices>
+inline void BasicLinearFunction::add(const Tuple & tuple, std::index_sequence<Indices...>)
+{
+  // trick to call add on each element indexed by Indices:
+  // - ( add(std::get<I>(tuple)), 42 ) for any integer I returns 42 (second element of (X, 42),
+  //   X is evaluated but is then ignored).
+  // - We create an initializer_list by pack expansion where each expanded element is a pair as
+  //   above. This evaluates add(std::get<I>(tuple)) for each I in Indices in turn.
+  auto l = {(add(std::get<Indices>(tuple)), 42)...};
+}
 
-}  // namespace function
+template<typename Derived>
+inline void BasicLinearFunction::add(const utils::LinearExpr<Derived> & lin)
+{
+  add(lin.matrix(), lin.variable());
+}
 
-}  // namespace tvm
+} // namespace function
+
+} // namespace tvm

--- a/include/tvm/function/IdentityFunction.h
+++ b/include/tvm/function/IdentityFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/function/IdentityFunction.h
+++ b/include/tvm/function/IdentityFunction.h
@@ -1,34 +1,33 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
-
 
 #include <tvm/function/BasicLinearFunction.h>
 
@@ -38,28 +37,29 @@ namespace tvm
 namespace function
 {
 
-  /** f(x) = x, for a single variable.*/
-  class TVM_DLLAPI IdentityFunction : public BasicLinearFunction
-  {
-  public:
-    /** Build an identity function on variable \p x*/
-    IdentityFunction(VariablePtr x);
+/** f(x) = x, for a single variable.*/
+class TVM_DLLAPI IdentityFunction : public BasicLinearFunction
+{
+public:
+  /** Build an identity function on variable \p x*/
+  IdentityFunction(VariablePtr x);
 
-  protected:
-    void updateValue_() override;
-    void updateVelocity_() override;
+protected:
+  void updateValue_() override;
+  void updateVelocity_() override;
 
-  private:
-    /** Overriden function that always throws.*/
-    void A(const MatrixConstRef& A, const Variable& x,
-      const tvm::internal::MatrixProperties& p = tvm::internal::MatrixProperties()) override;
-    /** Overriden function that always throws.*/
-    void A(const MatrixConstRef& A,
-      const tvm::internal::MatrixProperties& p = tvm::internal::MatrixProperties()) override;
-    /** Overriden function that always throws.*/
-    void b(const VectorConstRef& b, const tvm::internal::MatrixProperties&) override;
-  };
+private:
+  /** Overriden function that always throws.*/
+  void A(const MatrixConstRef & A,
+         const Variable & x,
+         const tvm::internal::MatrixProperties & p = tvm::internal::MatrixProperties()) override;
+  /** Overriden function that always throws.*/
+  void A(const MatrixConstRef & A,
+         const tvm::internal::MatrixProperties & p = tvm::internal::MatrixProperties()) override;
+  /** Overriden function that always throws.*/
+  void b(const VectorConstRef & b, const tvm::internal::MatrixProperties &) override;
+};
 
-}  // namespace function
+} // namespace function
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/function/abstract/Function.h
+++ b/include/tvm/function/abstract/Function.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/function/abstract/Function.h
+++ b/include/tvm/function/abstract/Function.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -45,95 +45,85 @@ namespace function
 namespace abstract
 {
 
-  /** Base class defining the classical outputs for a function
-    *
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   {
-    *     rank = same; node [shape=hexagon];
-    *     Value; Jacobian; Velocity;
-    *     NormalAcceleration; JDot;
-    *   }
-    *   {
-    *     rank = same; node [style=invis, label=""];
-    *     outValue; outJacobian; outVelocity;
-    *     outNormalAcceleration; outJDot;
-    *   }
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    *   Velocity -> outVelocity [label="velocity()"];
-    *   NormalAcceleration -> outNormalAcceleration [label="normalAcceleration()"];
-    *   JDot -> outJDot [label="JDot(x_i)"];
-    * }
-    * \enddot
-    */
-  class TVM_DLLAPI Function : public tvm::internal::FirstOrderProvider
-  {
-  public:
-    SET_OUTPUTS(Function, Velocity, NormalAcceleration, JDot)
+/** Base class defining the classical outputs for a function
+ *
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   {
+ *     rank = same; node [shape=hexagon];
+ *     Value; Jacobian; Velocity;
+ *     NormalAcceleration; JDot;
+ *   }
+ *   {
+ *     rank = same; node [style=invis, label=""];
+ *     outValue; outJacobian; outVelocity;
+ *     outNormalAcceleration; outJDot;
+ *   }
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ *   Velocity -> outVelocity [label="velocity()"];
+ *   NormalAcceleration -> outNormalAcceleration [label="normalAcceleration()"];
+ *   JDot -> outJDot [label="JDot(x_i)"];
+ * }
+ * \enddot
+ */
+class TVM_DLLAPI Function : public tvm::internal::FirstOrderProvider
+{
+public:
+  SET_OUTPUTS(Function, Velocity, NormalAcceleration, JDot)
 
-    /** Note: by default, these methods return the cached value.
-      * However, they are virtual in case the user might want to bypass the cache.
-      * This would be typically the case if he/she wants to directly return the
-      * output of another method, e.g. return the jacobian of an other Function.
-      */
-    virtual const Eigen::VectorXd& velocity() const;
-    virtual const Eigen::VectorXd& normalAcceleration() const;
-    virtual const Eigen::MatrixXd& JDot(const Variable& x) const;
+  /** Note: by default, these methods return the cached value.
+   * However, they are virtual in case the user might want to bypass the cache.
+   * This would be typically the case if he/she wants to directly return the
+   * output of another method, e.g. return the jacobian of an other Function.
+   */
+  virtual const Eigen::VectorXd & velocity() const;
+  virtual const Eigen::VectorXd & normalAcceleration() const;
+  virtual const Eigen::MatrixXd & JDot(const Variable & x) const;
 
-  protected:
-    /** Constructor for a function with value in \f$ \mathbb{R}^m \f$.
-      *
-      * \param m the size of the function/constraint image space, i.e. the row
-      * size of the jacobians (or equivalently in this case the size of the
-      * output value).
-      */
-    Function(int m=0);
+protected:
+  /** Constructor for a function with value in \f$ \mathbb{R}^m \f$.
+   *
+   * \param m the size of the function/constraint image space, i.e. the row
+   * size of the jacobians (or equivalently in this case the size of the
+   * output value).
+   */
+  Function(int m = 0);
 
-    /** Constructor for a function with value in a specified space.
-      *
-      * \param image Description of the image space
-      */
-    Function(Space image);
+  /** Constructor for a function with value in a specified space.
+   *
+   * \param image Description of the image space
+   */
+  Function(Space image);
 
-    /** Resize all cache members corresponding to active output*/
-    void resizeCache() override;
-    void resizeVelocityCache();
-    void resizeNormalAccelerationCache();
-    void resizeJDotCache();
+  /** Resize all cache members corresponding to active output*/
+  void resizeCache() override;
+  void resizeVelocityCache();
+  void resizeNormalAccelerationCache();
+  void resizeJDotCache();
 
-    void addVariable_(VariablePtr v) override;
-    void removeVariable_(VariablePtr v) override;
+  void addVariable_(VariablePtr v) override;
+  void removeVariable_(VariablePtr v) override;
 
-    // cache
-    Eigen::VectorXd velocity_;
-    Eigen::VectorXd normalAcceleration_;
-    utils::internal::map<Variable const *, Eigen::MatrixXd> JDot_;
+  // cache
+  Eigen::VectorXd velocity_;
+  Eigen::VectorXd normalAcceleration_;
+  utils::internal::map<Variable const *, Eigen::MatrixXd> JDot_;
 
-  private:
-    //we retain the variables' derivatives shared_ptr to ensure the reference is never lost
-    std::vector<VariablePtr> variablesDot_;
-  };
+private:
+  // we retain the variables' derivatives shared_ptr to ensure the reference is never lost
+  std::vector<VariablePtr> variablesDot_;
+};
 
+inline const Eigen::VectorXd & Function::velocity() const { return velocity_; }
 
-  inline const Eigen::VectorXd& Function::velocity() const
-  {
-    return velocity_;
-  }
+inline const Eigen::VectorXd & Function::normalAcceleration() const { return normalAcceleration_; }
 
-  inline const Eigen::VectorXd& Function::normalAcceleration() const
-  {
-    return normalAcceleration_;
-  }
+inline const Eigen::MatrixXd & Function::JDot(const Variable & x) const { return JDot_.at(&x); }
 
-  inline const Eigen::MatrixXd& Function::JDot(const Variable& x) const
-  {
-    return JDot_.at(&x);
-  }
+} // namespace abstract
 
-}  // namespace abstract
+} // namespace function
 
-}  // namespace function
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/function/abstract/LinearFunction.h
+++ b/include/tvm/function/abstract/LinearFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/function/abstract/LinearFunction.h
+++ b/include/tvm/function/abstract/LinearFunction.h
@@ -1,34 +1,33 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
-
 
 #include <tvm/function/abstract/Function.h>
 
@@ -46,68 +45,68 @@ namespace function
 namespace abstract
 {
 
-  /** Base class for linear functions.
-    *
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   {
-    *     rank=same; node [shape=circle];
-    *     x_i; dx_i;
-    *   }
-    *   {
-    *     rank = same; node [shape=hexagon];
-    *     Value; Jacobian; Velocity;
-    *     NormalAcceleration; JDot; B
-    *   }
-    *   {
-    *     rank = same;
-    *     uValue [label=Value];
-    *     uVelocity [label=Velocity];
-    *   }
-    *   {
-    *     rank = same; node [style=invis, label=""];
-    *     outValue; outJacobian; outVelocity;
-    *     outNormalAcceleration; outJDot; outB
-    *   }
-    *   x_i -> uValue [label="value()"];
-    *   dx_i -> uVelocity [label="value()"];
-    *   Jacobian -> uValue;
-    *   B -> uValue;
-    *   Jacobian -> uVelocity;
-    *   uValue -> Value;
-    *   uVelocity -> Velocity;
-    *   B -> outB [label="b()"];
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    *   Velocity -> outVelocity [label="velocity()"];
-    *   NormalAcceleration -> outNormalAcceleration [label="normalAcceleration()"];
-    *   JDot -> outJDot [label="JDot(x_i)"];
-    * }
-    * \enddot
-    */
-  class TVM_DLLAPI LinearFunction : public Function
-  {
-  public:
-    SET_OUTPUTS(LinearFunction, B)
-    SET_UPDATES(LinearFunction, Value, Velocity)
+/** Base class for linear functions.
+ *
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   {
+ *     rank=same; node [shape=circle];
+ *     x_i; dx_i;
+ *   }
+ *   {
+ *     rank = same; node [shape=hexagon];
+ *     Value; Jacobian; Velocity;
+ *     NormalAcceleration; JDot; B
+ *   }
+ *   {
+ *     rank = same;
+ *     uValue [label=Value];
+ *     uVelocity [label=Velocity];
+ *   }
+ *   {
+ *     rank = same; node [style=invis, label=""];
+ *     outValue; outJacobian; outVelocity;
+ *     outNormalAcceleration; outJDot; outB
+ *   }
+ *   x_i -> uValue [label="value()"];
+ *   dx_i -> uVelocity [label="value()"];
+ *   Jacobian -> uValue;
+ *   B -> uValue;
+ *   Jacobian -> uVelocity;
+ *   uValue -> Value;
+ *   uVelocity -> Velocity;
+ *   B -> outB [label="b()"];
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ *   Velocity -> outVelocity [label="velocity()"];
+ *   NormalAcceleration -> outNormalAcceleration [label="normalAcceleration()"];
+ *   JDot -> outJDot [label="JDot(x_i)"];
+ * }
+ * \enddot
+ */
+class TVM_DLLAPI LinearFunction : public Function
+{
+public:
+  SET_OUTPUTS(LinearFunction, B)
+  SET_UPDATES(LinearFunction, Value, Velocity)
 
-    void updateValue();
-    void updateVelocity();
-    void resizeCache() override;
-    const internal::VectorWithProperties& b() const {return b_; }
+  void updateValue();
+  void updateVelocity();
+  void resizeCache() override;
+  const internal::VectorWithProperties & b() const { return b_; }
 
-  protected:
-    LinearFunction(int m);
-    virtual void updateValue_();
-    virtual void updateVelocity_();
-    void setDerivativesToZero();
+protected:
+  LinearFunction(int m);
+  virtual void updateValue_();
+  virtual void updateVelocity_();
+  void setDerivativesToZero();
 
-    internal::VectorWithProperties b_;
-  };
+  internal::VectorWithProperties b_;
+};
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace function
+} // namespace function
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/geometry/Plane.h
+++ b/include/tvm/geometry/Plane.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,122 +39,124 @@ namespace tvm
 namespace geometry
 {
 
-  /** Represents a 2D plane in 3D space
+/** Represents a 2D plane in 3D space
+ *
+ * A static plane is represented by the usual (normal, offset)
+ * representation. (i.e. normal.dot(x) + offset = 0)
+ *
+ * A moving plane is represented by a (normal, point) couple and their
+ * derivatives. (i.e. normal.dot(point) = -offset)
+ *
+ * This object does not update any of these quantities (exception: when point
+ * is changed, offset is changed accordingly), this reponsability belongs to
+ * the Plane provider. In other words, this is *not* a plane integrator.
+ *
+ * Outputs:
+ * - Position: position of the plane, represents (normal, offset, point)
+ *   quantities
+ * - Velocity: first derivative of (normal, point)
+ * - Acceleration: second derivative of (normal, point)
+ *
+ */
+
+class TVM_DLLAPI Plane : public graph::abstract::Node<Plane>
+{
+public:
+  SET_OUTPUTS(Plane, Position, Velocity, Acceleration)
+
+  /** Constructor for a static plane
    *
-   * A static plane is represented by the usual (normal, offset)
-   * representation. (i.e. normal.dot(x) + offset = 0)
+   * \param normal Normal of the plane
    *
-   * A moving plane is represented by a (normal, point) couple and their
-   * derivatives. (i.e. normal.dot(point) = -offset)
-   *
-   * This object does not update any of these quantities (exception: when point
-   * is changed, offset is changed accordingly), this reponsability belongs to
-   * the Plane provider. In other words, this is *not* a plane integrator.
-   *
-   * Outputs:
-   * - Position: position of the plane, represents (normal, offset, point)
-   *   quantities
-   * - Velocity: first derivative of (normal, point)
-   * - Acceleration: second derivative of (normal, point)
+   * \param offset Offset of the plane
    *
    */
+  Plane(const Eigen::Vector3d & normal, double offset);
 
-  class TVM_DLLAPI Plane : public graph::abstract::Node<Plane>
+  /** Constructor for a moving plane
+   *
+   * \param normal Normal of the plane
+   *
+   * \param point Point on the plane
+   *
+   */
+  Plane(const Eigen::Vector3d & normal, const Eigen::Vector3d & point);
+
+  /** Set a direct dependency to the outputs of the integrator
+   *
+   * Such an integrator should update the plane in its own update method
+   */
+  template<typename S, typename EnumO>
+  void setIntegrator(std::shared_ptr<S> integrator, EnumO oPosition, EnumO oVelocity, EnumO oAcceleration)
   {
-  public:
-    SET_OUTPUTS(Plane, Position, Velocity, Acceleration)
+    addDirectDependency(Output::Position, integrator, oPosition);
+    addDirectDependency(Output::Velocity, integrator, oVelocity);
+    addDirectDependency(Output::Acceleration, integrator, oAcceleration);
+  }
 
-    /** Constructor for a static plane
-     *
-     * \param normal Normal of the plane
-     *
-     * \param offset Offset of the plane
-     *
-     */
-    Plane(const Eigen::Vector3d & normal, double offset);
+  /** Set a direct dependency to the outputs of the integrator
+   *
+   * This variant is probably preferable if the integrator creates the plane object
+   *
+   * Such an integrator should update the plane in its own update method
+   */
+  template<typename S,
+           typename EnumO,
+           typename std::enable_if<std::is_base_of<tvm::graph::abstract::Outputs, S>::value, int>::type = 0>
+  void setIntegrator(S & integrator, EnumO oPosition, EnumO oVelocity, EnumO oAcceleration)
+  {
+    addDirectDependency(Output::Position, integrator, oPosition);
+    addDirectDependency(Output::Velocity, integrator, oVelocity);
+    addDirectDependency(Output::Acceleration, integrator, oAcceleration);
+  }
 
-    /** Constructor for a moving plane
-     *
-     * \param normal Normal of the plane
-     *
-     * \param point Point on the plane
-     *
-     */
-    Plane(const Eigen::Vector3d & normal, const Eigen::Vector3d & point);
+  /** Change the plane normal and point
+   *
+   * Triggers offset computation
+   */
+  void position(const Eigen::Vector3d & normal, const Eigen::Vector3d & point);
 
-    /** Set a direct dependency to the outputs of the integrator
-     *
-     * Such an integrator should update the plane in its own update method
-     */
-    template<typename S, typename EnumO>
-    void setIntegrator(std::shared_ptr<S> integrator, EnumO oPosition, EnumO oVelocity, EnumO oAcceleration)
-    {
-      addDirectDependency(Output::Position, integrator, oPosition);
-      addDirectDependency(Output::Velocity, integrator, oVelocity);
-      addDirectDependency(Output::Acceleration, integrator, oAcceleration);
-    }
+  /** Change the plane normal and offset */
+  void position(const Eigen::Vector3d & normal, double offset);
 
-    /** Set a direct dependency to the outputs of the integrator
-     *
-     * This variant is probably preferable if the integrator creates the plane object
-     *
-     * Such an integrator should update the plane in its own update method
-     */
-    template<typename S, typename EnumO,
-      typename std::enable_if<std::is_base_of<tvm::graph::abstract::Outputs, S>::value, int>::type = 0>
-    void setIntegrator(S & integrator, EnumO oPosition, EnumO oVelocity, EnumO oAcceleration)
-    {
-      addDirectDependency(Output::Position, integrator, oPosition);
-      addDirectDependency(Output::Velocity, integrator, oVelocity);
-      addDirectDependency(Output::Acceleration, integrator, oAcceleration);
-    }
+  /** Change the point and normal's speeds */
+  void velocity(const Eigen::Vector3d & nDot, const Eigen::Vector3d & speed);
 
-    /** Change the plane normal and point
-     *
-     * Triggers offset computation
-     */
-    void position(const Eigen::Vector3d & normal, const Eigen::Vector3d & point);
+  /** Change the point and normal's acceleration */
+  void acceleration(const Eigen::Vector3d & nDotDot, const Eigen::Vector3d & accel);
 
-    /** Change the plane normal and offset */
-    void position(const Eigen::Vector3d & normal, double offset);
+  /** Access the normal */
+  const Eigen::Vector3d & normal() const { return normal_; }
 
-    /** Change the point and normal's speeds */
-    void velocity(const Eigen::Vector3d & nDot, const Eigen::Vector3d & speed);
+  /** Access the offset */
+  double offset() const { return offset_; }
 
-    /** Change the point and normal's acceleration */
-    void acceleration(const Eigen::Vector3d & nDotDot, const Eigen::Vector3d & accel);
+  /** Access the point */
+  const Eigen::Vector3d & point() const { return point_; }
 
-    /** Access the normal */
-    const Eigen::Vector3d & normal() const { return normal_; }
+  /** Access the normal derivative */
+  const Eigen::Vector3d & normalDot() const { return normalDot_; }
 
-    /** Access the offset */
-    double offset() const {return offset_; }
+  /** Access the point's speed */
+  const Eigen::Vector3d & speed() const { return speed_; }
 
-    /** Access the point */
-    const Eigen::Vector3d & point() const { return point_; }
+  /** Access the normal second derivative */
+  const Eigen::Vector3d & normalDotDot() const { return normalDotDot_; }
 
-    /** Access the normal derivative */
-    const Eigen::Vector3d & normalDot() const { return normalDot_; }
+  /** Access the point's acceleration */
+  const Eigen::Vector3d & acceleration() const { return accel_; }
 
-    /** Access the point's speed */
-    const Eigen::Vector3d & speed() const { return speed_; }
+private:
+  Eigen::Vector3d normal_;
+  double offset_;
+  Eigen::Vector3d point_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d normalDot_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d speed_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d normalDotDot_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d accel_ = Eigen::Vector3d::Zero();
+};
 
-    /** Access the normal second derivative */
-    const Eigen::Vector3d & normalDotDot() const { return normalDotDot_; }
-
-    /** Access the point's acceleration */
-    const Eigen::Vector3d & acceleration() const { return accel_; }
-  private:
-    Eigen::Vector3d normal_;
-    double offset_;
-    Eigen::Vector3d point_ = Eigen::Vector3d::Zero();
-    Eigen::Vector3d normalDot_ = Eigen::Vector3d::Zero();
-    Eigen::Vector3d speed_ = Eigen::Vector3d::Zero();
-    Eigen::Vector3d normalDotDot_ = Eigen::Vector3d::Zero();
-    Eigen::Vector3d accel_ = Eigen::Vector3d::Zero();
-  };
-
-  using PlanePtr = std::shared_ptr<Plane>;
+using PlanePtr = std::shared_ptr<Plane>;
 
 } // namespace geometry
 

--- a/include/tvm/geometry/Plane.h
+++ b/include/tvm/geometry/Plane.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/geometry/Plane.h
+++ b/include/tvm/geometry/Plane.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/graph/abstract/Node.h>
 
 namespace tvm

--- a/include/tvm/graph/CallGraph.h
+++ b/include/tvm/graph/CallGraph.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/graph/CallGraph.h
+++ b/include/tvm/graph/CallGraph.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/graph/internal/AbstractNode.h>
 #include <tvm/graph/internal/DependencyGraph.h>
 

--- a/include/tvm/graph/CallGraph.h
+++ b/include/tvm/graph/CallGraph.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -55,10 +55,7 @@ public:
   void update();
 
   /** Execute the plan */
-  inline void execute() const
-  {
-    plan_.execute();
-  }
+  inline void execute() const { plan_.execute(); }
 
   /** Clear the object.*/
   void clear();
@@ -98,6 +95,7 @@ protected:
         c();
       }
     }
+
   private:
     /** The calls in the correct call order */
     std::vector<Call> plan_;
@@ -111,8 +109,7 @@ protected:
    *
    * \returns The list of dependencies for the given source.
    */
-  std::vector<int> addOutput(abstract::Outputs * source,
-                             int output);
+  std::vector<int> addOutput(abstract::Outputs * source, int output);
 
   /** Add a Call to the graph
    *
@@ -132,7 +129,7 @@ protected:
   internal::DependencyGraph dependencyGraph_;
 
   /** Used to avoid duplicate entries in the graph */
-  std::map<std::intptr_t, std::map<int, std::vector<int> > > visited_;
+  std::map<std::intptr_t, std::map<int, std::vector<int>>> visited_;
 
   /** Store the call plan */
   Plan plan_;

--- a/include/tvm/graph/abstract/Node.h
+++ b/include/tvm/graph/abstract/Node.h
@@ -32,12 +32,12 @@ protected:
    * related object method.
    *
    */
-  template<typename EnumT, typename U, typename ... Args>
-  void registerUpdates(EnumT u, void(U::*fn)(), Args ... args);
+  template<typename EnumT, typename U, typename... Args>
+  void registerUpdates(EnumT u, void (U::*fn)(), Args... args);
 
   /** Register a single update */
   template<typename EnumT, typename U>
-  void registerUpdates(EnumT u, void(U::*fn)());
+  void registerUpdates(EnumT u, void (U::*fn)());
 
   /** Add a dependency of an output to an update call
    *
@@ -61,17 +61,21 @@ protected:
   void addInternalDependency(EnumU1 uDependent, EnumU2 u);
 
   /** Add a dependency of an update function to multiple input signals from a source */
-  template<typename U = T, typename EnumU, typename S, typename EnumO, typename ... Args>
-  void addInputDependency(EnumU u, std::shared_ptr<S> source, EnumO i, Args ... args);
+  template<typename U = T, typename EnumU, typename S, typename EnumO, typename... Args>
+  void addInputDependency(EnumU u, std::shared_ptr<S> source, EnumO i, Args... args);
 
   /** Add a dependency of an update function to multiple input signals from a source
    *
    * The lifetime of \p source should be guaranteed by the caller
    *
    */
-  template<typename U = T, typename EnumU, typename S, typename EnumO, typename ... Args,
-    typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type = 0 >
-  void addInputDependency(EnumU u, S & source, EnumO i, Args ... args);
+  template<typename U = T,
+           typename EnumU,
+           typename S,
+           typename EnumO,
+           typename... Args,
+           typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type = 0>
+  void addInputDependency(EnumU u, S & source, EnumO i, Args... args);
 
   /** Add a dependency of an output to an input signal and its source
    *
@@ -98,17 +102,21 @@ protected:
    * dependencies at the same time.
    *
    */
-  template<typename U = T, typename EnumO, typename S, typename EnumI,
-    typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type = 0 >
+  template<typename U = T,
+           typename EnumO,
+           typename S,
+           typename EnumI,
+           typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type = 0>
   void addDirectDependency(EnumO o, S & source, EnumI i);
+
 private:
   /* Internal version that takes a pointer to the source */
   template<typename U, typename EnumU, typename S>
   void checkAddInputDependency(EnumU u);
   template<typename U = T, typename EnumU, typename S, typename EnumO>
   void addInputDependency(EnumU u, S * source, EnumO i);
-  template<typename U = T, typename EnumU, typename S, typename EnumO, typename ... Args>
-  void addInputDependency(EnumU u, S* source, EnumO i, Args ... args);
+  template<typename U = T, typename EnumU, typename S, typename EnumO, typename... Args>
+  void addInputDependency(EnumU u, S * source, EnumO i, Args... args);
   template<typename U, typename EnumO, typename S, typename EnumI>
   void checkAddDirectDependency(EnumO o);
   template<typename U = T, typename EnumO, typename S, typename EnumI>

--- a/include/tvm/graph/abstract/Node.hpp
+++ b/include/tvm/graph/abstract/Node.hpp
@@ -8,22 +8,21 @@
 
 #include <sstream>
 
-
 #define TVM_GRAPH_LOG_REGISTER_UPDATE(node, u, fn) \
-  tvm::graph::internal::Logger::logger().registerUpdate<U,EnumT>(static_cast<U*>(node), u, fn);
+  tvm::graph::internal::Logger::logger().registerUpdate<U, EnumT>(static_cast<U *>(node), u, fn);
 
 #define TVM_GRAPH_LOG_ADD_OUTPUT_DEPENDENCY(node, o, u) \
-  tvm::graph::internal::Logger::logger().addOutputDependency<U,EnumO,EnumU>(static_cast<U*>(node), o, u);
+  tvm::graph::internal::Logger::logger().addOutputDependency<U, EnumO, EnumU>(static_cast<U *>(node), o, u);
 
-#define TVM_GRAPH_LOG_ADD_INTERNAL_DEPENDENCY(node, uDependent, u) \
-  tvm::graph::internal::Logger::logger().addInternalDependency<U,EnumU1,EnumU2>(static_cast<U*>(node), uDependent, u);
+#define TVM_GRAPH_LOG_ADD_INTERNAL_DEPENDENCY(node, uDependent, u)                                                    \
+  tvm::graph::internal::Logger::logger().addInternalDependency<U, EnumU1, EnumU2>(static_cast<U *>(node), uDependent, \
+                                                                                  u);
 
 #define TVM_GRAPH_LOG_ADD_INPUT_DEPENDENCY(node, u, source, i) \
-  tvm::graph::internal::Logger::logger().addInputDependency<U,EnumU,S,EnumO>(static_cast<U*>(node), u, source, i);
+  tvm::graph::internal::Logger::logger().addInputDependency<U, EnumU, S, EnumO>(static_cast<U *>(node), u, source, i);
 
 #define TVM_GRAPH_LOG_ADD_DIRECT_DEPENDENCY(node, o, source, i) \
-  tvm::graph::internal::Logger::logger().addDirectDependency(static_cast<U*>(node), o, source, i);
-
+  tvm::graph::internal::Logger::logger().addDirectDependency(static_cast<U *>(node), o, source, i);
 
 namespace tvm
 {
@@ -35,8 +34,8 @@ namespace abstract
 {
 
 template<typename T>
-template<typename EnumT, typename U, typename ... Args>
-void Node<T>::registerUpdates(EnumT u, void(U::*fn)(), Args ... args)
+template<typename EnumT, typename U, typename... Args>
+void Node<T>::registerUpdates(EnumT u, void (U::*fn)(), Args... args)
 {
   registerUpdates(u, fn);
   if(sizeof...(args))
@@ -47,7 +46,7 @@ void Node<T>::registerUpdates(EnumT u, void(U::*fn)(), Args ... args)
 
 template<typename T>
 template<typename EnumT, typename U>
-void Node<T>::registerUpdates(EnumT u, void(U::*fn)())
+void Node<T>::registerUpdates(EnumT u, void (U::*fn)())
 {
   static_assert(internal::is_valid_update<U>(EnumT()), "This update signal is not part of this Node");
   if(!U::UpdateStaticallyEnabled(u))
@@ -61,10 +60,7 @@ void Node<T>::registerUpdates(EnumT u, void(U::*fn)())
   {
     throw std::range_error("Attempted to register an update call using an id that was already registered.");
   }
-  updates_[static_cast<int>(u)] = [fn](AbstractNode & self)
-  {
-    return (static_cast<U&>(self).*fn)();
-  };
+  updates_[static_cast<int>(u)] = [fn](AbstractNode & self) { return (static_cast<U &>(self).*fn)(); };
   TVM_GRAPH_LOG_REGISTER_UPDATE(this, u, fn)
 }
 
@@ -72,18 +68,21 @@ template<typename T>
 template<typename U, typename EnumO, typename EnumU>
 void Node<T>::addOutputDependency(EnumO o, EnumU u)
 {
-  static_assert(is_valid_output<U>(EnumO()), "Invalid output for this type. If you are calling this method from a derived class, put this class in template parameter.");
-  static_assert(internal::is_valid_update<U>(EnumU()), "Invalid update for this type. If you are calling this method from a derived class, put this class in template parameter.");
+  static_assert(is_valid_output<U>(EnumO()), "Invalid output for this type. If you are calling this method from a "
+                                             "derived class, put this class in template parameter.");
+  static_assert(internal::is_valid_update<U>(EnumU()), "Invalid update for this type. If you are calling this method "
+                                                       "from a derived class, put this class in template parameter.");
   if(!U::OutputStaticallyEnabled(o))
   {
     std::stringstream ss;
     ss << "Output " << U::OutputName(o) << " is disabled within " << U::OutputBaseName;
     throw std::runtime_error(ss.str());
   }
-  if (directDependencies_.count(static_cast<int>(o)))
+  if(directDependencies_.count(static_cast<int>(o)))
   {
     std::stringstream ss;
-    ss << "Output " << U::OutputName(o) << " already has a direct dependency. You cannot mix direct and output dependencies";
+    ss << "Output " << U::OutputName(o)
+       << " already has a direct dependency. You cannot mix direct and output dependencies";
     throw std::runtime_error(ss.str());
   }
   outputDependencies_[static_cast<int>(o)].push_back(static_cast<int>(u));
@@ -104,8 +103,11 @@ template<typename T>
 template<typename U, typename EnumU1, typename EnumU2>
 void Node<T>::addInternalDependency(EnumU1 uDependent, EnumU2 u)
 {
-  static_assert(internal::is_valid_update<U>(EnumU1()), "Invalid dependent update for this type. If you are calling this method from a derived class, put this class in template parameter.");
-  static_assert(internal::is_valid_update<U>(EnumU2()), "Invalid update for this type. If you are calling this method from a derived class, put this class in template parameter.");
+  static_assert(internal::is_valid_update<U>(EnumU1()),
+                "Invalid dependent update for this type. If you are calling this method from a derived class, put this "
+                "class in template parameter.");
+  static_assert(internal::is_valid_update<U>(EnumU2()), "Invalid update for this type. If you are calling this method "
+                                                        "from a derived class, put this class in template parameter.");
   if(!U::UpdateStaticallyEnabled(uDependent))
   {
     std::stringstream ss;
@@ -126,7 +128,8 @@ template<typename T>
 template<typename U, typename EnumU, typename S>
 void Node<T>::checkAddInputDependency(EnumU u)
 {
-  static_assert(internal::is_valid_update<U>(EnumU()), "Invalid update for this type. If you are calling this method from a derived class, put this class in template parameter.");
+  static_assert(internal::is_valid_update<U>(EnumU()), "Invalid update for this type. If you are calling this method "
+                                                       "from a derived class, put this class in template parameter.");
   if(!U::UpdateStaticallyEnabled(u))
   {
     std::stringstream ss;
@@ -136,8 +139,8 @@ void Node<T>::checkAddInputDependency(EnumU u)
 }
 
 template<typename T>
-template<typename U, typename EnumU, typename S, typename EnumO, typename ... Args>
-void Node<T>::addInputDependency(EnumU u, std::shared_ptr<S> source, EnumO i, Args ... args)
+template<typename U, typename EnumU, typename S, typename EnumO, typename... Args>
+void Node<T>::addInputDependency(EnumU u, std::shared_ptr<S> source, EnumO i, Args... args)
 {
   // Make sure the call makes sense
   checkAddInputDependency<U, EnumU, S>(u);
@@ -148,9 +151,13 @@ void Node<T>::addInputDependency(EnumU u, std::shared_ptr<S> source, EnumO i, Ar
 }
 
 template<typename T>
-template<typename U, typename EnumU, typename S, typename EnumO, typename ... Args,
-    typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type>
-void Node<T>::addInputDependency(EnumU u, S & source, EnumO i, Args ... args)
+template<typename U,
+         typename EnumU,
+         typename S,
+         typename EnumO,
+         typename... Args,
+         typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type>
+void Node<T>::addInputDependency(EnumU u, S & source, EnumO i, Args... args)
 {
   // Make sure the call makes sense
   checkAddInputDependency<U, EnumU, S>(u);
@@ -169,13 +176,10 @@ void Node<T>::addInputDependency(EnumU u, S * source, EnumO i)
   {
     auto & inputDependency = inputDependencies_[static_cast<int>(u)];
     auto depIt = std::find_if(inputDependency.begin(), inputDependency.end(),
-                              [&source](const input_dependency_t::value_type & p)
-                              {
-                                return source == p.first;
-                              });
+                              [&source](const input_dependency_t::value_type & p) { return source == p.first; });
     if(depIt == inputDependency.end())
     {
-      inputDependency[source] = { static_cast<int>(i) };
+      inputDependency[source] = {static_cast<int>(i)};
     }
     else
     {
@@ -190,8 +194,8 @@ void Node<T>::addInputDependency(EnumU u, S * source, EnumO i)
 }
 
 template<typename T>
-template<typename U, typename EnumU, typename S, typename EnumO, typename ... Args>
-void Node<T>::addInputDependency(EnumU u, S * source, EnumO i, Args ... args)
+template<typename U, typename EnumU, typename S, typename EnumO, typename... Args>
+void Node<T>::addInputDependency(EnumU u, S * source, EnumO i, Args... args)
 {
   addInputDependency<U>(u, source, i);
   if(sizeof...(args))
@@ -204,24 +208,26 @@ template<typename T>
 template<typename U, typename EnumO, typename S, typename EnumI>
 void Node<T>::checkAddDirectDependency(EnumO o)
 {
-  static_assert(is_valid_output<U>(EnumO()), "Invalid output for this type. If you are calling this method from a derived class, put this class in template parameter.");
+  static_assert(is_valid_output<U>(EnumO()), "Invalid output for this type. If you are calling this method from a "
+                                             "derived class, put this class in template parameter.");
   static_assert(is_valid_output<S>(EnumI()), "Invalid output for this type of source.");
-  if (!U::OutputStaticallyEnabled(o))
+  if(!U::OutputStaticallyEnabled(o))
   {
     std::stringstream ss;
     ss << "Output " << U::OutputName(o) << " is disabled within " << U::OutputBaseName;
     throw std::runtime_error(ss.str());
   }
-  if (directDependencies_.count(static_cast<int>(o)))
+  if(directDependencies_.count(static_cast<int>(o)))
   {
     std::stringstream ss;
     ss << "Output " << U::OutputName(o) << " already has a direct dependency. ";
     throw std::runtime_error(ss.str());
   }
-  if (outputDependencies_.count(static_cast<int>(o)))
+  if(outputDependencies_.count(static_cast<int>(o)))
   {
     std::stringstream ss;
-    ss << "Output " << U::OutputName(o) << " already has output dependencies. You cannot mix direct and output dependencies";
+    ss << "Output " << U::OutputName(o)
+       << " already has output dependencies. You cannot mix direct and output dependencies";
     throw std::runtime_error(ss.str());
   }
 }
@@ -239,8 +245,11 @@ inline void Node<T>::addDirectDependency(EnumO o, std::shared_ptr<S> source, Enu
 }
 
 template<typename T>
-template<typename U, typename EnumO, typename S, typename EnumI,
-    typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type>
+template<typename U,
+         typename EnumO,
+         typename S,
+         typename EnumI,
+         typename std::enable_if<std::is_base_of<abstract::Outputs, S>::value, int>::type>
 inline void Node<T>::addDirectDependency(EnumO o, S & source, EnumI i)
 {
   // Check the add is valid
@@ -255,7 +264,7 @@ template<typename T>
 template<typename U, typename EnumO, typename S, typename EnumI>
 inline void Node<T>::addDirectDependency(EnumO o, S * source, EnumI i)
 {
-  directDependencies_[static_cast<int>(o)] = { source, static_cast<int>(i) };
+  directDependencies_[static_cast<int>(o)] = {source, static_cast<int>(i)};
   TVM_GRAPH_LOG_ADD_DIRECT_DEPENDENCY(this, o, source, i);
 }
 

--- a/include/tvm/graph/abstract/OutputSelector.h
+++ b/include/tvm/graph/abstract/OutputSelector.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/graph/abstract/OutputSelector.h
+++ b/include/tvm/graph/abstract/OutputSelector.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -33,7 +33,6 @@
 #include <vector>
 
 #include <tvm/graph/abstract/Outputs.h>
-
 
 namespace tvm
 {
@@ -44,144 +43,142 @@ namespace graph
 namespace abstract
 {
 
-  /** A structure holding the members used in OutputSelector if add = true,
-    * and nothing otherwise.
-    */
-  template<bool add = true>
-  struct SelectorMembers
+/** A structure holding the members used in OutputSelector if add = true,
+ * and nothing otherwise.
+ */
+template<bool add = true>
+struct SelectorMembers
+{
+  /** Used to store and test whether an output is dynamically enabled or not.*/
+  std::vector<bool> dynamicallyEnabled_;
+  /** track if the enabling/disabling of outputs is locked or not*/
+  bool locked_ = false;
+};
+
+template<>
+struct SelectorMembers<false>
+{
+};
+
+// forward declaration
+template<typename T, typename Base>
+class OutputSelector;
+
+/** detail functions, see is_output_selector*/
+template<typename T, typename Base>
+std::true_type is_output_selector_impl(OutputSelector<T, Base> const volatile &);
+
+/** detail functions, see is_output_selector*/
+std::false_type is_output_selector_impl(...);
+
+/** Check at compile-time if T derives from OutputSelector
+ *
+ * We cannot use std::is_base_of because OutputSelector is a template class.
+ * Instead, we rely on the declaration (only) of the two overloads of
+ * is_output_selector_impl. If (and only if) T derives from OutputSelector
+ * the overload returning std::true_type will be selected, and thus the
+ * following function returns true.
+ */
+template<typename T>
+constexpr bool is_output_selector()
+{
+  return decltype(is_output_selector_impl(std::declval<const T &>()))::value;
+}
+
+/** This class adds to its template argument the capability to enable or
+ * disable some of its outputs.
+ *
+ * We use here a bit of template metaprogramming to take care of the
+ * following problem:
+ * imagine we have the following inheritance structure
+ * class A
+ * class B : public OutputSelector<A>
+ * class C : public B
+ * class D : public OutputSelector<C>
+ * We want D to hold a single vector of bool for tracking enabled outputs
+ * and a single bool for lock. In our example, this means that
+ * OutputSelector<A> holds the data, and OutputSelector<C> reuse the same
+ * data. We implement this by checking if the template parameter is a
+ * derived class of OutputSelector. If it is not (case of A in our example)
+ * we make OutputSelector inherit from SelectorMembers<true> so that it
+ * inherits the data. If it is (case of C), we make OutputSelector inherit
+ * from SelectorMembers<false> so that no data is added.
+ */
+template<typename OutputProvider, typename Base = OutputProvider>
+class OutputSelector : public Base, protected SelectorMembers<!is_output_selector<Base>()>
+{
+public:
+  /** Constructor. Simply forward the arguments for constructing OutputProvider*/
+  template<typename... Args>
+  OutputSelector(Args &&... args) : Base(std::forward<Args>(args)...)
   {
-    /** Used to store and test whether an output is dynamically enabled or not.*/
-    std::vector<bool> dynamicallyEnabled_;
-    /** track if the enabling/disabling of outputs is locked or not*/
-    bool locked_ = false;
-  };
-
-  template<>
-  struct SelectorMembers<false>
-  {
-  };
-
-  //forward declaration
-  template <typename T, typename Base> class OutputSelector;
-
-
-  /** detail functions, see is_output_selector*/
-  template< typename T, typename Base>
-  std::true_type is_output_selector_impl(OutputSelector<T, Base> const volatile&);
-
-  /** detail functions, see is_output_selector*/
-  std::false_type is_output_selector_impl(...);
-
-  /** Check at compile-time if T derives from OutputSelector
-    *
-    * We cannot use std::is_base_of because OutputSelector is a template class.
-    * Instead, we rely on the declaration (only) of the two overloads of
-    * is_output_selector_impl. If (and only if) T derives from OutputSelector
-    * the overload returning std::true_type will be selected, and thus the
-    * following function returns true.
-    */
-  template <typename T>
-  constexpr bool is_output_selector() {
-    return decltype(is_output_selector_impl(std::declval<const T&>()))::value;
+    static_assert(std::is_base_of<Outputs, Base>::value, "Cannot build for a type that is not derived of Outputs");
+    this->dynamicallyEnabled_.resize(OutputProvider::OutputSize, true);
   }
 
-  /** This class adds to its template argument the capability to enable or
-    * disable some of its outputs.
-    *
-    * We use here a bit of template metaprogramming to take care of the
-    * following problem:
-    * imagine we have the following inheritance structure
-    * class A
-    * class B : public OutputSelector<A>
-    * class C : public B
-    * class D : public OutputSelector<C>
-    * We want D to hold a single vector of bool for tracking enabled outputs
-    * and a single bool for lock. In our example, this means that
-    * OutputSelector<A> holds the data, and OutputSelector<C> reuse the same
-    * data. We implement this by checking if the template parameter is a
-    * derived class of OutputSelector. If it is not (case of A in our example)
-    * we make OutputSelector inherit from SelectorMembers<true> so that it
-    * inherits the data. If it is (case of C), we make OutputSelector inherit
-    * from SelectorMembers<false> so that no data is added.
-    */
-  template <typename OutputProvider, typename Base = OutputProvider>
-  class OutputSelector :
-    public Base,
-    protected SelectorMembers<!is_output_selector<Base>()>
+  /** Lock the outputs, preventing them to be enabled or disabled. */
+  void lock() { this->locked_ = true; }
+
+  /** Unlock the outputs, allowing them to be enabled or disabled. */
+  void unlock() { this->locked_ = false; }
+
+  /** Check if the outputs are locked. */
+  bool isLocked() const { return this->locked_; }
+
+protected:
+  /** Disable an output. The enum must refer to an existing output. */
+  template<typename EnumT>
+  void disableOutput(EnumT e)
   {
-  public:
-    /** Constructor. Simply forward the arguments for constructing OutputProvider*/
-    template <typename ... Args>
-    OutputSelector(Args&&... args)
-      : Base(std::forward<Args>(args)...)
-    {
-      static_assert(std::is_base_of<Outputs, Base>::value, "Cannot build for a type that is not derived of Outputs");
-      this->dynamicallyEnabled_.resize(OutputProvider::OutputSize, true);
-    }
+    if(!is_valid_output<OutputProvider>(e))
+      throw std::runtime_error("You can only disable outputs that are part of the class.");
 
-    /** Lock the outputs, preventing them to be enabled or disabled. */
-    void lock() { this->locked_ = true; }
+    if(!this->locked_)
+      this->dynamicallyEnabled_[static_cast<size_t>(e)] = false;
+    else
+      throw std::runtime_error("Outputs have been locked, you cannot disable one.");
+  }
 
-    /** Unlock the outputs, allowing them to be enabled or disabled. */
-    void unlock() { this->locked_ = false; }
+  /** Multi-argument version of disableOutput. */
+  template<typename EnumT, typename... Args>
+  void disableOutput(EnumT e, Args... args)
+  {
+    disableOutput(e);
+    disableOutput(args...);
+  }
 
-    /** Check if the outputs are locked. */
-    bool isLocked() const { return this->locked_; }
+  /** Enable an output. The enum must refer to an existing output. */
+  template<typename EnumT>
+  void enableOutput(EnumT e)
+  {
+    if(!is_valid_output<OutputProvider>(e))
+      throw std::runtime_error("You can only disable outputs that are part of the class.");
 
-  protected:
-    /** Disable an output. The enum must refer to an existing output. */
-    template<typename EnumT>
-    void disableOutput(EnumT e)
-    {
-      if (!is_valid_output<OutputProvider>(e))
-        throw std::runtime_error("You can only disable outputs that are part of the class.");
+    if(!this->isOutputStaticallyEnabled(static_cast<int>(e)))
+      throw std::runtime_error("You can not enable outputs that are statically disabled.");
 
-      if (!this->locked_)
-        this->dynamicallyEnabled_[static_cast<size_t>(e)] = false;
-      else
-        throw std::runtime_error("Outputs have been locked, you cannot disable one.");
-    }
+    if(!this->locked_)
+      this->dynamicallyEnabled_[static_cast<size_t>(e)] = true;
+    else
+      throw std::runtime_error("Outputs have been locked, you cannot enable one.");
+  }
 
-    /** Multi-argument version of disableOutput. */
-    template<typename EnumT, typename ... Args>
-    void disableOutput(EnumT e, Args ... args)
-    {
-      disableOutput(e);
-      disableOutput(args...);
-    }
+  /** Multi-argument version of enableOutput. */
+  template<typename EnumT, typename... Args>
+  void enableOutput(EnumT e, Args... args)
+  {
+    enableOutput(e);
+    enableOutput(args...);
+  }
 
-    /** Enable an output. The enum must refer to an existing output. */
-    template<typename EnumT>
-    void enableOutput(EnumT e)
-    {
-      if (!is_valid_output<OutputProvider>(e))
-        throw std::runtime_error("You can only disable outputs that are part of the class.");
-
-      if (!this->isOutputStaticallyEnabled(static_cast<int>(e)))
-        throw std::runtime_error("You can not enable outputs that are statically disabled.");
-
-      if (!this->locked_)
-        this->dynamicallyEnabled_[static_cast<size_t>(e)] = true;
-      else
-        throw std::runtime_error("Outputs have been locked, you cannot enable one.");
-    }
-
-    /** Multi-argument version of enableOutput. */
-    template<typename EnumT, typename ... Args>
-    void enableOutput(EnumT e, Args ... args)
-    {
-      enableOutput(e);
-      enableOutput(args...);
-    }
-
-    /** Override the method of Outputs to get the desired enable/disable behavior. */
-    bool isOutputCustomEnabled(int e) const override
-    {
-      if (e < 0 || e >= static_cast<int>(this->dynamicallyEnabled_.size()))
-        throw std::runtime_error("Enum value is invalid");
-      return this->dynamicallyEnabled_[e];
-    }
-  };
+  /** Override the method of Outputs to get the desired enable/disable behavior. */
+  bool isOutputCustomEnabled(int e) const override
+  {
+    if(e < 0 || e >= static_cast<int>(this->dynamicallyEnabled_.size()))
+      throw std::runtime_error("Enum value is invalid");
+    return this->dynamicallyEnabled_[e];
+  }
+};
 
 } // namespace abstract
 

--- a/include/tvm/graph/abstract/OutputSelector.h
+++ b/include/tvm/graph/abstract/OutputSelector.h
@@ -30,8 +30,7 @@ struct SelectorMembers
 
 template<>
 struct SelectorMembers<false>
-{
-};
+{};
 
 // forward declaration
 template<typename T, typename Base>

--- a/include/tvm/graph/abstract/Outputs.h
+++ b/include/tvm/graph/abstract/Outputs.h
@@ -39,8 +39,7 @@ public:
   };
   /** Base class for Output. Empty */
   struct Output
-  {
-  };
+  {};
 
   /** Store the size of the Output enumeration */
   static constexpr unsigned int OutputSize = 0;

--- a/include/tvm/graph/abstract/Outputs.h
+++ b/include/tvm/graph/abstract/Outputs.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/graph/abstract/Outputs.h
+++ b/include/tvm/graph/abstract/Outputs.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -61,9 +61,13 @@ public:
   virtual ~Outputs() = default;
 
   /** Base Output enumeration. Empty */
-  enum class Output_ {};
+  enum class Output_
+  {
+  };
   /** Base class for Output. Empty */
-  struct Output {};
+  struct Output
+  {
+  };
 
   /** Store the size of the Output enumeration */
   static constexpr unsigned int OutputSize = 0;
@@ -83,7 +87,7 @@ public:
   /** Check if a given output is enabled, be it at the class (static) or
    * instance (dynamic) level).
    */
-  template <typename EnumT>
+  template<typename EnumT>
   bool isOutputEnabled(EnumT e) const
   {
     // FIXME is there a way to check that the enum has the good type here ?
@@ -92,18 +96,15 @@ public:
   }
 
   /** Same as above, but taking int, for conveniency*/
-  bool isOutputEnabled(int i) const
-  {
-    return isOutputStaticallyEnabled(i) && isOutputCustomEnabled(i);
-  }
+  bool isOutputEnabled(int i) const { return isOutputStaticallyEnabled(i) && isOutputCustomEnabled(i); }
 
   /** Check if a given output is enabled at the class level (run-time).
-  *
-  * The default implementation always returns true. The
-  * expected parameter is int to swallow the different
-  * output types.
-  *
-  */
+   *
+   * The default implementation always returns true. The
+   * expected parameter is int to swallow the different
+   * output types.
+   *
+   */
   virtual bool isOutputStaticallyEnabled(int) const { return true; }
 
   /** Check if an output is enabled given a custom criterion
@@ -111,7 +112,7 @@ public:
    * The default implementation always returns true.
    * This is a handle for the user to override.
    **/
-  virtual bool isOutputCustomEnabled(int) const { return true;}
+  virtual bool isOutputCustomEnabled(int) const { return true; }
 
   /** Check if a given output is enabled at the class level (compile-time)
    *
@@ -119,7 +120,10 @@ public:
    *
    */
   template<typename EnumT>
-  static constexpr bool OutputStaticallyEnabled(EnumT) { return true; }
+  static constexpr bool OutputStaticallyEnabled(EnumT)
+  {
+    return true;
+  }
 
 protected:
   /** Used to avoid a dynamic cast when working on Outputs that may be tvm::data::Node */
@@ -135,39 +139,37 @@ protected:
  * call this macro.
  *
  */
-#define SET_OUTPUTS(SelfT, ...)\
-  PP_ID(EXTEND_ENUM(Output, SelfT, __VA_ARGS__))
+#define SET_OUTPUTS(SelfT, ...) PP_ID(EXTEND_ENUM(Output, SelfT, __VA_ARGS__))
 
 /** Mark some output signals as disabled for that class
-  * This overrides Outputs::isOutputEnabled.
-  */
-#define DISABLE_OUTPUTS(...)\
-  PP_ID(DISABLE_SIGNALS(Output, __VA_ARGS__))
+ * This overrides Outputs::isOutputEnabled.
+ */
+#define DISABLE_OUTPUTS(...) PP_ID(DISABLE_SIGNALS(Output, __VA_ARGS__))
 
 /** Mark all outputs as enabled */
-#define CLEAR_DISABLED_OUTPUTS()\
-  PP_ID(CLEAR_DISABLED_SIGNALS(Output))
+#define CLEAR_DISABLED_OUTPUTS() PP_ID(CLEAR_DISABLED_SIGNALS(Output))
 
 /** Check if a value of EnumT is a valid output for Outputs type T */
 template<typename T, typename EnumT>
 constexpr bool is_valid_output(EnumT v)
 {
-  static_assert(std::is_base_of<Outputs, T>::value, "Cannot test output validity for a type that is not derived of Outputs");
+  static_assert(std::is_base_of<Outputs, T>::value,
+                "Cannot test output validity for a type that is not derived of Outputs");
   static_assert(std::is_enum<EnumT>::value, "Cannot test output validity for a value that is not an enumeration");
-  return std::is_same<typename T::Output_, EnumT>::value ||
-         ( (!std::is_same<typename T::OutputParent, typename T::OutputBase>::value) &&
-           is_valid_output<typename T::OutputParent>(v) );
+  return std::is_same<typename T::Output_, EnumT>::value
+         || ((!std::is_same<typename T::OutputParent, typename T::OutputBase>::value)
+             && is_valid_output<typename T::OutputParent>(v));
 }
 
 /** Check if all values of a given set are valid outputs for Outputs type T */
-template<typename T, typename EnumT, typename ... Args>
-constexpr bool is_valid_output(EnumT v, Args ... args)
+template<typename T, typename EnumT, typename... Args>
+constexpr bool is_valid_output(EnumT v, Args... args)
 {
   return is_valid_output<T>(v) && is_valid_output<T>(args...);
 }
 
 } // namespace abstract
 
-}  // namespace graph
+} // namespace graph
 
 } // namespace tvm

--- a/include/tvm/graph/abstract/Outputs.h
+++ b/include/tvm/graph/abstract/Outputs.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/internal/enums.h>
 
 #include <type_traits>

--- a/include/tvm/graph/internal/AbstractNode.h
+++ b/include/tvm/graph/internal/AbstractNode.h
@@ -21,8 +21,8 @@ class CallGraph;
 
 namespace abstract
 {
-  template<typename T>
-  class Node;
+template<typename T>
+class Node;
 }
 
 namespace internal
@@ -41,9 +41,13 @@ public:
   friend class tvm::graph::CallGraph;
 
   /** Base Update enumeration. Empty */
-  enum class Update_ {};
+  enum class Update_
+  {
+  };
   /** Base class for Update. Empty */
-  struct Update {};
+  struct Update
+  {
+  };
 
   /** Store the size of the Update enumeration */
   static constexpr unsigned int UpdateSize = 0;
@@ -61,9 +65,9 @@ public:
   static constexpr const char * UpdateName(Update_) { return "INVALID"; }
 
   /** Check if a given update is enabled, be it at the class (static) or
-  * instance (dynamic) level).
-  */
-  template <typename EnumT>
+   * instance (dynamic) level).
+   */
+  template<typename EnumT>
   bool isUpdateEnabled(EnumT e) const
   {
     int i = static_cast<int>(e);
@@ -71,19 +75,19 @@ public:
   }
 
   /** Check if a given update is enabled at the class level (run-time).
-  *
-  * The default implementation always returns true. The
-  * expected parameter is int to swallow the different
-  * update types.
-  *
-  */
+   *
+   * The default implementation always returns true. The
+   * expected parameter is int to swallow the different
+   * update types.
+   *
+   */
   virtual bool isUpdateStaticallyEnabled(int) const { return true; }
 
   /** Check if an update is enabled given a custom criterion
-  *
-  * The default implementation always return true.
-  * This is a handle for the user to override.
-  **/
+   *
+   * The default implementation always return true.
+   * This is a handle for the user to override.
+   **/
   virtual bool isUpdateCustomEnabled(int) const { return true; }
 
   /** Check if a given update is enabled (compile-time)
@@ -92,7 +96,10 @@ public:
    *
    */
   template<typename EnumT>
-  static constexpr bool UpdateStaticallyEnabled(EnumT) { return true; }
+  static constexpr bool UpdateStaticallyEnabled(EnumT)
+  {
+    return true;
+  }
 
   virtual ~AbstractNode() = default;
 
@@ -102,9 +109,10 @@ public:
     assert(updates_.count(i));
     updates_[i](*this);
   }
+
 protected:
   /** Map from a update id to  corresponding dependency function.*/
-  std::map<int, std::function<void(AbstractNode&)>> updates_;
+  std::map<int, std::function<void(AbstractNode &)>> updates_;
 
   /** Map from an output to the list of updates it depends on (expressed by the respective ids).*/
   std::map<int, std::vector<int>> outputDependencies_;
@@ -115,11 +123,9 @@ protected:
   std::map<int, input_dependency_t> inputDependencies_;
   /** Map from an output to the input it directly uses, without requiring an update (expressed by the respective ids).*/
   std::map<int, std::pair<Outputs *, int>> directDependencies_;
+
 private:
-  AbstractNode()
-  {
-    is_node_ = true;
-  }
+  AbstractNode() { is_node_ = true; }
 };
 
 /** Add new update signals for a given entity SelfT.
@@ -131,31 +137,29 @@ private:
  * call this macro.
  *
  */
-#define SET_UPDATES(SelfT, ...)\
-  PP_ID(EXTEND_ENUM(Update, SelfT, __VA_ARGS__))
+#define SET_UPDATES(SelfT, ...) PP_ID(EXTEND_ENUM(Update, SelfT, __VA_ARGS__))
 
 /** Mark some update signals as disabled for that class */
-#define DISABLE_UPDATES(...)\
-  PP_ID(DISABLE_SIGNALS(Update, __VA_ARGS__))
+#define DISABLE_UPDATES(...) PP_ID(DISABLE_SIGNALS(Update, __VA_ARGS__))
 
 /** Mark all updates as enabled */
-#define CLEAR_DISABLED_UPDATES()\
-  PP_ID(CLEAR_DISABLED_SIGNALS(Update))
+#define CLEAR_DISABLED_UPDATES() PP_ID(CLEAR_DISABLED_SIGNALS(Update))
 
 /** Check if a value of EnumT is a valid update for Node type T */
 template<typename T, typename EnumT>
 constexpr bool is_valid_update(EnumT v)
 {
-  static_assert(std::is_base_of<AbstractNode, T>::value, "Cannot test update validity for a type that is not derived of Updates");
+  static_assert(std::is_base_of<AbstractNode, T>::value,
+                "Cannot test update validity for a type that is not derived of Updates");
   static_assert(std::is_enum<EnumT>::value, "Cannot test update validity for a value that is not an enumeration");
-  return std::is_same<typename T::Update_, EnumT>::value ||
-         ( (!std::is_same<typename T::UpdateParent, typename T::UpdateBase>::value) &&
-           is_valid_update<typename T::UpdateParent>(v) );
+  return std::is_same<typename T::Update_, EnumT>::value
+         || ((!std::is_same<typename T::UpdateParent, typename T::UpdateBase>::value)
+             && is_valid_update<typename T::UpdateParent>(v));
 }
 
 /** Check if all values of a given set are valid updates for Updates type T */
-template<typename T, typename EnumT, typename ... Args>
-constexpr bool is_valid_update(EnumT v, Args ... args)
+template<typename T, typename EnumT, typename... Args>
+constexpr bool is_valid_update(EnumT v, Args... args)
 {
   return is_valid_update<T>(v) && is_valid_update<T>(args...);
 }

--- a/include/tvm/graph/internal/AbstractNode.h
+++ b/include/tvm/graph/internal/AbstractNode.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/graph/internal/Inputs.h>
 
 #include <cassert>

--- a/include/tvm/graph/internal/AbstractNode.h
+++ b/include/tvm/graph/internal/AbstractNode.h
@@ -46,8 +46,7 @@ public:
   };
   /** Base class for Update. Empty */
   struct Update
-  {
-  };
+  {};
 
   /** Store the size of the Update enumeration */
   static constexpr unsigned int UpdateSize = 0;

--- a/include/tvm/graph/internal/DependencyGraph.h
+++ b/include/tvm/graph/internal/DependencyGraph.h
@@ -92,7 +92,7 @@ private:
     size_t rootCompr(size_t node);
 
     std::vector<size_t> parent_; // parent_[i] is the id of the parent of element i
-    std::vector<size_t> rank_; // rank of each element.
+    std::vector<size_t> rank_;   // rank of each element.
   };
 
   /** A recursive function that finds and returns strongly connected components
@@ -138,7 +138,7 @@ private:
                  std::vector<uint8_t> & stack,
                  DisjointSet & components) const;
 
-  std::vector<uint8_t> roots_; // roots_[i] is true iff the i-th node has no incoming edges
+  std::vector<uint8_t> roots_;                // roots_[i] is true iff the i-th node has no incoming edges
   std::vector<std::vector<size_t>> children_; // children_[i] lists all the childs of node i
   std::set<std::pair<size_t, size_t>> edges_; // a list of edges (from, to)
 };

--- a/include/tvm/graph/internal/DependencyGraph.h
+++ b/include/tvm/graph/internal/DependencyGraph.h
@@ -4,140 +4,142 @@
 
 #include <tvm/api.h>
 
-#include <vector>
 #include <set>
 #include <stack>
+#include <vector>
 
 namespace tvm::graph::internal
 {
-  /** An oriented graph to represent dependencies between nodes.
-    * 
-    * An edge (f, t) represents a dependency from \p f on \p t.
-    */
-  class TVM_DLLAPI DependencyGraph
+/** An oriented graph to represent dependencies between nodes.
+ *
+ * An edge (f, t) represents a dependency from \p f on \p t.
+ */
+class TVM_DLLAPI DependencyGraph
+{
+public:
+  /** Create a node and return its id.*/
+  size_t addNode();
+  /** Add an edge from node with id \p from to node with id \p to.
+   * Return \p true if this indeed creates a new edge, \p false if this
+   * edge was already present.
+   */
+  bool addEdge(size_t from, size_t to);
+  /** Return the reduced graph of this graph as a pair (v,g)
+   * v is a list of groups of vertices, each group corresponding to a
+   * strongly connected component.
+   * g is the direct acyclic graph between these groups
+   */
+  std::pair<std::vector<std::vector<size_t>>, DependencyGraph> reduce() const;
+  /** Return the list of nodes in reversed topological order.*/
+  std::vector<size_t> order() const;
+  /** Return the list of node groups. Each group corresponds to a connected
+   * component of the graph seen as non-oriented. Within each group the
+   * nodes are sorted in reversed topological order.
+   */
+  std::vector<std::vector<size_t>> groupedOrder() const;
+  /** Number of vertices*/
+  size_t size() const;
+  /** List of edges*/
+  const std::set<std::pair<size_t, size_t>> & edges() const;
+  /** Clear the graph.*/
+  void clear();
+
+private:
+  /** This class implements a minimalist disjoint set data structure.
+   * See https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+   *
+   * Given a number n, there are n elements with implicit id from 0 to n-1.
+   * Each element point to a parent and has a rank. This defines in
+   * particular trees, where a root point to itself.
+   * The rank is a heuristic on the depth at which a node is in its tree.
+   */
+  class DisjointSet
   {
   public:
-    /** Create a node and return its id.*/
-    size_t addNode();
-    /** Add an edge from node with id \p from to node with id \p to.
-      * Return \p true if this indeed creates a new edge, \p false if this
-      * edge was already present.
-      */
-    bool addEdge(size_t from, size_t to);
-    /** Return the reduced graph of this graph as a pair (v,g)
-      * v is a list of groups of vertices, each group corresponding to a
-      * strongly connected component.
-      * g is the direct acyclic graph between these groups
-      */
-    std::pair<std::vector<std::vector<size_t>>, DependencyGraph> reduce() const;
-    /** Return the list of nodes in reversed topological order.*/
-    std::vector<size_t> order() const;
-    /** Return the list of node groups. Each group corresponds to a connected
-      * component of the graph seen as non-oriented. Within each group the
-      * nodes are sorted in reversed topological order.
-      */
-    std::vector<std::vector<size_t>> groupedOrder() const;
-    /** Number of vertices*/
-    size_t size() const;
-    /** List of edges*/
-    const std::set<std::pair<size_t, size_t>>& edges() const;
-    /** Clear the graph.*/
-    void clear();
+    /** Initialize for 0 elements*/
+    DisjointSet() = default;
 
+    /** Initialize for n elements*/
+    DisjointSet(size_t n);
+
+    /** Resize to n elements*/
+    void resize(size_t n);
+
+    /** Find the root of the tree the element \p node is in.
+     */
+    size_t root(size_t node) const;
+
+    /** Unify the tree \p node1 is in with the tree \p node2 is in.
+     * This is done by having the root of one of the trees point at the root of
+     * the other.
+     * Chosing wich root points to which is done based on the rank of both roots,
+     * where the rank is a heuristic number approximating the tree depth. The
+     * root with the smallest rank point to the other, in which case the rank of
+     * the other remain unchanged. If both roots have the same rank, the second
+     * point to the first and the rank of the first one is incremented by one.
+     * The ranks are stored in the aptly named \p rank.
+     */
+    void unify(size_t node1, size_t node2);
+
+    /** Check if node i is a root.*/
+    bool isRoot(size_t i) const;
 
   private:
-    /** This class implements a minimalist disjoint set data structure.
-    * See https://en.wikipedia.org/wiki/Disjoint-set_data_structure
-    *
-    * Given a number n, there are n elements with implicit id from 0 to n-1.
-    * Each element point to a parent and has a rank. This defines in
-    * particular trees, where a root point to itself.
-    * The rank is a heuristic on the depth at which a node is in its tree.
-    */
-    class DisjointSet
-    {
-    public:
-      /** Initialize for 0 elements*/
-      DisjointSet() = default;
+    /** Find the root of the tree the element \p node is in.
+     * The function also perform a path compression, in that all node discovered
+     * along the way are made to point directly to the root.
+     */
+    size_t rootCompr(size_t node);
 
-      /** Initialize for n elements*/
-      DisjointSet(size_t n);
-
-      /** Resize to n elements*/
-      void resize(size_t n);
-
-      /** Find the root of the tree the element \p node is in.
-        */
-      size_t root(size_t node) const;
-
-      /** Unify the tree \p node1 is in with the tree \p node2 is in.
-        * This is done by having the root of one of the trees point at the root of
-        * the other.
-        * Chosing wich root points to which is done based on the rank of both roots,
-        * where the rank is a heuristic number approximating the tree depth. The
-        * root with the smallest rank point to the other, in which case the rank of
-        * the other remain unchanged. If both roots have the same rank, the second
-        * point to the first and the rank of the first one is incremented by one.
-        * The ranks are stored in the aptly named \p rank.
-        */
-      void unify(size_t node1, size_t node2);
-
-      /** Check if node i is a root.*/
-      bool isRoot(size_t i) const;
-
-    private:
-      /** Find the root of the tree the element \p node is in.
-        * The function also perform a path compression, in that all node discovered
-        * along the way are made to point directly to the root.
-        */
-      size_t rootCompr(size_t node);
-
-      std::vector<size_t> parent_;  // parent_[i] is the id of the parent of element i
-      std::vector<size_t> rank_;    // rank of each element.
-    };
-
-    /** A recursive function that finds and returns strongly connected components
-      * (SCC) using DFS traversal.
-      * \param ret a vector of SCC
-      * \param u the vertex to visit
-      * \param disc discovery time of the vertices (should be -1 if not
-      * discovered yet)
-      * \param low earliest visited vertex (the vertex with minimum discovery
-      * time) that can be reached from subtree rooted with current vertex
-      * \param st stack to store all connected ancestors
-      * \param stackMember array for checking faster if a node is in the stack
-      * \param time a counter increased at each entry in the function. Should
-      * be non-negative.
-      *
-      * Adapted from
-      * https://www.geeksforgeeks.org/tarjan-algorithm-find-strongly-connected-components/
-      */
-    void SCCUtil(std::vector<std::vector<size_t>>& ret,
-      size_t u, std::vector<int>& disc, std::vector<int>& low,
-      std::stack<size_t>& st, std::vector<uint8_t>& stackMember, int& time) const;
-
-    /** An intermediate function for computing the topological order.*/
-    std::pair<std::vector<size_t>, DisjointSet> order_() const;
-
-
-    /** A recursive function used for topological ordering. It also detects
-      * connected components of the graph.
-      * \param v the vertex to process
-      * \param order the vertices in reversed topological order
-      * \param visited visited[i] is true if and only if vertex i was visited
-      * \param stack stack[i] is true if and only if vertex i is among the
-      * vertices being processed.
-      * \param components A disjoint-set data structure representing the
-      * connected components
-      */
-    void orderUtil(size_t v, std::vector<size_t>& order,
-      std::vector<uint8_t>& visited, std::vector<uint8_t>& stack,
-      DisjointSet& components) const;
-
-
-    std::vector<uint8_t> roots_;                    //roots_[i] is true iff the i-th node has no incoming edges
-    std::vector<std::vector<size_t>> children_;     //children_[i] lists all the childs of node i
-    std::set<std::pair<size_t, size_t>> edges_;     //a list of edges (from, to)
-
+    std::vector<size_t> parent_; // parent_[i] is the id of the parent of element i
+    std::vector<size_t> rank_; // rank of each element.
   };
-}
+
+  /** A recursive function that finds and returns strongly connected components
+   * (SCC) using DFS traversal.
+   * \param ret a vector of SCC
+   * \param u the vertex to visit
+   * \param disc discovery time of the vertices (should be -1 if not
+   * discovered yet)
+   * \param low earliest visited vertex (the vertex with minimum discovery
+   * time) that can be reached from subtree rooted with current vertex
+   * \param st stack to store all connected ancestors
+   * \param stackMember array for checking faster if a node is in the stack
+   * \param time a counter increased at each entry in the function. Should
+   * be non-negative.
+   *
+   * Adapted from
+   * https://www.geeksforgeeks.org/tarjan-algorithm-find-strongly-connected-components/
+   */
+  void SCCUtil(std::vector<std::vector<size_t>> & ret,
+               size_t u,
+               std::vector<int> & disc,
+               std::vector<int> & low,
+               std::stack<size_t> & st,
+               std::vector<uint8_t> & stackMember,
+               int & time) const;
+
+  /** An intermediate function for computing the topological order.*/
+  std::pair<std::vector<size_t>, DisjointSet> order_() const;
+
+  /** A recursive function used for topological ordering. It also detects
+   * connected components of the graph.
+   * \param v the vertex to process
+   * \param order the vertices in reversed topological order
+   * \param visited visited[i] is true if and only if vertex i was visited
+   * \param stack stack[i] is true if and only if vertex i is among the
+   * vertices being processed.
+   * \param components A disjoint-set data structure representing the
+   * connected components
+   */
+  void orderUtil(size_t v,
+                 std::vector<size_t> & order,
+                 std::vector<uint8_t> & visited,
+                 std::vector<uint8_t> & stack,
+                 DisjointSet & components) const;
+
+  std::vector<uint8_t> roots_; // roots_[i] is true iff the i-th node has no incoming edges
+  std::vector<std::vector<size_t>> children_; // children_[i] lists all the childs of node i
+  std::set<std::pair<size_t, size_t>> edges_; // a list of edges (from, to)
+};
+} // namespace tvm::graph::internal

--- a/include/tvm/graph/internal/Inputs.h
+++ b/include/tvm/graph/internal/Inputs.h
@@ -85,8 +85,7 @@ private:
   /** Terminal case */
   template<typename T>
   void addInput(T &)
-  {
-  }
+  {}
 };
 
 } // namespace internal

--- a/include/tvm/graph/internal/Inputs.h
+++ b/include/tvm/graph/internal/Inputs.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/graph/internal/Inputs.h
+++ b/include/tvm/graph/internal/Inputs.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -70,33 +70,37 @@ public:
     Iterator(inputs_t::iterator it, inputs_t::iterator end);
     /** True if the iterator is valid */
     operator bool();
+
   private:
     inputs_t::iterator end_;
   };
 
   /** Add outputs from a given Output object */
-  template<typename T, typename EnumI, typename ... Args>
-  void addInput(std::shared_ptr<T> source, EnumI i, Args ... args);
+  template<typename T, typename EnumI, typename... Args>
+  void addInput(std::shared_ptr<T> source, EnumI i, Args... args);
 
   /** Add outputs from a given Output object.
    *
    * Leave the caller responsible for the source lifetime
    */
-  template<typename T, typename EnumI, typename ... Args,
-    typename std::enable_if<std::is_base_of<abstract::Outputs, T>::value, int>::type = 0 >
-  void addInput(T & source, EnumI i, Args ... args);
+  template<typename T,
+           typename EnumI,
+           typename... Args,
+           typename std::enable_if<std::is_base_of<abstract::Outputs, T>::value, int>::type = 0>
+  void addInput(T & source, EnumI i, Args... args);
   /** Remove all outputs from a given Output object */
   template<typename T>
-  void removeInput(T* source);
+  void removeInput(T * source);
   /** Remove outputs from a given Output object */
-  template<typename T, typename ... Args>
-  void removeInput(T* source, Args ... args);
+  template<typename T, typename... Args>
+  void removeInput(T * source, Args... args);
   /** Retrieve an input from a given Output object */
   template<typename T>
-  Iterator getInput(T* source);
+  Iterator getInput(T * source);
   /** Retrieve an input from a given Output object */
   template<typename T>
-  Iterator getInput(const std::shared_ptr<T>& source);
+  Iterator getInput(const std::shared_ptr<T> & source);
+
 private:
   /** Remove an input with a given iterator and source */
   void removeInput(Iterator it, abstract::Outputs * source);
@@ -107,7 +111,9 @@ private:
   void addInput(T * source, EnumI i);
   /** Terminal case */
   template<typename T>
-  void addInput(T &) {}
+  void addInput(T &)
+  {
+  }
 };
 
 } // namespace internal

--- a/include/tvm/graph/internal/Inputs.hpp
+++ b/include/tvm/graph/internal/Inputs.hpp
@@ -16,8 +16,7 @@ namespace
 {
 template<typename T>
 inline void check_output_enabled(const T &)
-{
-}
+{}
 
 template<typename T, typename EnumT, typename... Args>
 inline void check_output_enabled(const T & s, EnumT o, Args... args)

--- a/include/tvm/graph/internal/Inputs.hpp
+++ b/include/tvm/graph/internal/Inputs.hpp
@@ -6,30 +6,34 @@
 
 #include <tvm/graph/internal/Logger.h>
 
-
-#define TVM_GRAPH_LOG_ADD_INPUT(add, node, i, source) \
-  if (add) {tvm::graph::internal::Logger::logger().addInput<T,EnumI>(node,source,i);}
+#define TVM_GRAPH_LOG_ADD_INPUT(add, node, i, source)                           \
+  if(add)                                                                       \
+  {                                                                             \
+    tvm::graph::internal::Logger::logger().addInput<T, EnumI>(node, source, i); \
+  }
 
 namespace
 {
-  template<typename T>
-  inline void check_output_enabled(const T &) {}
+template<typename T>
+inline void check_output_enabled(const T &)
+{
+}
 
-  template<typename T, typename EnumT, typename ... Args>
-  inline void check_output_enabled(const T & s, EnumT o, Args ... args)
+template<typename T, typename EnumT, typename... Args>
+inline void check_output_enabled(const T & s, EnumT o, Args... args)
+{
+  if(!s.isOutputEnabled(static_cast<int>(o)))
   {
-    if(!s.isOutputEnabled(static_cast<int>(o)))
-    {
-      std::stringstream ss;
-      ss << "Output " << T::OutputName(o) << " is not enabled in " << T::OutputBaseName << " (or derived)";
-      throw std::runtime_error(ss.str());
-    }
-    if(sizeof...(Args))
-    {
-      check_output_enabled(s, args...);
-    }
+    std::stringstream ss;
+    ss << "Output " << T::OutputName(o) << " is not enabled in " << T::OutputBaseName << " (or derived)";
+    throw std::runtime_error(ss.str());
   }
-}  // namespace
+  if(sizeof...(Args))
+  {
+    check_output_enabled(s, args...);
+  }
+}
+} // namespace
 
 namespace tvm
 {
@@ -40,16 +44,18 @@ namespace graph
 namespace internal
 {
 
-template<typename T, typename EnumI, typename ... Args>
-inline void Inputs::addInput(std::shared_ptr<T> source, EnumI i, Args ... args)
+template<typename T, typename EnumI, typename... Args>
+inline void Inputs::addInput(std::shared_ptr<T> source, EnumI i, Args... args)
 {
   addInput(*source, i, args...);
   store_.insert(source);
 }
 
-template<typename T, typename EnumI, typename ... Args,
-    typename std::enable_if<std::is_base_of<abstract::Outputs, T>::value, int>::type>
-inline void Inputs::addInput(T & source, EnumI i, Args ... args)
+template<typename T,
+         typename EnumI,
+         typename... Args,
+         typename std::enable_if<std::is_base_of<abstract::Outputs, T>::value, int>::type>
+inline void Inputs::addInput(T & source, EnumI i, Args... args)
 {
   addInput(&source, i);
   if(sizeof...(Args))
@@ -64,23 +70,23 @@ inline void Inputs::addInput(T * source, EnumI i)
   static_assert(abstract::is_valid_output<T>(EnumI()), "The output you requested is not part of the provided source");
   check_output_enabled(*source, i);
   auto it = getInput(source);
-  if (it)
+  if(it)
   {
     auto p = it->second.insert(static_cast<int>(i));
     TVM_GRAPH_LOG_ADD_INPUT(p.second, this, i, source);
   }
   else
   {
-    inputs_[source] = { static_cast<int>(i) };
+    inputs_[source] = {static_cast<int>(i)};
     TVM_GRAPH_LOG_ADD_INPUT(true, this, i, source);
   }
 }
 
 template<typename T>
-inline void Inputs::removeInput(T* source)
+inline void Inputs::removeInput(T * source)
 {
   auto it = getInput(source);
-  if (!it)
+  if(!it)
   {
     throw std::runtime_error("You attempted to remove inputs from a source that is not part of this object.");
   }
@@ -90,24 +96,25 @@ inline void Inputs::removeInput(T* source)
   }
 }
 
-template<typename T, typename ... Args>
-inline void Inputs::removeInput(T* source, Args ... args)
+template<typename T, typename... Args>
+inline void Inputs::removeInput(T * source, Args... args)
 {
-  static_assert(abstract::is_valid_output<T>(Args()...), "One of the outputs you requested is not part of the provided source");
+  static_assert(abstract::is_valid_output<T>(Args()...),
+                "One of the outputs you requested is not part of the provided source");
   auto it = getInput(source);
-  if (!it)
+  if(!it)
   {
     throw std::runtime_error("You attempted to remove inputs from a source that is not part of this object.");
   }
   else
   {
-    std::set<int> v{ static_cast<int>(args)... };
-    for (auto i : v)
+    std::set<int> v{static_cast<int>(args)...};
+    for(auto i : v)
     {
-      if (it->second.erase(i) == 0)
+      if(it->second.erase(i) == 0)
         throw std::runtime_error("You attempted to remove an input that was not there.");
     }
-    if (it->second.size() == 0)
+    if(it->second.size() == 0)
     {
       removeInput(it, source);
     }
@@ -115,20 +122,18 @@ inline void Inputs::removeInput(T* source, Args ... args)
 }
 
 template<typename T>
-inline Inputs::Iterator Inputs::getInput(T* source)
+inline Inputs::Iterator Inputs::getInput(T * source)
 {
-  static_assert(std::is_base_of<abstract::Outputs, T>::value, "Inputs cannot store outputs that do not derived from Ouputs.");
+  static_assert(std::is_base_of<abstract::Outputs, T>::value,
+                "Inputs cannot store outputs that do not derived from Ouputs.");
   // FIXME Use something more clever or a better data structure to search for inputs
-  return { std::find_if(inputs_.begin(), inputs_.end(),
-                        [&source](const typename inputs_t::value_type & p)
-                        {
-                          return p.first == source;
-                        }),
-            inputs_.end()};
+  return {std::find_if(inputs_.begin(), inputs_.end(),
+                       [&source](const typename inputs_t::value_type & p) { return p.first == source; }),
+          inputs_.end()};
 }
 
 template<typename T>
-inline Inputs::Iterator Inputs::getInput(const std::shared_ptr<T>& source)
+inline Inputs::Iterator Inputs::getInput(const std::shared_ptr<T> & source)
 {
   return getInput(source.get());
 }

--- a/include/tvm/graph/internal/Log.h
+++ b/include/tvm/graph/internal/Log.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/graph/internal/Log.h
+++ b/include/tvm/graph/internal/Log.h
@@ -264,8 +264,7 @@ inline Log::EnumValue::EnumValue(E e) : type(typeid(e)), value(static_cast<int>(
 
 template<typename T>
 inline Log::Pointer::Pointer(T * p) : type(typeid(*p)), value(reinterpret_cast<std::uintptr_t>(p))
-{
-}
+{}
 
 inline Log::Pointer::Pointer(const std::type_index & t, std::uintptr_t v) : type(t), value(v) {}
 

--- a/include/tvm/graph/internal/Log.h
+++ b/include/tvm/graph/internal/Log.h
@@ -71,7 +71,7 @@ public:
     EnumValue(E e);
 
     std::type_index type; // representation of the enumeration type
-    int value; // value of the enumeration
+    int value;            // value of the enumeration
 
     bool operator<(const EnumValue & other) const { return lexLess(*this, other, &EnumValue::type, &EnumValue::value); }
     bool operator==(const EnumValue & other) const { return eq(*this, other, &EnumValue::type, &EnumValue::value); }
@@ -97,10 +97,10 @@ public:
   /** Description of an update. */
   struct Update
   {
-    EnumValue id; // id of the update
-    std::string name; // name of the update
+    EnumValue id;            // id of the update
+    std::string name;        // name of the update
     std::uintptr_t function; // address of the update function
-    Pointer owner; // address of the instance registering the update
+    Pointer owner;           // address of the instance registering the update
     bool operator<(const Update & other) const
     {
       return lexLess(*this, other, &Update::owner, &Update::id, &Update::function);
@@ -114,9 +114,9 @@ public:
   /** Description of an output. */
   struct Output
   {
-    EnumValue id; // id of the output
+    EnumValue id;     // id of the output
     std::string name; // name of the output
-    Pointer owner; // address of the instance registering the output
+    Pointer owner;    // address of the instance registering the output
     bool operator<(const Output & other) const { return lexLess(*this, other, &Output::owner, &Output::id); }
     bool operator==(const Output & other) const { return eq(*this, other, &Output::owner, &Output::id); }
   };
@@ -124,10 +124,10 @@ public:
   /** Description of an input. */
   struct Input
   {
-    EnumValue id; // id of the input
+    EnumValue id;     // id of the input
     std::string name; // name of the input
-    Pointer source; // address of the instance providing the input
-    Pointer owner; // address of the instance registering the input
+    Pointer source;   // address of the instance providing the input
+    Pointer owner;    // address of the instance registering the input
     bool operator<(const Input & other) const
     {
       return lexLess(*this, other, &Input::owner, &Input::id, &Input::source);
@@ -138,10 +138,10 @@ public:
   /** Description of an input->update dependency. */
   struct InputDependency
   {
-    EnumValue input; // the input
+    EnumValue input;  // the input
     EnumValue update; // the update
-    Pointer source; // address of the instance providing the input
-    Pointer owner; // address of the instance registering the dependency
+    Pointer source;   // address of the instance providing the input
+    Pointer owner;    // address of the instance registering the dependency
     bool operator<(const InputDependency & other) const
     {
       return lexLess(*this, other, &InputDependency::owner, &InputDependency::update, &InputDependency::source,
@@ -159,7 +159,7 @@ public:
   {
     EnumValue update; // the update
     EnumValue output; // the output
-    Pointer owner; // address of the instance registering the dependency
+    Pointer owner;    // address of the instance registering the dependency
     bool operator<(const OutputDependency & other) const
     {
       return lexLess(*this, other, &OutputDependency::owner, &OutputDependency::update, &OutputDependency::output);
@@ -174,8 +174,8 @@ public:
   struct InternalDependency
   {
     EnumValue from; // the update depended upon
-    EnumValue to; // the depending update
-    Pointer owner; // address of the instance registering the dependency
+    EnumValue to;   // the depending update
+    Pointer owner;  // address of the instance registering the dependency
     bool operator<(const InternalDependency & other) const
     {
       return lexLess(*this, other, &InternalDependency::owner, &InternalDependency::from, &InternalDependency::to);
@@ -189,10 +189,10 @@ public:
   /** Description of an input->output dependency. */
   struct DirectDependency
   {
-    EnumValue input; // the input
+    EnumValue input;  // the input
     EnumValue output; // the output
-    Pointer source; // address of the instance providing the input
-    Pointer owner; // address of the instance registering the dependency
+    Pointer source;   // address of the instance providing the input
+    Pointer owner;    // address of the instance registering the dependency
     bool operator<(const DirectDependency & other) const
     {
       return lexLess(*this, other, &DirectDependency::owner, &DirectDependency::output, &DirectDependency::source,

--- a/include/tvm/graph/internal/Log.h
+++ b/include/tvm/graph/internal/Log.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -41,233 +41,263 @@
 #include <typeinfo>
 #include <vector>
 
-
 namespace tvm
 {
-  
+
 namespace graph
 {
 class CallGraph;
 
 namespace internal
 {
-  class Inputs;
+class Inputs;
 
-  /** lexicographic comparison of two objects given an ordered list of the
-    * members to compare. 
-    */
-  template<typename ObjType, typename MemberType, typename... Args>
-  bool lexLess(const ObjType& l, const ObjType& r, MemberType ObjType::* member, Args&&... args)
+/** lexicographic comparison of two objects given an ordered list of the
+ * members to compare.
+ */
+template<typename ObjType, typename MemberType, typename... Args>
+bool lexLess(const ObjType & l, const ObjType & r, MemberType ObjType::*member, Args &&... args)
+{
+  return (l.*member) < (r.*member) || ((l.*member == r.*member) && lexLess(l, r, std::forward<Args>(args)...));
+}
+
+/** Equality comparison of two objects given an ordered list of the members
+ * to compare.
+ */
+template<typename ObjType, typename MemberType, typename... Args>
+bool eq(const ObjType & l, const ObjType & r, MemberType ObjType::*member, Args &&... args)
+{
+  return (l.*member == r.*member) && eq(l, r, std::forward<Args>(args)...);
+}
+
+/** End of recursion. */
+template<typename ObjType, typename MemberType>
+bool lexLess(const ObjType & l, const ObjType & r, MemberType ObjType::*member)
+{
+  return (l.*member) < (r.*member);
+}
+
+/** End of recursion. */
+template<typename ObjType, typename MemberType>
+bool eq(const ObjType & l, const ObjType & r, MemberType ObjType::*member)
+{
+  return (l.*member) == (r.*member);
+}
+
+/** A data structure, used by Logger to log the inputs, outputs, updates and
+ * dependencies that are declared at runtime.
+ */
+class TVM_DLLAPI Log
+{
+public:
+  /** A non-enum representation of enum, as a pair (type of enum, value).*/
+  struct EnumValue
   {
-    return (l.*member) < (r.*member) || ((l.*member == r.*member) && lexLess(l, r, std::forward<Args>(args)...));
-  }
+    /** Build from an enum*/
+    template<typename E>
+    EnumValue(E e);
 
-  /** Equality comparison of two objects given an ordered list of the members
-    * to compare.
-    */
-  template<typename ObjType, typename MemberType, typename... Args>
-  bool eq(const ObjType& l, const ObjType& r, MemberType ObjType::* member, Args&&... args)
-  {
-    return (l.*member == r.*member) && eq(l, r, std::forward<Args>(args)...);
-  }
+    std::type_index type; // representation of the enumeration type
+    int value; // value of the enumeration
 
-  /** End of recursion. */
-  template<typename ObjType, typename MemberType>
-  bool lexLess(const ObjType& l, const ObjType& r, MemberType ObjType::* member)
-  {
-    return (l.*member) < (r.*member);
-  }
-
-  /** End of recursion. */
-  template<typename ObjType, typename MemberType>
-  bool eq(const ObjType& l, const ObjType& r, MemberType ObjType::* member)
-  {
-    return (l.*member) == (r.*member);
-  }
-
-
-  /** A data structure, used by Logger to log the inputs, outputs, updates and
-    * dependencies that are declared at runtime.
-    */
-  class TVM_DLLAPI Log
-  {
-  public:
-    /** A non-enum representation of enum, as a pair (type of enum, value).*/
-    struct EnumValue
-    {
-      /** Build from an enum*/
-      template<typename E>
-      EnumValue(E e);
-
-      std::type_index type;   // representation of the enumeration type
-      int value;              // value of the enumeration
-      
-      bool operator<(const EnumValue& other) const { return lexLess(*this, other, &EnumValue::type, &EnumValue::value); }
-      bool operator==(const EnumValue& other) const { return eq(*this, other, &EnumValue::type, &EnumValue::value); }
-    };
-
-    /** A type-independent representation of a pointer as a pair (type, address).*/
-    struct Pointer
-    {
-      /** Build from an pointer*/
-      template<typename T> Pointer(T* p);
-
-      /** Build from a pair (type, address).*/
-      Pointer(const std::type_index& t, std::uintptr_t v);
-
-      std::type_index type;   // representation of the pointer type
-      std::uintptr_t  value;  // address of the pointer
-
-      bool operator<(const Pointer& other) const { return lexLess(*this, other, &Pointer::value); }
-      bool operator==(const Pointer& other) const { return eq(*this, other, &Pointer::value); }
-    };
-
-    /** Description of an update. */
-    struct Update
-    {
-      EnumValue id;             //id of the update
-      std::string name;         //name of the update
-      std::uintptr_t function;  //address of the update function
-      Pointer owner;            //address of the instance registering the update
-      bool operator<(const Update& other) const { return lexLess(*this, other, &Update::owner, &Update::id, &Update::function); }
-      bool operator==(const Update& other) const { return eq(*this, other, &Update::owner, &Update::id, &Update::function); }
-    };
-
-    /** Description of an output. */
-    struct Output
-    {
-      EnumValue id;             //id of the output
-      std::string name;         //name of the output
-      Pointer owner;            //address of the instance registering the output
-      bool operator<(const Output& other) const { return lexLess(*this, other, &Output::owner, &Output::id); }
-      bool operator==(const Output& other) const { return eq(*this, other, &Output::owner, &Output::id); }
-    };
-
-    /** Description of an input. */
-    struct Input
-    {
-      EnumValue id;             //id of the input
-      std::string name;         //name of the input
-      Pointer source;           //address of the instance providing the input
-      Pointer owner;            //address of the instance registering the input
-      bool operator<(const Input& other) const { return lexLess(*this, other, &Input::owner, &Input::id, &Input::source); }
-      bool operator==(const Input& other) const { return eq(*this, other, &Input::owner, &Input::id, &Input::source); }
-    };
-
-    /** Description of an input->update dependency. */
-    struct InputDependency
-    {
-      EnumValue input;          //the input
-      EnumValue update;         //the update
-      Pointer source;           //address of the instance providing the input
-      Pointer owner;            //address of the instance registering the dependency
-      bool operator<(const InputDependency& other) const { return lexLess(*this, other, &InputDependency::owner, &InputDependency::update, &InputDependency::source, &InputDependency::input); }
-      bool operator==(const InputDependency& other) const { return eq(*this, other, &InputDependency::owner, &InputDependency::update, &InputDependency::source, &InputDependency::input); }
-    };
-
-    /** Description of an update->output dependency. */
-    struct OutputDependency
-    {
-      EnumValue update;         //the update
-      EnumValue output;         //the output
-      Pointer owner;            //address of the instance registering the dependency
-      bool operator<(const OutputDependency& other) const { return lexLess(*this, other, &OutputDependency::owner, &OutputDependency::update, &OutputDependency::output); }
-      bool operator==(const OutputDependency& other) const { return eq(*this, other, &OutputDependency::owner, &OutputDependency::update, &OutputDependency::output); }
-    };
-
-    /** Description of an update->update dependency. */
-    struct InternalDependency
-    {
-      EnumValue from;           //the update depended upon
-      EnumValue to;             //the depending update
-      Pointer owner;            //address of the instance registering the dependency
-      bool operator<(const InternalDependency& other) const { return lexLess(*this, other, &InternalDependency::owner, &InternalDependency::from, &InternalDependency::to); }
-      bool operator==(const InternalDependency& other) const { return eq(*this, other, &InternalDependency::owner, &InternalDependency::from, &InternalDependency::to); }
-    };
-
-    /** Description of an input->output dependency. */
-    struct DirectDependency
-    {
-      EnumValue input;          //the input
-      EnumValue output;         //the output
-      Pointer source;           //address of the instance providing the input
-      Pointer owner;            //address of the instance registering the dependency
-      bool operator<(const DirectDependency& other) const { return lexLess(*this, other, &DirectDependency::owner, &DirectDependency::output, &DirectDependency::source, &DirectDependency::input); }
-      bool operator==(const DirectDependency& other) const { return eq(*this, other, &DirectDependency::owner, &DirectDependency::output, &DirectDependency::source, &DirectDependency::input); }
-    };
-
-    /** Generate a dot representation for node corresponding to p.*/
-    std::string generateDot(const Pointer& p) const;
-
-    /** Generate the specified CallGraph. */
-    std::string generateDot(const CallGraph* const g) const;
-
-    /** Generate the whole graph, highlighting the eleements specified by
-      * oUtHighlight and upHightlight.
-      */
-    std::string generateDot(const std::vector<Log::Output>& outHighlight = {}, const std::vector<Log::Update>& upHighlight = {}) const;
-
-    //raw logs
-    std::vector<Update> updates_;
-    std::vector<Input> inputs_;
-    std::vector<Output> outputs_;
-    std::vector<InputDependency> inputDependencies_;
-    std::vector<OutputDependency> outputDependencies_;
-    std::vector<InternalDependency> internalDependencies_;
-    std::vector<DirectDependency> directDependencies_;
-
-    /** Each elements of the map is the list of inputs of a CallGraph, as added
-      * in CallGraph.add
-      */
-    std::map<Pointer, std::vector<Pointer>> graphOutputs_;  
-
-    /** Maps a data address to all the type info associated with this address.
-      * For a given address, each type appears only once, and types are sorted in
-      * their order of appearance in the logging process. We assume that the
-      * last one to appear is the most derived in the inheritance hierarchy.
-      *
-      * FIXME: can we find a more robust way to determine the real type of a
-      * data?
-      */
-    std::map<std::uintptr_t, std::vector<std::type_index>> types_;
-
-    private:
-      /** Generate a (unique) name for the given output, based on its name, and
-        * the class and memory address of its owner.
-        */
-      std::string nodeName(const Log::Output& output) const;
-      /** Generate a (unique) name for the given input, based on its name, and
-        * the class and memory address of the source.
-        */
-      std::string nodeName(const Log::Input& input) const;
-      /** Generate a (unique) name for the given update, based on its name, and
-        * the class and memory address of its owner.
-        */
-      std::string nodeName(const Log::Update& update) const;
+    bool operator<(const EnumValue & other) const { return lexLess(*this, other, &EnumValue::type, &EnumValue::value); }
+    bool operator==(const EnumValue & other) const { return eq(*this, other, &EnumValue::type, &EnumValue::value); }
   };
 
-
-  template<typename E>
-  inline Log::EnumValue::EnumValue(E e)
-    : type(typeid(e)), value(static_cast<int>(e))
+  /** A type-independent representation of a pointer as a pair (type, address).*/
+  struct Pointer
   {
-    static_assert(std::is_enum<E>::value, "EnumValue can only be defined for enums.");
-  }
+    /** Build from an pointer*/
+    template<typename T>
+    Pointer(T * p);
 
-  template<typename T>
-  inline Log::Pointer::Pointer(T* p)
-    : type(typeid(*p))
-    , value(reinterpret_cast<std::uintptr_t>(p))
-  {
-  }
+    /** Build from a pair (type, address).*/
+    Pointer(const std::type_index & t, std::uintptr_t v);
 
-  inline Log::Pointer::Pointer(const std::type_index& t, std::uintptr_t v)
-    : type(t), value(v)
+    std::type_index type; // representation of the pointer type
+    std::uintptr_t value; // address of the pointer
+
+    bool operator<(const Pointer & other) const { return lexLess(*this, other, &Pointer::value); }
+    bool operator==(const Pointer & other) const { return eq(*this, other, &Pointer::value); }
+  };
+
+  /** Description of an update. */
+  struct Update
   {
-  }
+    EnumValue id; // id of the update
+    std::string name; // name of the update
+    std::uintptr_t function; // address of the update function
+    Pointer owner; // address of the instance registering the update
+    bool operator<(const Update & other) const
+    {
+      return lexLess(*this, other, &Update::owner, &Update::id, &Update::function);
+    }
+    bool operator==(const Update & other) const
+    {
+      return eq(*this, other, &Update::owner, &Update::id, &Update::function);
+    }
+  };
+
+  /** Description of an output. */
+  struct Output
+  {
+    EnumValue id; // id of the output
+    std::string name; // name of the output
+    Pointer owner; // address of the instance registering the output
+    bool operator<(const Output & other) const { return lexLess(*this, other, &Output::owner, &Output::id); }
+    bool operator==(const Output & other) const { return eq(*this, other, &Output::owner, &Output::id); }
+  };
+
+  /** Description of an input. */
+  struct Input
+  {
+    EnumValue id; // id of the input
+    std::string name; // name of the input
+    Pointer source; // address of the instance providing the input
+    Pointer owner; // address of the instance registering the input
+    bool operator<(const Input & other) const
+    {
+      return lexLess(*this, other, &Input::owner, &Input::id, &Input::source);
+    }
+    bool operator==(const Input & other) const { return eq(*this, other, &Input::owner, &Input::id, &Input::source); }
+  };
+
+  /** Description of an input->update dependency. */
+  struct InputDependency
+  {
+    EnumValue input; // the input
+    EnumValue update; // the update
+    Pointer source; // address of the instance providing the input
+    Pointer owner; // address of the instance registering the dependency
+    bool operator<(const InputDependency & other) const
+    {
+      return lexLess(*this, other, &InputDependency::owner, &InputDependency::update, &InputDependency::source,
+                     &InputDependency::input);
+    }
+    bool operator==(const InputDependency & other) const
+    {
+      return eq(*this, other, &InputDependency::owner, &InputDependency::update, &InputDependency::source,
+                &InputDependency::input);
+    }
+  };
+
+  /** Description of an update->output dependency. */
+  struct OutputDependency
+  {
+    EnumValue update; // the update
+    EnumValue output; // the output
+    Pointer owner; // address of the instance registering the dependency
+    bool operator<(const OutputDependency & other) const
+    {
+      return lexLess(*this, other, &OutputDependency::owner, &OutputDependency::update, &OutputDependency::output);
+    }
+    bool operator==(const OutputDependency & other) const
+    {
+      return eq(*this, other, &OutputDependency::owner, &OutputDependency::update, &OutputDependency::output);
+    }
+  };
+
+  /** Description of an update->update dependency. */
+  struct InternalDependency
+  {
+    EnumValue from; // the update depended upon
+    EnumValue to; // the depending update
+    Pointer owner; // address of the instance registering the dependency
+    bool operator<(const InternalDependency & other) const
+    {
+      return lexLess(*this, other, &InternalDependency::owner, &InternalDependency::from, &InternalDependency::to);
+    }
+    bool operator==(const InternalDependency & other) const
+    {
+      return eq(*this, other, &InternalDependency::owner, &InternalDependency::from, &InternalDependency::to);
+    }
+  };
+
+  /** Description of an input->output dependency. */
+  struct DirectDependency
+  {
+    EnumValue input; // the input
+    EnumValue output; // the output
+    Pointer source; // address of the instance providing the input
+    Pointer owner; // address of the instance registering the dependency
+    bool operator<(const DirectDependency & other) const
+    {
+      return lexLess(*this, other, &DirectDependency::owner, &DirectDependency::output, &DirectDependency::source,
+                     &DirectDependency::input);
+    }
+    bool operator==(const DirectDependency & other) const
+    {
+      return eq(*this, other, &DirectDependency::owner, &DirectDependency::output, &DirectDependency::source,
+                &DirectDependency::input);
+    }
+  };
+
+  /** Generate a dot representation for node corresponding to p.*/
+  std::string generateDot(const Pointer & p) const;
+
+  /** Generate the specified CallGraph. */
+  std::string generateDot(const CallGraph * const g) const;
+
+  /** Generate the whole graph, highlighting the eleements specified by
+   * oUtHighlight and upHightlight.
+   */
+  std::string generateDot(const std::vector<Log::Output> & outHighlight = {},
+                          const std::vector<Log::Update> & upHighlight = {}) const;
+
+  // raw logs
+  std::vector<Update> updates_;
+  std::vector<Input> inputs_;
+  std::vector<Output> outputs_;
+  std::vector<InputDependency> inputDependencies_;
+  std::vector<OutputDependency> outputDependencies_;
+  std::vector<InternalDependency> internalDependencies_;
+  std::vector<DirectDependency> directDependencies_;
+
+  /** Each elements of the map is the list of inputs of a CallGraph, as added
+   * in CallGraph.add
+   */
+  std::map<Pointer, std::vector<Pointer>> graphOutputs_;
+
+  /** Maps a data address to all the type info associated with this address.
+   * For a given address, each type appears only once, and types are sorted in
+   * their order of appearance in the logging process. We assume that the
+   * last one to appear is the most derived in the inheritance hierarchy.
+   *
+   * FIXME: can we find a more robust way to determine the real type of a
+   * data?
+   */
+  std::map<std::uintptr_t, std::vector<std::type_index>> types_;
+
+private:
+  /** Generate a (unique) name for the given output, based on its name, and
+   * the class and memory address of its owner.
+   */
+  std::string nodeName(const Log::Output & output) const;
+  /** Generate a (unique) name for the given input, based on its name, and
+   * the class and memory address of the source.
+   */
+  std::string nodeName(const Log::Input & input) const;
+  /** Generate a (unique) name for the given update, based on its name, and
+   * the class and memory address of its owner.
+   */
+  std::string nodeName(const Log::Update & update) const;
+};
+
+template<typename E>
+inline Log::EnumValue::EnumValue(E e) : type(typeid(e)), value(static_cast<int>(e))
+{
+  static_assert(std::is_enum<E>::value, "EnumValue can only be defined for enums.");
+}
+
+template<typename T>
+inline Log::Pointer::Pointer(T * p) : type(typeid(*p)), value(reinterpret_cast<std::uintptr_t>(p))
+{
+}
+
+inline Log::Pointer::Pointer(const std::type_index & t, std::uintptr_t v) : type(t), value(v) {}
 
 } // namespace internal
 
-}  //namespace graph
+} // namespace graph
 
 } // namespace tvm

--- a/include/tvm/graph/internal/Logger.h
+++ b/include/tvm/graph/internal/Logger.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/graph/internal/Log.h>
 
 #include <algorithm>

--- a/include/tvm/graph/internal/Logger.h
+++ b/include/tvm/graph/internal/Logger.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/graph/internal/Logger.h
+++ b/include/tvm/graph/internal/Logger.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,181 +38,167 @@
 
 namespace tvm
 {
-  
+
 namespace graph
 {
 class CallGraph;
-namespace abstract { class Outputs; }
+namespace abstract
+{
+class Outputs;
+}
 
 namespace internal
 {
-  class Inputs;
+class Inputs;
 
-  class TVM_DLLAPI Logger
-  {
-  public:
-    static Logger& logger();
-    
-    void disable();
-    void enable();
+class TVM_DLLAPI Logger
+{
+public:
+  static Logger & logger();
 
-    const Log& log() const;
+  void disable();
+  void enable();
 
-    template<typename U, typename EnumT>
-    void registerUpdate(U* node, EnumT u, void(U::*fn)());
-
-    template<typename S, typename EnumO>
-    void addInput(Inputs* node, S* source, EnumO i);
-
-    template<typename U, typename EnumO, typename EnumU>
-    void addOutputDependency(U* node, EnumO o, EnumU u);
-
-    template<typename U, typename EnumU1, typename EnumU2>
-    void addInternalDependency(U* node, EnumU1 uDependent, EnumU2 u);
-
-    template<typename U, typename EnumU, typename S, typename EnumO>
-    void addInputDependency(U* node, EnumU u, S* source, EnumO i);
-
-    template<typename U, typename EnumO, typename S, typename EnumI>
-    void addDirectDependency(U* node, EnumO o, S* source, EnumI i);
-
-    void addGraphOutput(CallGraph* g, Inputs* node);
-
-    /** Register the type associated to a pointer. */
-    template<typename U>
-    void registerType(U* node);
-
-    template<typename U>
-    void logCall(U* node, void(U::*fn)());
-
-  private:
-    Logger() = default;
-    
-    //raw log
-    Log log_;
-    bool disabled_;
-  };
-
-  //Helper function for pointer-to-member-function
-  template <typename T>
-  std::uintptr_t getPointerValue(void (T::*ptfm)())
-  {
-    auto cptr = reinterpret_cast<std::uintptr_t*>(&ptfm);
-    return *cptr;
-  }
-
-  inline const Log& Logger::log() const
-  {
-    return log_;
-  }
+  const Log & log() const;
 
   template<typename U, typename EnumT>
-  inline void Logger::registerUpdate(U* node, EnumT u, void(U::* fn)())
-  {
-    if (disabled_) return;
-
-    Log::Update up{ Log::EnumValue(u),
-                   U::UpdateName(u),
-                   getPointerValue<U>(fn),
-                   Log::Pointer(node) };
-    log_.updates_.push_back(up);
-    registerType(node);
-  }
+  void registerUpdate(U * node, EnumT u, void (U::*fn)());
 
   template<typename S, typename EnumO>
-  inline void Logger::addInput(Inputs* node, S* source, EnumO i)
-  {
-    if (disabled_) return;
-    
-    Log::Input in = { Log::EnumValue(i),
-                     S::OutputName(i),
-                     Log::Pointer(source),
-                     Log::Pointer(node) };
-    log_.inputs_.push_back(in);
-    registerType(node);
-    registerType(source);
-  }
+  void addInput(Inputs * node, S * source, EnumO i);
 
   template<typename U, typename EnumO, typename EnumU>
-  inline void Logger::addOutputDependency(U* node, EnumO o, EnumU u)
-  {
-    if (disabled_) return;
-    
-    Log::Output out = { Log::EnumValue(o),
-                       U::OutputName(o),
-                       Log::Pointer(node) };
-    log_.outputs_.push_back(out);
-
-    Log::OutputDependency dep = { Log::EnumValue(u),
-                                 Log::EnumValue(o),
-                                 Log::Pointer(node) };
-    log_.outputDependencies_.push_back(dep);
-    registerType(node);
-  }
-
+  void addOutputDependency(U * node, EnumO o, EnumU u);
 
   template<typename U, typename EnumU1, typename EnumU2>
-  inline void Logger::addInternalDependency(U* node, EnumU1 uDependent, EnumU2 u)
-  {
-    if (disabled_) return;
-    
-    Log::InternalDependency dep = { Log::EnumValue(u),
-                                   Log::EnumValue(uDependent),
-                                   Log::Pointer(node) };
-    log_.internalDependencies_.push_back(dep);
-    registerType(node);
-  }
+  void addInternalDependency(U * node, EnumU1 uDependent, EnumU2 u);
 
   template<typename U, typename EnumU, typename S, typename EnumO>
-  inline void Logger::addInputDependency(U* node, EnumU u, S* source, EnumO i)
-  {
-    if (disabled_) return;
-    
-    Log::InputDependency dep = { Log::EnumValue(i),
-                                Log::EnumValue(u),
-                                Log::Pointer(source),
-                                Log::Pointer(node) };
-    log_.inputDependencies_.push_back(dep);
-    registerType(node);
-    registerType(source);
-  }
+  void addInputDependency(U * node, EnumU u, S * source, EnumO i);
 
   template<typename U, typename EnumO, typename S, typename EnumI>
-  inline void Logger::addDirectDependency(U* node, EnumO o, S* source, EnumI i)
-  {
-    if (disabled_) return;
+  void addDirectDependency(U * node, EnumO o, S * source, EnumI i);
 
-    Log::Output out = { Log::EnumValue(o),
-                       U::OutputName(o),
-                       Log::Pointer(node) };
-    log_.outputs_.push_back(out);
+  void addGraphOutput(CallGraph * g, Inputs * node);
 
-    Log::DirectDependency dep = { Log::EnumValue(i),
-                                 Log::EnumValue(o),
-                                 Log::Pointer(source),
-                                 Log::Pointer(node) };
-    log_.directDependencies_.push_back(dep);
-    registerType(node);
-    registerType(source);
-  }
+  /** Register the type associated to a pointer. */
+  template<typename U>
+  void registerType(U * node);
 
   template<typename U>
-  inline void Logger::registerType(U* node)
+  void logCall(U * node, void (U::*fn)());
+
+private:
+  Logger() = default;
+
+  // raw log
+  Log log_;
+  bool disabled_;
+};
+
+// Helper function for pointer-to-member-function
+template<typename T>
+std::uintptr_t getPointerValue(void (T::*ptfm)())
+{
+  auto cptr = reinterpret_cast<std::uintptr_t *>(&ptfm);
+  return *cptr;
+}
+
+inline const Log & Logger::log() const { return log_; }
+
+template<typename U, typename EnumT>
+inline void Logger::registerUpdate(U * node, EnumT u, void (U::*fn)())
+{
+  if(disabled_)
+    return;
+
+  Log::Update up{Log::EnumValue(u), U::UpdateName(u), getPointerValue<U>(fn), Log::Pointer(node)};
+  log_.updates_.push_back(up);
+  registerType(node);
+}
+
+template<typename S, typename EnumO>
+inline void Logger::addInput(Inputs * node, S * source, EnumO i)
+{
+  if(disabled_)
+    return;
+
+  Log::Input in = {Log::EnumValue(i), S::OutputName(i), Log::Pointer(source), Log::Pointer(node)};
+  log_.inputs_.push_back(in);
+  registerType(node);
+  registerType(source);
+}
+
+template<typename U, typename EnumO, typename EnumU>
+inline void Logger::addOutputDependency(U * node, EnumO o, EnumU u)
+{
+  if(disabled_)
+    return;
+
+  Log::Output out = {Log::EnumValue(o), U::OutputName(o), Log::Pointer(node)};
+  log_.outputs_.push_back(out);
+
+  Log::OutputDependency dep = {Log::EnumValue(u), Log::EnumValue(o), Log::Pointer(node)};
+  log_.outputDependencies_.push_back(dep);
+  registerType(node);
+}
+
+template<typename U, typename EnumU1, typename EnumU2>
+inline void Logger::addInternalDependency(U * node, EnumU1 uDependent, EnumU2 u)
+{
+  if(disabled_)
+    return;
+
+  Log::InternalDependency dep = {Log::EnumValue(u), Log::EnumValue(uDependent), Log::Pointer(node)};
+  log_.internalDependencies_.push_back(dep);
+  registerType(node);
+}
+
+template<typename U, typename EnumU, typename S, typename EnumO>
+inline void Logger::addInputDependency(U * node, EnumU u, S * source, EnumO i)
+{
+  if(disabled_)
+    return;
+
+  Log::InputDependency dep = {Log::EnumValue(i), Log::EnumValue(u), Log::Pointer(source), Log::Pointer(node)};
+  log_.inputDependencies_.push_back(dep);
+  registerType(node);
+  registerType(source);
+}
+
+template<typename U, typename EnumO, typename S, typename EnumI>
+inline void Logger::addDirectDependency(U * node, EnumO o, S * source, EnumI i)
+{
+  if(disabled_)
+    return;
+
+  Log::Output out = {Log::EnumValue(o), U::OutputName(o), Log::Pointer(node)};
+  log_.outputs_.push_back(out);
+
+  Log::DirectDependency dep = {Log::EnumValue(i), Log::EnumValue(o), Log::Pointer(source), Log::Pointer(node)};
+  log_.directDependencies_.push_back(dep);
+  registerType(node);
+  registerType(source);
+}
+
+template<typename U>
+inline void Logger::registerType(U * node)
+{
+  if(disabled_)
+    return;
+
+  std::type_index t(typeid(*node));
+  std::uintptr_t val = reinterpret_cast<std::uintptr_t>(node);
+  auto & types = log_.types_[val];
+  auto it = std::find(types.begin(), types.end(), t);
+  if(it == types.end())
   {
-    if (disabled_) return;
-    
-    std::type_index t(typeid(*node));
-    std::uintptr_t val = reinterpret_cast<std::uintptr_t>(node);
-    auto& types = log_.types_[val];
-    auto it = std::find(types.begin(), types.end(), t);
-    if (it == types.end())
-    {
-      types.push_back(t);
-    }
+    types.push_back(t);
   }
+}
 
 } // namespace internal
 
-}  //namespace graph
+} // namespace graph
 
 } // namespace tvm

--- a/include/tvm/hint/Substitution.h
+++ b/include/tvm/hint/Substitution.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -43,111 +43,119 @@ namespace tvm
 namespace hint
 {
 
-  namespace abstract
-  {
-    class SubstitutionCalculatorImpl;
-  }
-
-  /** Hint for a substitution that could be done by the solver.
-    * A substitution is a set of variables and a set of constraints used to
-    * presolve them, which allow to effectively removing them from the problem.
-    */
-  class TVM_DLLAPI Substitution
-  {
-  public:
-    /** Constructor for a single constraint and a single variable
-      * \param cstr The constraint used for the substitution.
-      * \param x The variable to substitute.
-      * \param rank the rank of the matrix multiplying \p x. By default it is
-      * the row size of this matrix.
-      * \param calc A class that performs matrix operations related to the
-      * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
-      * tvm::hint::abstract::SubstitutionCalculatorImpl 
-      *
-      * \attention Rank matters and is supposed to be fixed. This is because it
-      * is influencing the size of other matrices in the problem. However, the
-      * matrix doesn't need to be full rank.
-      */
-    Substitution(LinearConstraintPtr cstr, VariablePtr x, int rank = constant::fullRank, 
-                 const abstract::SubstitutionCalculator& calc = internal::AutoCalculator());
-    /** Constructor for a set of constraints and a single variable
-      * \param cstr The set of constraints used for the substitution.
-      * \param x The variable to substitute.
-      * \param rank the rank of the matrix multiplying \p x obtained by stacking
-      * the matrices in factor of \p x in each constraint. By default it is
-      * the row size of this matrix.
-      * \param calc A class that performs matrix operations related to the
-      * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
-      * tvm::hint::abstract::SubstitutionCalculatorImpl 
-      *
-      * \attention Rank matters and is supposed to be fixed. This is because it
-      * is influencing the size of other matrices in the problem. However, the
-      * matrix doesn't need to be full rank.
-      */
-    Substitution(const std::vector<LinearConstraintPtr>& cstr, VariablePtr x, int rank = constant::fullRank,
-                 const abstract::SubstitutionCalculator& calc = internal::AutoCalculator());
-    /** Constructor for a single constraint and a set of variables
-      * \param cstr The constraint used for the substitution.
-      * \param x The set variables to substitute.
-      * \param rank the rank of the matrices multiplying \p x obtained by
-      * concatening the matrices in front of each \p xi. By default it is
-      * the row size of this matrix.
-      * \param calc A class that performs matrix operations related to the
-      * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
-      * tvm::hint::abstract::SubstitutionCalculatorImpl 
-      *
-      * \attention Rank matters and is supposed to be fixed. This is because it
-      * is influencing the size of other matrices in the problem. However, the
-      * matrix doesn't need to be full rank.
-      */
-    Substitution(LinearConstraintPtr cstr, std::vector<VariablePtr>& x, int rank = constant::fullRank,
-                 const abstract::SubstitutionCalculator& calc = internal::AutoCalculator());
-    /** Constructor for a set of constraints and a set of variables
-      * \param cstr The set of constraints used for the substitution.
-      * \param x The set variables to substitute.
-      * \param rank the rank of the matrix multiplying \p x, i.e the agreggation
-      * of all the matrices in front of the \p xi in all the constraints. By
-      * default, it is the row size of this matrix.
-      * \param calc A class that performs matrix operations related to the
-      * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
-      * tvm::hint::abstract::SubstitutionCalculatorImpl 
-      *
-      * \attention Rank matters and is supposed to be fixed. This is because it
-      * is influencing the size of other matrices in the problem. However, the
-      * matrix doesn't need to be full rank.
-      */
-    Substitution(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank = constant::fullRank,
-                 const abstract::SubstitutionCalculator& calc = internal::AutoCalculator());
-
-    /** The rank of the matrix multiplying \p x.*/
-    int rank() const;
-    /** The total (row) size of the constraints.*/
-    int m() const;
-    /** The set of constraints used in the substitution.*/
-    const std::vector<LinearConstraintPtr>& constraints() const;
-    /** The set of variables to substitute*/
-    const std::vector<VariablePtr>& variables() const;
-    /** Return \p true is this subsitution is based on a single constraint and
-      * a single variable.
-      */
-    bool isSimple() const;
-
-    /** Return the calculator used by this substitution.*/
-    std::shared_ptr<abstract::SubstitutionCalculatorImpl> calculator() const;
-
-  private:
-    /** Check the validity and coherence of the parameters passed to the
-      * constructor.
-      */
-    void check() const;
-
-    int rank_;
-    int m_;
-    std::vector<LinearConstraintPtr> constraints_;
-    std::vector<VariablePtr> x_;
-
-    std::shared_ptr<abstract::SubstitutionCalculatorImpl> calculator_;
-  };
+namespace abstract
+{
+class SubstitutionCalculatorImpl;
 }
 
-}
+/** Hint for a substitution that could be done by the solver.
+ * A substitution is a set of variables and a set of constraints used to
+ * presolve them, which allow to effectively removing them from the problem.
+ */
+class TVM_DLLAPI Substitution
+{
+public:
+  /** Constructor for a single constraint and a single variable
+   * \param cstr The constraint used for the substitution.
+   * \param x The variable to substitute.
+   * \param rank the rank of the matrix multiplying \p x. By default it is
+   * the row size of this matrix.
+   * \param calc A class that performs matrix operations related to the
+   * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
+   * tvm::hint::abstract::SubstitutionCalculatorImpl
+   *
+   * \attention Rank matters and is supposed to be fixed. This is because it
+   * is influencing the size of other matrices in the problem. However, the
+   * matrix doesn't need to be full rank.
+   */
+  Substitution(LinearConstraintPtr cstr,
+               VariablePtr x,
+               int rank = constant::fullRank,
+               const abstract::SubstitutionCalculator & calc = internal::AutoCalculator());
+  /** Constructor for a set of constraints and a single variable
+   * \param cstr The set of constraints used for the substitution.
+   * \param x The variable to substitute.
+   * \param rank the rank of the matrix multiplying \p x obtained by stacking
+   * the matrices in factor of \p x in each constraint. By default it is
+   * the row size of this matrix.
+   * \param calc A class that performs matrix operations related to the
+   * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
+   * tvm::hint::abstract::SubstitutionCalculatorImpl
+   *
+   * \attention Rank matters and is supposed to be fixed. This is because it
+   * is influencing the size of other matrices in the problem. However, the
+   * matrix doesn't need to be full rank.
+   */
+  Substitution(const std::vector<LinearConstraintPtr> & cstr,
+               VariablePtr x,
+               int rank = constant::fullRank,
+               const abstract::SubstitutionCalculator & calc = internal::AutoCalculator());
+  /** Constructor for a single constraint and a set of variables
+   * \param cstr The constraint used for the substitution.
+   * \param x The set variables to substitute.
+   * \param rank the rank of the matrices multiplying \p x obtained by
+   * concatening the matrices in front of each \p xi. By default it is
+   * the row size of this matrix.
+   * \param calc A class that performs matrix operations related to the
+   * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
+   * tvm::hint::abstract::SubstitutionCalculatorImpl
+   *
+   * \attention Rank matters and is supposed to be fixed. This is because it
+   * is influencing the size of other matrices in the problem. However, the
+   * matrix doesn't need to be full rank.
+   */
+  Substitution(LinearConstraintPtr cstr,
+               std::vector<VariablePtr> & x,
+               int rank = constant::fullRank,
+               const abstract::SubstitutionCalculator & calc = internal::AutoCalculator());
+  /** Constructor for a set of constraints and a set of variables
+   * \param cstr The set of constraints used for the substitution.
+   * \param x The set variables to substitute.
+   * \param rank the rank of the matrix multiplying \p x, i.e the agreggation
+   * of all the matrices in front of the \p xi in all the constraints. By
+   * default, it is the row size of this matrix.
+   * \param calc A class that performs matrix operations related to the
+   * substitution \sa tvm::hint::abstract::SubstitutionCalculator,
+   * tvm::hint::abstract::SubstitutionCalculatorImpl
+   *
+   * \attention Rank matters and is supposed to be fixed. This is because it
+   * is influencing the size of other matrices in the problem. However, the
+   * matrix doesn't need to be full rank.
+   */
+  Substitution(const std::vector<LinearConstraintPtr> & cstr,
+               const std::vector<VariablePtr> & x,
+               int rank = constant::fullRank,
+               const abstract::SubstitutionCalculator & calc = internal::AutoCalculator());
+
+  /** The rank of the matrix multiplying \p x.*/
+  int rank() const;
+  /** The total (row) size of the constraints.*/
+  int m() const;
+  /** The set of constraints used in the substitution.*/
+  const std::vector<LinearConstraintPtr> & constraints() const;
+  /** The set of variables to substitute*/
+  const std::vector<VariablePtr> & variables() const;
+  /** Return \p true is this subsitution is based on a single constraint and
+   * a single variable.
+   */
+  bool isSimple() const;
+
+  /** Return the calculator used by this substitution.*/
+  std::shared_ptr<abstract::SubstitutionCalculatorImpl> calculator() const;
+
+private:
+  /** Check the validity and coherence of the parameters passed to the
+   * constructor.
+   */
+  void check() const;
+
+  int rank_;
+  int m_;
+  std::vector<LinearConstraintPtr> constraints_;
+  std::vector<VariablePtr> x_;
+
+  std::shared_ptr<abstract::SubstitutionCalculatorImpl> calculator_;
+};
+} // namespace hint
+
+} // namespace tvm

--- a/include/tvm/hint/Substitution.h
+++ b/include/tvm/hint/Substitution.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/abstract/SubstitutionCalculator.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculator.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/abstract/SubstitutionCalculator.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculator.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/hint/abstract/SubstitutionCalculatorImpl.h>
 
 #include <memory>

--- a/include/tvm/hint/abstract/SubstitutionCalculator.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculator.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -44,25 +44,28 @@ namespace hint
 
 namespace abstract
 {
-  /** A SubstitutionCalculator is a lightweight factory that can generates a
-    * SubstitutionCalculatorImpl.
-    * It is used to specify custom operations to be made during the substitution
-    * process.
-    */
-  class TVM_DLLAPI SubstitutionCalculator
-  {
-  public:
-    virtual ~SubstitutionCalculator() = default;
+/** A SubstitutionCalculator is a lightweight factory that can generates a
+ * SubstitutionCalculatorImpl.
+ * It is used to specify custom operations to be made during the substitution
+ * process.
+ */
+class TVM_DLLAPI SubstitutionCalculator
+{
+public:
+  virtual ~SubstitutionCalculator() = default;
 
-    std::unique_ptr<SubstitutionCalculatorImpl> impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const;
+  std::unique_ptr<SubstitutionCalculatorImpl> impl(const std::vector<LinearConstraintPtr> & cstr,
+                                                   const std::vector<VariablePtr> & x,
+                                                   int rank) const;
 
-  protected:
-    virtual std::unique_ptr<SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const = 0;
+protected:
+  virtual std::unique_ptr<SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr> & cstr,
+                                                            const std::vector<VariablePtr> & x,
+                                                            int rank) const = 0;
+};
 
-  };
+} // namespace abstract
 
-} // internal
+} // namespace hint
 
-} // hint
-
-} // tvm
+} // namespace tvm

--- a/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include <tvm/Range.h>
-#include <tvm/VariableVector.h>
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
+#include <tvm/Range.h>
+#include <tvm/VariableVector.h>
 
 #include <vector>
 

--- a/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
@@ -1,38 +1,38 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
+#include <tvm/Range.h>
+#include <tvm/VariableVector.h>
 #include <tvm/api.h>
 #include <tvm/defs.h>
-#include <tvm/VariableVector.h>
-#include <tvm/Range.h>
 
 #include <vector>
 
@@ -44,133 +44,126 @@ namespace hint
 
 namespace abstract
 {
-  /** Given a set of variables aggregated as \p x, and a set of constraints
-    * that, once aggregated, writes A x + ..., this base class proposes a set of
-    * operations related to A that are useful for performing substitutions.
-    * The operations revolve around 3 matrices:
-    *  - A^#, a generalize inverse of A (i.e. a matrix such that A A^# A = A)
-    *  - N, a basis of the nullspace of A. It does not need to be orthonormal.
-    *  - S, a basis of the nullspace of A^T. It does not need to be orthonormal.
-    *
-    * The choice of A^#, N and S is implemented by derivation of this base class.
-    * A generic implementation is given by GenericCalculator::Impl
-    */
-  class TVM_DLLAPI SubstitutionCalculatorImpl
+/** Given a set of variables aggregated as \p x, and a set of constraints
+ * that, once aggregated, writes A x + ..., this base class proposes a set of
+ * operations related to A that are useful for performing substitutions.
+ * The operations revolve around 3 matrices:
+ *  - A^#, a generalize inverse of A (i.e. a matrix such that A A^# A = A)
+ *  - N, a basis of the nullspace of A. It does not need to be orthonormal.
+ *  - S, a basis of the nullspace of A^T. It does not need to be orthonormal.
+ *
+ * The choice of A^#, N and S is implemented by derivation of this base class.
+ * A generic implementation is given by GenericCalculator::Impl
+ */
+class TVM_DLLAPI SubstitutionCalculatorImpl
+{
+public:
+  virtual ~SubstitutionCalculatorImpl() = default;
+  /** Update the internal computations based on the current value of A, i.e
+   * the current values of the constraints' jacobian matrices.
+   */
+  void update();
+  /** If \minus = \false, perform \p outA = A^# * \p in and \p outS = S^T * \p in
+   * otherwise perform \p outA = - A^# * \p in and \p outS = S^T * \p in
+   */
+  void premultiplyByASharpAndSTranspose(MatrixRef outA, MatrixRef outS, const MatrixConstRef & in, bool minus) const;
+  /** Compute \p out = \p in * \p N.
+   * If \p add is \p true, perform \p out += \p in * \p N instead.
+   */
+  void postMultiplyByN(MatrixRef out, const MatrixConstRef & in, bool add = false) const;
+  /** Compute \p out = \p in * \p N(r,:).
+   * If \p add is \p true, perform \p out += \p in * \p N(r,:) instead.
+   */
+  void postMultiplyByN(MatrixRef out, const MatrixConstRef & in, Range r, bool add = false) const;
+  /** Return N as a dense matrix.*/
+  const Eigen::MatrixXd & N() const;
+
+  /** Number of lines of A (i.e. sum of the constraints' sizes.*/
+  Eigen::DenseIndex m() const;
+  /** Size of x (i.e. sum of the size of the variables to be substituted.*/
+  Eigen::DenseIndex n() const;
+  /** Rank of A*/
+  Eigen::DenseIndex r() const;
+
+protected:
+  /** Constructor
+   * \param cstr the list of constraints
+   * \param x the list of variables
+   * \param rank the rank of A
+   */
+  SubstitutionCalculatorImpl(const std::vector<LinearConstraintPtr> & cstr,
+                             const std::vector<VariablePtr> & x,
+                             int rank);
+
+  /** Specify wheter A is constant (in which case only the first update will
+   * actually perform computations.
+   */
+  void constant(bool c);
+  /** Return wheter A is constant*/
+  bool constant() const;
+
+  /** Return the matrix A*/
+  const Eigen::MatrixXd & A() const;
+
+  /** Return true if there is only one variable and one constraint*/
+  bool isSimple() const;
+
+  /** Handle for the derived class to perform the computations in update()*/
+  virtual void update_() = 0;
+  /** Computations for premultiplyByASharpAndSTranspose()*/
+  virtual void premultiplyByASharpAndSTranspose_(MatrixRef outA,
+                                                 MatrixRef outS,
+                                                 const MatrixConstRef & in,
+                                                 bool minus) const = 0;
+  /** Computations for postMultiplyByN()*/
+  virtual void postMultiplyByN_(MatrixRef out, const MatrixConstRef & in, bool add) const;
+  /** Computations for postMultiplyByN(). By default it uses N()*/
+  virtual void postMultiplyByN_(MatrixRef out, const MatrixConstRef & in, Range r, bool add) const;
+
+  /** Copy in A_ the values of the relevant jacobian matrices.*/
+  void fillA();
+
+  /** The matrix N*/
+  Eigen::MatrixXd N_;
+  /** The list of constraints.*/
+  std::vector<LinearConstraintPtr> constraints_;
+  /** The list of variables.*/
+  VariableVector variables_;
+
+private:
+  /** An association between a pair (variable, constraint) and a matrix block.*/
+  struct FillData
   {
-  public:
-    virtual ~SubstitutionCalculatorImpl() = default;
-    /** Update the internal computations based on the current value of A, i.e
-      * the current values of the constraints' jacobian matrices.
-      */
-    void update();
-    /** If \minus = \false, perform \p outA = A^# * \p in and \p outS = S^T * \p in
-      * otherwise perform \p outA = - A^# * \p in and \p outS = S^T * \p in
-      */
-    void premultiplyByASharpAndSTranspose(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const;
-    /** Compute \p out = \p in * \p N. 
-      * If \p add is \p true, perform \p out += \p in * \p N instead.
-      */
-    void postMultiplyByN(MatrixRef out, const MatrixConstRef& in, bool add = false) const;
-    /** Compute \p out = \p in * \p N(r,:). 
-      * If \p add is \p true, perform \p out += \p in * \p N(r,:) instead.
-      */
-    void postMultiplyByN(MatrixRef out, const MatrixConstRef& in, Range r, bool add = false) const;
-    /** Return N as a dense matrix.*/
-    const Eigen::MatrixXd& N() const;
-
-    /** Number of lines of A (i.e. sum of the constraints' sizes.*/
-    Eigen::DenseIndex m() const;
-    /** Size of x (i.e. sum of the size of the variables to be substituted.*/
-    Eigen::DenseIndex n() const;
-    /** Rank of A*/
-    Eigen::DenseIndex r() const;
-
-  protected:
-    /** Constructor
-      * \param cstr the list of constraints
-      * \param x the list of variables
-      * \param rank the rank of A
-      */
-    SubstitutionCalculatorImpl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank);
-    
-    /** Specify wheter A is constant (in which case only the first update will
-      * actually perform computations.
-      */
-    void constant(bool c);
-    /** Return wheter A is constant*/
-    bool constant() const;
-
-    /** Return the matrix A*/
-    const Eigen::MatrixXd& A() const;
-
-    /** Return true if there is only one variable and one constraint*/
-    bool isSimple() const;
-    
-    /** Handle for the derived class to perform the computations in update()*/
-    virtual void update_() = 0;
-    /** Computations for premultiplyByASharpAndSTranspose()*/
-    virtual void premultiplyByASharpAndSTranspose_(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const = 0;
-    /** Computations for postMultiplyByN()*/
-    virtual void postMultiplyByN_(MatrixRef out, const MatrixConstRef& in, bool add) const;
-    /** Computations for postMultiplyByN(). By default it uses N()*/
-    virtual void postMultiplyByN_(MatrixRef out, const MatrixConstRef& in, Range r, bool add) const;
-
-    /** Copy in A_ the values of the relevant jacobian matrices.*/
-    void fillA();
-
-    /** The matrix N*/
-    Eigen::MatrixXd N_;
-    /** The list of constraints.*/
-    std::vector<LinearConstraintPtr> constraints_;
-    /** The list of variables.*/
-    VariableVector variables_;
-
-  private:
-    /** An association between a pair (variable, constraint) and a matrix block.*/
-    struct FillData
-    {
-      VariablePtr x;
-      LinearConstraintPtr cstr;
-      Eigen::Block<Eigen::MatrixXd> block;
-    };
-
-    Eigen::DenseIndex m_; //row size of A
-    Eigen::DenseIndex n_; //col size of A
-    Eigen::DenseIndex r_; //rank of A
-    bool constant_;       //constness of A
-    bool init_;           //used to perform update_() only once if A is constant
-    bool simple_;         //true if there is only one variable and one constraint
-    Eigen::MatrixXd A_; //aggregated matrix for non-simple case;
-    /** All the pairs (x,c) with x in variables_ and c in constraints_ for which
-      * c.contains(x), and the block of A in which to copy c.jacobian(x)
-      */
-    std::vector<FillData> fillData_;
-
-    friend class SubstitutionCalculator;
+    VariablePtr x;
+    LinearConstraintPtr cstr;
+    Eigen::Block<Eigen::MatrixXd> block;
   };
 
-  inline Eigen::DenseIndex SubstitutionCalculatorImpl::m() const
-  {
-    return m_;
-  }
+  Eigen::DenseIndex m_; // row size of A
+  Eigen::DenseIndex n_; // col size of A
+  Eigen::DenseIndex r_; // rank of A
+  bool constant_; // constness of A
+  bool init_; // used to perform update_() only once if A is constant
+  bool simple_; // true if there is only one variable and one constraint
+  Eigen::MatrixXd A_; // aggregated matrix for non-simple case;
+  /** All the pairs (x,c) with x in variables_ and c in constraints_ for which
+   * c.contains(x), and the block of A in which to copy c.jacobian(x)
+   */
+  std::vector<FillData> fillData_;
 
-  inline Eigen::DenseIndex SubstitutionCalculatorImpl::n() const
-  {
-    return n_;
-  }
+  friend class SubstitutionCalculator;
+};
 
-  inline Eigen::DenseIndex SubstitutionCalculatorImpl::r() const
-  {
-    return r_;
-  }
+inline Eigen::DenseIndex SubstitutionCalculatorImpl::m() const { return m_; }
 
-  inline bool SubstitutionCalculatorImpl::isSimple() const
-  {
-    return simple_;
-  }
+inline Eigen::DenseIndex SubstitutionCalculatorImpl::n() const { return n_; }
 
-} // internal
+inline Eigen::DenseIndex SubstitutionCalculatorImpl::r() const { return r_; }
 
-} // hint
+inline bool SubstitutionCalculatorImpl::isSimple() const { return simple_; }
 
-} // tvm
+} // namespace abstract
+
+} // namespace hint
+
+} // namespace tvm

--- a/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
+++ b/include/tvm/hint/abstract/SubstitutionCalculatorImpl.h
@@ -115,10 +115,10 @@ private:
   Eigen::DenseIndex m_; // row size of A
   Eigen::DenseIndex n_; // col size of A
   Eigen::DenseIndex r_; // rank of A
-  bool constant_; // constness of A
-  bool init_; // used to perform update_() only once if A is constant
-  bool simple_; // true if there is only one variable and one constraint
-  Eigen::MatrixXd A_; // aggregated matrix for non-simple case;
+  bool constant_;       // constness of A
+  bool init_;           // used to perform update_() only once if A is constant
+  bool simple_;         // true if there is only one variable and one constraint
+  Eigen::MatrixXd A_;   // aggregated matrix for non-simple case;
   /** All the pairs (x,c) with x in variables_ and c in constraints_ for which
    * c.contains(x), and the block of A in which to copy c.jacobian(x)
    */

--- a/include/tvm/hint/internal/AutoCalculator.h
+++ b/include/tvm/hint/internal/AutoCalculator.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/internal/AutoCalculator.h
+++ b/include/tvm/hint/internal/AutoCalculator.h
@@ -1,32 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
-
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -44,27 +43,29 @@ namespace hint
 namespace internal
 {
 
-  /** Automatically generates the most appropriate calculator for the given
-    * constraints and variables.
-    *
-    * Current rules:
-    * - for a simple substitution with invertible diagonal matrix, generates a
-    *   DiagonalCalculator
-    * - otherwise generates a GenericCalculator
-    *
-    * \note You need to ensure that the matrix properties used when applying the
-    * rules have been correctly set. If this is not the case, this should be
-    * corrected at the function level. In particular it is improper to rely on
-    * a run of the update pipeline to have all the properties correctly set.
-    */
-  class TVM_DLLAPI AutoCalculator : public abstract::SubstitutionCalculator
-  {
-  protected:
-    std::unique_ptr<abstract::SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const override;
-  };
+/** Automatically generates the most appropriate calculator for the given
+ * constraints and variables.
+ *
+ * Current rules:
+ * - for a simple substitution with invertible diagonal matrix, generates a
+ *   DiagonalCalculator
+ * - otherwise generates a GenericCalculator
+ *
+ * \note You need to ensure that the matrix properties used when applying the
+ * rules have been correctly set. If this is not the case, this should be
+ * corrected at the function level. In particular it is improper to rely on
+ * a run of the update pipeline to have all the properties correctly set.
+ */
+class TVM_DLLAPI AutoCalculator : public abstract::SubstitutionCalculator
+{
+protected:
+  std::unique_ptr<abstract::SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr> & cstr,
+                                                              const std::vector<VariablePtr> & x,
+                                                              int rank) const override;
+};
 
-} // internal
+} // namespace internal
 
-} // hint
+} // namespace hint
 
-} // tvm
+} // namespace tvm

--- a/include/tvm/hint/internal/DiagonalCalculator.h
+++ b/include/tvm/hint/internal/DiagonalCalculator.h
@@ -49,9 +49,9 @@ public:
 
     Eigen::DenseIndex first_;
     Eigen::DenseIndex size_;
-    std::vector<Eigen::DenseIndex> nnz_; // indices of the non-zero rows
-    std::vector<Eigen::DenseIndex> innz_; // indices of the non-zero rows in the resulting matrix
-    std::vector<Eigen::DenseIndex> cnnz_; // complementary to nnz in [0:col-1]
+    std::vector<Eigen::DenseIndex> nnz_;   // indices of the non-zero rows
+    std::vector<Eigen::DenseIndex> innz_;  // indices of the non-zero rows in the resulting matrix
+    std::vector<Eigen::DenseIndex> cnnz_;  // complementary to nnz in [0:col-1]
     std::vector<Eigen::DenseIndex> zeros_; // indices of the zero rows
 
     Eigen::VectorXd inverse_;
@@ -91,7 +91,7 @@ protected:
 private:
   Eigen::DenseIndex first_;
   Eigen::DenseIndex size_;
-  std::vector<Eigen::DenseIndex> nnz_; // indices of the non-zero rows
+  std::vector<Eigen::DenseIndex> nnz_;   // indices of the non-zero rows
   std::vector<Eigen::DenseIndex> zeros_; // indices of the zero rows
 };
 } // namespace internal

--- a/include/tvm/hint/internal/DiagonalCalculator.h
+++ b/include/tvm/hint/internal/DiagonalCalculator.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,76 +42,87 @@ namespace hint
 
 namespace internal
 {
-  /** A calculator for all matrices that are the row selection of a diagonal
-    * matrix.
-    * The structure of the matrix (position of non-zero elements) is assumed to
-    * be constant.
-    */
-  class TVM_DLLAPI DiagonalCalculator : public abstract::SubstitutionCalculator
+/** A calculator for all matrices that are the row selection of a diagonal
+ * matrix.
+ * The structure of the matrix (position of non-zero elements) is assumed to
+ * be constant.
+ */
+class TVM_DLLAPI DiagonalCalculator : public abstract::SubstitutionCalculator
+{
+public:
+  class TVM_DLLAPI Impl : public abstract::SubstitutionCalculatorImpl
   {
   public:
-    class TVM_DLLAPI Impl : public abstract::SubstitutionCalculatorImpl
-    {
-    public:
-      Impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank, 
-           Eigen::DenseIndex first, Eigen::DenseIndex size);
-      Impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank, 
-           const std::vector<Eigen::DenseIndex>& nnzRows, const std::vector<Eigen::DenseIndex>& zeroRows);
+    Impl(const std::vector<LinearConstraintPtr> & cstr,
+         const std::vector<VariablePtr> & x,
+         int rank,
+         Eigen::DenseIndex first,
+         Eigen::DenseIndex size);
+    Impl(const std::vector<LinearConstraintPtr> & cstr,
+         const std::vector<VariablePtr> & x,
+         int rank,
+         const std::vector<Eigen::DenseIndex> & nnzRows,
+         const std::vector<Eigen::DenseIndex> & zeroRows);
 
-      virtual void update_() override;
-      virtual void premultiplyByASharpAndSTranspose_(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const override;
-      virtual void postMultiplyByN_(MatrixRef out, const MatrixConstRef& in, bool add) const override;
-
-    private:
-      void build();
-
-      Eigen::DenseIndex first_;
-      Eigen::DenseIndex size_;
-      std::vector<Eigen::DenseIndex> nnz_;      //indices of the non-zero rows
-      std::vector<Eigen::DenseIndex> innz_;     //indices of the non-zero rows in the resulting matrix
-      std::vector<Eigen::DenseIndex> cnnz_;     //complementary to nnz in [0:col-1]
-      std::vector<Eigen::DenseIndex> zeros_;    //indices of the zero rows
-
-      Eigen::VectorXd inverse_;
-    };
-
-    /** Continuous rows of a diagonal matrix starting at row \p first of this
-      * matrix and finishing at row \p first + \p size (not included).
-      * If \p size = -1, finishes at the last row.
-      */
-    DiagonalCalculator(Eigen::DenseIndex first = 0, Eigen::DenseIndex size = -1);
-    /** Non-continuous rows of a diagonal matrix
-      * \param nnzRows indices of the rows with a non-zero element.
-      * \param zeroRows indices of the rows (if any) with only zero
-      *
-      * Examples:
-      * Knowing that it describes a matrix with 6 columns, nnzRows = {0,2,3},
-      * zeroRows = {} corresponds to the shape
-      * x 0 0 0 0 0
-      * 0 0 x 0 0 0
-      * 0 0 0 x 0 0
-      *
-      * while nnzRows = {0,2,3}, zeroRows = {1,4} corresponds to
-      * x 0 0 0 0 0
-      * 0 0 0 0 0 0
-      * 0 0 x 0 0 0
-      * 0 0 0 x 0 0
-      * 0 0 0 0 0 0
-      */
-    DiagonalCalculator(const std::vector<Eigen::DenseIndex>& nnzRows, const std::vector<Eigen::DenseIndex>& zeroRows = {});
-
-  protected:
-    std::unique_ptr<abstract::SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const;
+    virtual void update_() override;
+    virtual void premultiplyByASharpAndSTranspose_(MatrixRef outA,
+                                                   MatrixRef outS,
+                                                   const MatrixConstRef & in,
+                                                   bool minus) const override;
+    virtual void postMultiplyByN_(MatrixRef out, const MatrixConstRef & in, bool add) const override;
 
   private:
+    void build();
+
     Eigen::DenseIndex first_;
     Eigen::DenseIndex size_;
-    std::vector<Eigen::DenseIndex> nnz_;      //indices of the non-zero rows
-    std::vector<Eigen::DenseIndex> zeros_;    //indices of the zero rows
+    std::vector<Eigen::DenseIndex> nnz_; // indices of the non-zero rows
+    std::vector<Eigen::DenseIndex> innz_; // indices of the non-zero rows in the resulting matrix
+    std::vector<Eigen::DenseIndex> cnnz_; // complementary to nnz in [0:col-1]
+    std::vector<Eigen::DenseIndex> zeros_; // indices of the zero rows
 
+    Eigen::VectorXd inverse_;
   };
-} // internal
 
-} // hint
+  /** Continuous rows of a diagonal matrix starting at row \p first of this
+   * matrix and finishing at row \p first + \p size (not included).
+   * If \p size = -1, finishes at the last row.
+   */
+  DiagonalCalculator(Eigen::DenseIndex first = 0, Eigen::DenseIndex size = -1);
+  /** Non-continuous rows of a diagonal matrix
+   * \param nnzRows indices of the rows with a non-zero element.
+   * \param zeroRows indices of the rows (if any) with only zero
+   *
+   * Examples:
+   * Knowing that it describes a matrix with 6 columns, nnzRows = {0,2,3},
+   * zeroRows = {} corresponds to the shape
+   * x 0 0 0 0 0
+   * 0 0 x 0 0 0
+   * 0 0 0 x 0 0
+   *
+   * while nnzRows = {0,2,3}, zeroRows = {1,4} corresponds to
+   * x 0 0 0 0 0
+   * 0 0 0 0 0 0
+   * 0 0 x 0 0 0
+   * 0 0 0 x 0 0
+   * 0 0 0 0 0 0
+   */
+  DiagonalCalculator(const std::vector<Eigen::DenseIndex> & nnzRows,
+                     const std::vector<Eigen::DenseIndex> & zeroRows = {});
 
-} // tvm
+protected:
+  std::unique_ptr<abstract::SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr> & cstr,
+                                                              const std::vector<VariablePtr> & x,
+                                                              int rank) const;
+
+private:
+  Eigen::DenseIndex first_;
+  Eigen::DenseIndex size_;
+  std::vector<Eigen::DenseIndex> nnz_; // indices of the non-zero rows
+  std::vector<Eigen::DenseIndex> zeros_; // indices of the zero rows
+};
+} // namespace internal
+
+} // namespace hint
+
+} // namespace tvm

--- a/include/tvm/hint/internal/DiagonalCalculator.h
+++ b/include/tvm/hint/internal/DiagonalCalculator.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/internal/DiagonalCalculator.h
+++ b/include/tvm/hint/internal/DiagonalCalculator.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/hint/abstract/SubstitutionCalculator.h>
 #include <tvm/hint/abstract/SubstitutionCalculatorImpl.h>
 

--- a/include/tvm/hint/internal/GenericCalculator.h
+++ b/include/tvm/hint/internal/GenericCalculator.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -47,38 +47,42 @@ namespace hint
 
 namespace internal
 {
-  /** The default substitution calculator for a set of constraints.
-    * A^#, N and S are deduced from a single rank-revealing QR:
-    * A | P1  P2 | = | Q1  Q2 | | R1  R2 |
-    *                           |  0   0 |
-    * A^# = P1 R1^-1 Q1^T
-    * N = P2 - P1 R1^-1 R2
-    * S = Q2
-    */
-  class TVM_DLLAPI GenericCalculator: public abstract::SubstitutionCalculator
+/** The default substitution calculator for a set of constraints.
+ * A^#, N and S are deduced from a single rank-revealing QR:
+ * A | P1  P2 | = | Q1  Q2 | | R1  R2 |
+ *                           |  0   0 |
+ * A^# = P1 R1^-1 Q1^T
+ * N = P2 - P1 R1^-1 R2
+ * S = Q2
+ */
+class TVM_DLLAPI GenericCalculator : public abstract::SubstitutionCalculator
+{
+public:
+  class TVM_DLLAPI Impl : public abstract::SubstitutionCalculatorImpl
   {
   public:
-    class TVM_DLLAPI Impl : public abstract::SubstitutionCalculatorImpl
-    {
-    public:
-      Impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank);
+    Impl(const std::vector<LinearConstraintPtr> & cstr, const std::vector<VariablePtr> & x, int rank);
 
-      virtual void update_() override;
-      virtual void premultiplyByASharpAndSTranspose_(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const override;
+    virtual void update_() override;
+    virtual void premultiplyByASharpAndSTranspose_(MatrixRef outA,
+                                                   MatrixRef outS,
+                                                   const MatrixConstRef & in,
+                                                   bool minus) const override;
 
-    private:
-      Eigen::ColPivHouseholderQR<Eigen::MatrixXd> qr_;
-      Eigen::MatrixXd invR1R2_;                         //inv(R1)*R2
-      mutable utils::internal::BufferedMatrix tmp_;     //temporary for the premultiplication by Asharp and S^T
-    };
-
-  protected:
-    std::unique_ptr<abstract::SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const override;
-
+  private:
+    Eigen::ColPivHouseholderQR<Eigen::MatrixXd> qr_;
+    Eigen::MatrixXd invR1R2_; // inv(R1)*R2
+    mutable utils::internal::BufferedMatrix tmp_; // temporary for the premultiplication by Asharp and S^T
   };
 
-} // internal
+protected:
+  std::unique_ptr<abstract::SubstitutionCalculatorImpl> impl_(const std::vector<LinearConstraintPtr> & cstr,
+                                                              const std::vector<VariablePtr> & x,
+                                                              int rank) const override;
+};
 
-} // hint
+} // namespace internal
 
-} // tvm
+} // namespace hint
+
+} // namespace tvm

--- a/include/tvm/hint/internal/GenericCalculator.h
+++ b/include/tvm/hint/internal/GenericCalculator.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/internal/GenericCalculator.h
+++ b/include/tvm/hint/internal/GenericCalculator.h
@@ -44,7 +44,7 @@ public:
 
   private:
     Eigen::ColPivHouseholderQR<Eigen::MatrixXd> qr_;
-    Eigen::MatrixXd invR1R2_; // inv(R1)*R2
+    Eigen::MatrixXd invR1R2_;                     // inv(R1)*R2
     mutable utils::internal::BufferedMatrix tmp_; // temporary for the premultiplication by Asharp and S^T
   };
 

--- a/include/tvm/hint/internal/GenericCalculator.h
+++ b/include/tvm/hint/internal/GenericCalculator.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/hint/abstract/SubstitutionCalculator.h>
 #include <tvm/hint/abstract/SubstitutionCalculatorImpl.h>
 #include <tvm/utils/internal/BufferedMatrix.h>

--- a/include/tvm/hint/internal/SubstitutionUnit.h
+++ b/include/tvm/hint/internal/SubstitutionUnit.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/internal/SubstitutionUnit.h
+++ b/include/tvm/hint/internal/SubstitutionUnit.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <tvm/Range.h>
 #include <tvm/api.h>
+
+#include <tvm/Range.h>
 #include <tvm/constraint/BasicLinearConstraint.h>
 #include <tvm/function/BasicLinearFunction.h>
 #include <tvm/hint/Substitution.h>

--- a/include/tvm/hint/internal/SubstitutionUnit.h
+++ b/include/tvm/hint/internal/SubstitutionUnit.h
@@ -1,36 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/api.h>
 #include <tvm/Range.h>
+#include <tvm/api.h>
 #include <tvm/constraint/BasicLinearConstraint.h>
 #include <tvm/function/BasicLinearFunction.h>
 #include <tvm/hint/Substitution.h>
@@ -48,169 +48,169 @@ namespace hint
 
 namespace internal
 {
-  /** A class to perform all the computations related to a group of dependent
-    * substitutions.
-    */
-  class TVM_DLLAPI SubstitutionUnit
-  {
-  public:
-    /** Build a SubstitutionUnit containing the substitutions from 
-      * \p substitutionPool with indices in \p groups[i] for each \p i in
-      * \p order.
-      * Substitutions in a same groups[i] are merged as a single subsitution.
-      */
-    SubstitutionUnit(const std::vector<Substitution>& substitutionPool, 
-                     const std::vector<std::vector<size_t>>& groups,
-                     const std::vector<size_t> order);
+/** A class to perform all the computations related to a group of dependent
+ * substitutions.
+ */
+class TVM_DLLAPI SubstitutionUnit
+{
+public:
+  /** Build a SubstitutionUnit containing the substitutions from
+   * \p substitutionPool with indices in \p groups[i] for each \p i in
+   * \p order.
+   * Substitutions in a same groups[i] are merged as a single subsitution.
+   */
+  SubstitutionUnit(const std::vector<Substitution> & substitutionPool,
+                   const std::vector<std::vector<size_t>> & groups,
+                   const std::vector<size_t> order);
 
-    /** Update the matrices and vectors used for the substitutions.*/
-    void update();
+  /** Update the matrices and vectors used for the substitutions.*/
+  void update();
 
-    /** Return the substituted variables*/
-    const std::vector<VariablePtr>& variables() const;
-    /** Return the function giving the values of the substituted variables. The
-      * order of the vector corresponds to the order of the vector returned by
-      * \p variables()
-      */
-    const std::vector<std::shared_ptr<function::BasicLinearFunction>>& variableSubstitutions() const;
-    /** Return all the z variables (including the empty ones).*/
-    const std::vector<VariablePtr>& additionalVariables() const;
-    /** Return the additional constraints to be added to the problem.*/
-    const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>>& additionalConstraints() const;
-    /** Return all the y variables.*/
-    const std::vector<VariablePtr>& otherVariables() const;
+  /** Return the substituted variables*/
+  const std::vector<VariablePtr> & variables() const;
+  /** Return the function giving the values of the substituted variables. The
+   * order of the vector corresponds to the order of the vector returned by
+   * \p variables()
+   */
+  const std::vector<std::shared_ptr<function::BasicLinearFunction>> & variableSubstitutions() const;
+  /** Return all the z variables (including the empty ones).*/
+  const std::vector<VariablePtr> & additionalVariables() const;
+  /** Return the additional constraints to be added to the problem.*/
+  const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> & additionalConstraints() const;
+  /** Return all the y variables.*/
+  const std::vector<VariablePtr> & otherVariables() const;
 
-  private:
-    /** Build \p substitutions_ from the inputs
-      * \sa SubstitutionUnit:SubstitutionUnit
-      */
-    void extractSubstitutions(const std::vector<Substitution>& substitutionPool, const std::vector<std::vector<size_t>>& groups, const std::vector<size_t> order);
-    /** Populates \p constraints_, \p x_, \p y_, \p z_, \p substitutionMRanges_,
-      * \p substitutionNRanges_. \p constraintsY_, \p CXdependencies and \p m_
-      * from \p substitutions_.
-      */
-    void scanSubstitutions();
-    /** Compute the dependencies between the constraints, variables and susbsitutions.*/
-    void computeDependencies();
-    /** Resize the matrices and initialize to zero some parts that will be used*/
-    void initializeMatrices();
-    /** Build \p varSubstitutions_ and \p remainings_*/
-    void createFunctions();
+private:
+  /** Build \p substitutions_ from the inputs
+   * \sa SubstitutionUnit:SubstitutionUnit
+   */
+  void extractSubstitutions(const std::vector<Substitution> & substitutionPool,
+                            const std::vector<std::vector<size_t>> & groups,
+                            const std::vector<size_t> order);
+  /** Populates \p constraints_, \p x_, \p y_, \p z_, \p substitutionMRanges_,
+   * \p substitutionNRanges_. \p constraintsY_, \p CXdependencies and \p m_
+   * from \p substitutions_.
+   */
+  void scanSubstitutions();
+  /** Compute the dependencies between the constraints, variables and susbsitutions.*/
+  void computeDependencies();
+  /** Resize the matrices and initialize to zero some parts that will be used*/
+  void initializeMatrices();
+  /** Build \p varSubstitutions_ and \p remainings_*/
+  void createFunctions();
 
+  /** Sum of the sizes of all the constraints in all the substitutions.*/
+  int m_;
+  /** The substitutions in this unit.*/
+  std::vector<Substitution> substitutions_;
+  /** The calculators associated to the substitutions*/
+  std::vector<std::shared_ptr<abstract::SubstitutionCalculatorImpl>> calculators_;
+  /** The list of all constraints appearing in the substitutions*/
+  std::vector<LinearConstraintPtr> constraints_;
+  /** The substituted variables, by order of substitution*/
+  VariableVector x_;
+  /** The non-substituted variables*/
+  VariableVector y_;
+  /** The additionnal nullspace variables*/
+  VariableVector z_;
+  /** Imagining all the constraints of all the substitutions stacked, the i-th
+   * elements gives the rows corresponding to substitutions_[i].
+   */
+  std::vector<Range> substitutionMRanges_;
+  /** Imagining all the constraints of all the substitutions stacked, the i-th
+   * elements gives the columns corresponding to the variables of
+   * substitutions_[i].
+   */
+  std::vector<Range> substitutionNRanges_;
 
-    /** Sum of the sizes of all the constraints in all the substitutions.*/
-    int m_;
-    /** The substitutions in this unit.*/
-    std::vector<Substitution> substitutions_;
-    /** The calculators associated to the substitutions*/
-    std::vector<std::shared_ptr<abstract::SubstitutionCalculatorImpl>> calculators_;
-    /** The list of all constraints appearing in the substitutions*/
-    std::vector<LinearConstraintPtr> constraints_;
-    /** The substituted variables, by order of substitution*/
-    VariableVector x_;
-    /** The non-substituted variables*/
-    VariableVector y_;
-    /** The additionnal nullspace variables*/
-    VariableVector z_;
-    /** Imagining all the constraints of all the substitutions stacked, the i-th
-      * elements gives the rows corresponding to substitutions_[i].
-      */
-    std::vector<Range> substitutionMRanges_;
-    /** Imagining all the constraints of all the substitutions stacked, the i-th
-      * elements gives the columns corresponding to the variables of
-      * substitutions_[i].
-      */
-    std::vector<Range> substitutionNRanges_;
+  /** sub2cstr[i]_ gives the indices relative to constraints_ of the
+   * constraints corresponding to susbtitutions_[i].
+   */
+  std::vector<std::vector<size_t>> sub2cstr_;
+  /** sub2cstr[i]_ gives the indices relative to x_ of the variables x
+   * corresponding to susbtitutions_[i].
+   */
+  std::vector<std::vector<size_t>> sub2x_;
+  /** x2sub_[i] gives the index of the substitution from which x_[i] is
+   * computed.
+   */
+  std::vector<size_t> x2sub_;
+  /** xRange_[i] gives the range of x_[i] wrt substitutions_[i].variables().
+   * We cache it for efficiency purpose.
+   */
+  std::vector<Range> xRange_;
 
-    /** sub2cstr[i]_ gives the indices relative to constraints_ of the
-      * constraints corresponding to susbtitutions_[i].
-      */
-    std::vector<std::vector<size_t>> sub2cstr_;
-    /** sub2cstr[i]_ gives the indices relative to x_ of the variables x
-      * corresponding to susbtitutions_[i].
-      */
-    std::vector<std::vector<size_t>> sub2x_;
-    /** x2sub_[i] gives the index of the substitution from which x_[i] is
-      * computed.
-      */
-    std::vector<size_t> x2sub_;
-    /** xRange_[i] gives the range of x_[i] wrt substitutions_[i].variables().
-      * We cache it for efficiency purpose.
-      */
-    std::vector<Range> xRange_;
+  /** constraints_[i] contains y_[constraintsY_[i][j]].*/
+  std::vector<std::vector<int>> constraintsY_;
+  /** constraints_[i] depends on x_[CXdependencies_[i][j]].*/
+  std::vector<std::vector<int>> CXdependencies_;
+  /** x_[i] depends on y_[XYdependencies_[i][j]].*/
+  std::vector<std::vector<int>> XYdependencies_;
+  /** x_[i] depends on z_[XZdependencies_[i][j]].*/
+  std::vector<std::vector<int>> XZdependencies_;
+  /** substitutions_[i] depends on y_[SYdependencies_[i][j]].*/
+  std::vector<std::vector<int>> SYdependencies_;
+  /** substitutions_[i] depends on z_[SZdependencies_[i][j]].*/
+  std::vector<std::vector<int>> SZdependencies_;
 
-    /** constraints_[i] contains y_[constraintsY_[i][j]].*/
-    std::vector<std::vector<int>> constraintsY_;
-    /** constraints_[i] depends on x_[CXdependencies_[i][j]].*/
-    std::vector<std::vector<int>> CXdependencies_;
-    /** x_[i] depends on y_[XYdependencies_[i][j]].*/
-    std::vector<std::vector<int>> XYdependencies_;
-    /** x_[i] depends on z_[XZdependencies_[i][j]].*/
-    std::vector<std::vector<int>> XZdependencies_;
-    /** substitutions_[i] depends on y_[SYdependencies_[i][j]].*/
-    std::vector<std::vector<int>> SYdependencies_;
-    /** substitutions_[i] depends on z_[SZdependencies_[i][j]].*/
-    std::vector<std::vector<int>> SZdependencies_;
+  /** The substituted variables as linear functions of the non-sustituted ones.*/
+  std::vector<std::shared_ptr<function::BasicLinearFunction>> varSubstitutions_;
+  /** The remaining constraints on the non-substituted variables.*/
+  std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> remaining_;
 
-    /** The substituted variables as linear functions of the non-sustituted ones.*/
-    std::vector<std::shared_ptr<function::BasicLinearFunction>> varSubstitutions_;
-    /** The remaining constraints on the non-substituted variables.*/
-    std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> remaining_;
+  /** All the matrices B_{i,j} assembled, where \p i corresponds to the i-th
+   * constraint in \p constraints_ and \p j corresponds to the j-th variable
+   * in \p y_.
+   */
+  Eigen::MatrixXd B_;
+  /** All the matrices Z_{i,j} assembled, where \p i corresponds to the i-th
+   * constraint in \p constraints_ and \p j corresponds to the j-th variable
+   * in \p z_.
+   */
+  Eigen::MatrixXd Z_;
+  /** All the rhs c_i assembled, where \p i corresponds to the i-th constraint
+   * in \p constraints_.
+   */
+  Eigen::VectorXd c_;
+  /** cIsZero_[i] is true if the value of u corresponding to x_[i] is zero.*/
+  std::vector<bool> cIsZero_;
+  /** All the matrices M_{i,j} assembled, where \p i corresponds to the i-th
+   * variables in \p x_ and \p j corresponds to the j-th variable in \p y_.
+   * We have M_{i1:i2,j} = - A_{i1:i2}^# B_{i1:i2,j}, where i1:i2 is the
+   * range of \p x_ variables in a given substitution.
+   */
+  Eigen::MatrixXd M_;
+  /** All the matrices Z_{i,j} assembled, where \p i corresponds to the i-th
+   * variables in \p x_ and \p j corresponds to the j-th variable in \p z_.
+   * We have AsZ_{i1:i2,j} = - A_{i1:i2}^# Z_{i1:i2,j}, where i1:i2 is the
+   * range of \p x_ variables in a given substitution.
+   */
+  Eigen::MatrixXd AsZ_;
+  /** Assembly of all the u_i = A_i^# c_i*/
+  Eigen::VectorXd u_;
+  /** uIsZero_[i] is true if the value of u corresponding to the i-th
+   * substitutions is zero
+   */
+  std::vector<bool> uIsZero_;
+  /** For each element \p substitutions_[i], an assembly of S_i^T B_{i,j},
+   * where \p j corresponds to the j-th variable in y_.
+   */
+  std::vector<Eigen::MatrixXd> StB_;
+  /** For each element \p substitutions_[i], an assembly of S_i^T Z_{i,j},
+   * where \p j corresponds to the j-th variable in z_.
+   */
+  std::vector<Eigen::MatrixXd> StZ_;
+  /** For each element \p substitutions_[i], an assembly of S_i^T c_i. */
+  std::vector<Eigen::VectorXd> Stc_;
 
-    /** All the matrices B_{i,j} assembled, where \p i corresponds to the i-th
-      * constraint in \p constraints_ and \p j corresponds to the j-th variable
-      * in \p y_.
-      */
-    Eigen::MatrixXd B_;
-    /** All the matrices Z_{i,j} assembled, where \p i corresponds to the i-th
-      * constraint in \p constraints_ and \p j corresponds to the j-th variable
-      * in \p z_.
-      */
-    Eigen::MatrixXd Z_;
-    /** All the rhs c_i assembled, where \p i corresponds to the i-th constraint
-      * in \p constraints_.
-      */
-    Eigen::VectorXd c_;
-    /** cIsZero_[i] is true if the value of u corresponding to x_[i] is zero.*/
-    std::vector<bool> cIsZero_;
-    /** All the matrices M_{i,j} assembled, where \p i corresponds to the i-th
-      * variables in \p x_ and \p j corresponds to the j-th variable in \p y_.
-      * We have M_{i1:i2,j} = - A_{i1:i2}^# B_{i1:i2,j}, where i1:i2 is the 
-      * range of \p x_ variables in a given substitution.
-      */
-    Eigen::MatrixXd M_;
-    /** All the matrices Z_{i,j} assembled, where \p i corresponds to the i-th
-      * variables in \p x_ and \p j corresponds to the j-th variable in \p z_.
-      * We have AsZ_{i1:i2,j} = - A_{i1:i2}^# Z_{i1:i2,j}, where i1:i2 is the 
-      * range of \p x_ variables in a given substitution.
-      */
-    Eigen::MatrixXd AsZ_;
-    /** Assembly of all the u_i = A_i^# c_i*/
-    Eigen::VectorXd u_;
-    /** uIsZero_[i] is true if the value of u corresponding to the i-th
-      * substitutions is zero
-      */
-    std::vector<bool> uIsZero_;
-    /** For each element \p substitutions_[i], an assembly of S_i^T B_{i,j},
-      * where \p j corresponds to the j-th variable in y_.
-      */
-    std::vector<Eigen::MatrixXd> StB_;
-    /** For each element \p substitutions_[i], an assembly of S_i^T Z_{i,j},
-      * where \p j corresponds to the j-th variable in z_.
-      */
-    std::vector<Eigen::MatrixXd> StZ_;
-     /** For each element \p substitutions_[i], an assembly of S_i^T c_i. */
-    std::vector<Eigen::VectorXd> Stc_;
+  /** A temporary vector used in the update.*/
+  std::vector<bool> firstY_;
+  /** A temporary vector used in the update.*/
+  std::vector<bool> firstZ_;
+};
 
-    /** A temporary vector used in the update.*/
-    std::vector<bool> firstY_;
-    /** A temporary vector used in the update.*/
-    std::vector<bool> firstZ_;
-  };
+} // namespace internal
 
+} // namespace hint
 
-} // internal
-
-} // hint
-
-} // tvm
+} // namespace tvm

--- a/include/tvm/hint/internal/Substitutions.h
+++ b/include/tvm/hint/internal/Substitutions.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/graph/internal/DependencyGraph.h>
 #include <tvm/hint/Substitution.h>
 #include <tvm/hint/internal/SubstitutionUnit.h>

--- a/include/tvm/hint/internal/Substitutions.h
+++ b/include/tvm/hint/internal/Substitutions.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/hint/internal/Substitutions.h
+++ b/include/tvm/hint/internal/Substitutions.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -45,87 +45,87 @@ namespace hint
 
 namespace internal
 {
-  /** A set of substitutions*/
-  class TVM_DLLAPI Substitutions
-  {
-  public:
-    /** Add substitution \p s*/
-    void add(const Substitution& s);
+/** A set of substitutions*/
+class TVM_DLLAPI Substitutions
+{
+public:
+  /** Add substitution \p s*/
+  void add(const Substitution & s);
 
-    /** Get the vector of all substitutions, as added.
-      * Note that it is not necessarily the vector of substitutions actually
-      * used, as it might be needed to group substitutions (when a group of
-      * substitutions depends on each other variables).
-      */
-    const std::vector<Substitution>& substitutions() const;
+  /** Get the vector of all substitutions, as added.
+   * Note that it is not necessarily the vector of substitutions actually
+   * used, as it might be needed to group substitutions (when a group of
+   * substitutions depends on each other variables).
+   */
+  const std::vector<Substitution> & substitutions() const;
 
-    /** Return \p true if \p c is used in one of the substitutions*/
-    bool uses(LinearConstraintPtr c) const;
+  /** Return \p true if \p c is used in one of the substitutions*/
+  bool uses(LinearConstraintPtr c) const;
 
-    /** Compute all the data needed for the substitutions.
-      * Needs to be called after all the call to \p add, and before the calls to
-      * \p variables, \p variableSubstitutions and \p additionalConstraints.
-      */
-    void finalize();
+  /** Compute all the data needed for the substitutions.
+   * Needs to be called after all the call to \p add, and before the calls to
+   * \p variables, \p variableSubstitutions and \p additionalConstraints.
+   */
+  void finalize();
 
-    /** Update the data for the substitutions*/
-    void updateSubstitutions();
+  /** Update the data for the substitutions*/
+  void updateSubstitutions();
 
-    /** Update the value of the substituted variables according to the values of
-      * the non-substitued ones.*/
-    void updateVariableValues() const;
+  /** Update the value of the substituted variables according to the values of
+   * the non-substitued ones.*/
+  void updateVariableValues() const;
 
-    /** All variables x in the substitutions*/
-    const std::vector<VariablePtr>& variables() const;
-    /** The linear functions x = f(y,z) corresponding to the variables*/
-    const std::vector<std::shared_ptr<function::BasicLinearFunction>>& variableSubstitutions() const;
-    /** The additional nullspace variables z*/
-    const std::vector<VariablePtr>& additionalVariables() const;
-    /** The remaining constraints on y and z*/
-    const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>>& additionalConstraints() const;
-    /** The variables y*/
-    const std::vector<VariablePtr>& otherVariables() const;
-    /** If \p x is one of the substituted variables, returns the variables it is
-      * replaced by. Otherwise, return \p x
-      */
-    VariableVector substitute(const VariablePtr& x) const;
+  /** All variables x in the substitutions*/
+  const std::vector<VariablePtr> & variables() const;
+  /** The linear functions x = f(y,z) corresponding to the variables*/
+  const std::vector<std::shared_ptr<function::BasicLinearFunction>> & variableSubstitutions() const;
+  /** The additional nullspace variables z*/
+  const std::vector<VariablePtr> & additionalVariables() const;
+  /** The remaining constraints on y and z*/
+  const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> & additionalConstraints() const;
+  /** The variables y*/
+  const std::vector<VariablePtr> & otherVariables() const;
+  /** If \p x is one of the substituted variables, returns the variables it is
+   * replaced by. Otherwise, return \p x
+   */
+  VariableVector substitute(const VariablePtr & x) const;
 
-  private:
-    /** The substitutions, as added to the objects*/
-    std::vector<Substitution> substitutions_;
+private:
+  /** The substitutions, as added to the objects*/
+  std::vector<Substitution> substitutions_;
 
-    /** Dependency graph between the substitutions. There is an edge from i to j
-      * if the substitutions_[i] relies on substitutions_[j].
-      */
-    tvm::graph::internal::DependencyGraph dependencies_;
+  /** Dependency graph between the substitutions. There is an edge from i to j
+   * if the substitutions_[i] relies on substitutions_[j].
+   */
+  tvm::graph::internal::DependencyGraph dependencies_;
 
-    /** Group of dependent substitutions*/
-    std::vector<SubstitutionUnit> units_;
+  /** Group of dependent substitutions*/
+  std::vector<SubstitutionUnit> units_;
 
-    /** The variables substituted (x).*/
-    std::vector<VariablePtr> variables_;
+  /** The variables substituted (x).*/
+  std::vector<VariablePtr> variables_;
 
-    /** The substitution functions linked to the variables, i.e
-      * variables_[i].value() is given by varSubstitutions_[i].value().
-      */
-    std::vector<std::shared_ptr<function::BasicLinearFunction>> varSubstitutions_;
+  /** The substitution functions linked to the variables, i.e
+   * variables_[i].value() is given by varSubstitutions_[i].value().
+   */
+  std::vector<std::shared_ptr<function::BasicLinearFunction>> varSubstitutions_;
 
-    /** Nullspace variables (z) used in the substitutions*/
-    std::vector<VariablePtr> additionalVariables_;
+  /** Nullspace variables (z) used in the substitutions*/
+  std::vector<VariablePtr> additionalVariables_;
 
-    /** Other variables (y), i.e. the variables present in the constraints used
-      * for the substitutions but not substituted.
-      */
-    std::vector<VariablePtr> otherVariables_;
+  /** Other variables (y), i.e. the variables present in the constraints used
+   * for the substitutions but not substituted.
+   */
+  std::vector<VariablePtr> otherVariables_;
 
-    /** The additionnal constraints to add to the problem*/
-    std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> additionalConstraints_;
+  /** The additionnal constraints to add to the problem*/
+  std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> additionalConstraints_;
 
-    friend class SubstitutionTest;
-  };
+  friend class SubstitutionTest;
+};
 
-}
+} // namespace internal
 
-}
+} // namespace hint
 
-}
+} // namespace tvm

--- a/include/tvm/internal/CallbackManager.h
+++ b/include/tvm/internal/CallbackManager.h
@@ -9,70 +9,69 @@
 
 namespace tvm::internal
 {
-  /** A class to register and run callbacks, based on PairElementToken to identify
-    * the class who registered the callback and check if it is still alive.
-    * If this class was destroyed, the callback is automatically unregistered.
-    */
-  class CallbackManager
+/** A class to register and run callbacks, based on PairElementToken to identify
+ * the class who registered the callback and check if it is still alive.
+ * If this class was destroyed, the callback is automatically unregistered.
+ */
+class CallbackManager
+{
+public:
+  using Callback = std::function<void()>;
+  using TCPair = std::pair<PairElementToken, Callback>;
+
+  CallbackManager() = default;
+  CallbackManager(const CallbackManager &) = delete;
+  CallbackManager & operator=(const CallbackManager &) = delete;
+
+  virtual ~CallbackManager() = default;
+
+  /** Register a callback and return a handle that needs to be converted to
+   * PairElementToken.
+   */
+  PairElementTokenHandle registerCallback(std::function<void()> c);
+
+  /** Unregister a callback, identified by the token created from its registration.*/
+  void unregisterCallback(const PairElementToken & t);
+
+  /** Run all callbacks. Remove the ones for which the token obtained at the
+   * registration was destroyed.
+   */
+  void run();
+
+private:
+  std::vector<TCPair> callbacks_;
+};
+
+inline PairElementTokenHandle CallbackManager::registerCallback(std::function<void()> c)
+{
+  callbacks_.emplace_back(PairElementToken(), c);
+  return PairElementTokenHandle(callbacks_.back().first);
+}
+
+inline void CallbackManager::unregisterCallback(const PairElementToken & t)
+{
+  auto it =
+      std::find_if(callbacks_.begin(), callbacks_.end(), [&](const TCPair & p) { return p.first.isPairedWith(t); });
+  if(it != callbacks_.end())
+    callbacks_.erase(it);
+  else
+    throw std::runtime_error("Element to unregister not found.");
+}
+
+inline void CallbackManager::run()
+{
+  for(size_t i = 0; i < callbacks_.size();)
   {
-  public:
-    using Callback = std::function<void()>;
-    using TCPair = std::pair<PairElementToken, Callback>;
-
-    CallbackManager() = default;
-    CallbackManager(const CallbackManager&) = delete;
-    CallbackManager& operator=(const CallbackManager&) = delete;
-
-    virtual ~CallbackManager() = default;
-
-    /** Register a callback and return a handle that needs to be converted to
-      * PairElementToken.
-      */
-    PairElementTokenHandle registerCallback(std::function<void()> c);
-    
-    /** Unregister a callback, identified by the token created from its registration.*/
-    void unregisterCallback(const PairElementToken& t);
-
-    /** Run all callbacks. Remove the ones for which the token obtained at the
-      * registration was destroyed.
-      */
-    void run();
-
-  private:
-    std::vector<TCPair> callbacks_;
-  };
-
-
-  inline PairElementTokenHandle CallbackManager::registerCallback(std::function<void()> c)
-  {
-    callbacks_.emplace_back(PairElementToken(), c);
-    return PairElementTokenHandle(callbacks_.back().first);
-  }
-
-  inline void CallbackManager::unregisterCallback(const PairElementToken& t)
-  {
-    auto it = std::find_if(callbacks_.begin(), callbacks_.end(), [&](const TCPair& p) { return p.first.isPairedWith(t); });
-    if (it != callbacks_.end())
-      callbacks_.erase(it);
-    else
-      throw std::runtime_error("Element to unregister not found.");
-  }
-
-  inline void CallbackManager::run()
-  {
-    for (size_t i=0; i<callbacks_.size();)
+    if(callbacks_[i].first.isPaired())
     {
-      if (callbacks_[i].first.isPaired())
-      {
-        std::invoke(callbacks_[i].second);
-        ++i;
-      }
-      else
-      {
-        callbacks_.erase(callbacks_.begin() + i);
-      }
+      std::invoke(callbacks_[i].second);
+      ++i;
+    }
+    else
+    {
+      callbacks_.erase(callbacks_.begin() + i);
     }
   }
-
-
 }
+
+} // namespace tvm::internal

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -1,37 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/defs.h>
 #include <tvm/Variable.h>
 #include <tvm/VariableVector.h>
+#include <tvm/defs.h>
 #include <tvm/graph/abstract/Node.h>
 #include <tvm/internal/MatrixWithProperties.h>
 #include <tvm/utils/internal/map.h>
@@ -48,190 +48,166 @@ namespace tvm
 namespace internal
 {
 
-  /** Describes an entity that can provide a value and its jacobian
-    *
-    * \dot
-    * digraph "update graph" {
-    *   rankdir="LR";
-    *   {
-    *     rank = same;
-    *     node [shape=hexagon];
-    *     Value; Jacobian; 
-    *   }
-    *   {
-    *     rank = same;
-    *     node [style=invis, label=""];
-    *     outValue; outJacobian;
-    *   }
-    *   Value -> outValue [label="value()"];
-    *   Jacobian -> outJacobian [label="jacobian(x_i)"];
-    * }
-    * \enddot
-    */
-  class TVM_DLLAPI FirstOrderProvider : public graph::abstract::Node<FirstOrderProvider>
+/** Describes an entity that can provide a value and its jacobian
+ *
+ * \dot
+ * digraph "update graph" {
+ *   rankdir="LR";
+ *   {
+ *     rank = same;
+ *     node [shape=hexagon];
+ *     Value; Jacobian;
+ *   }
+ *   {
+ *     rank = same;
+ *     node [style=invis, label=""];
+ *     outValue; outJacobian;
+ *   }
+ *   Value -> outValue [label="value()"];
+ *   Jacobian -> outJacobian [label="jacobian(x_i)"];
+ * }
+ * \enddot
+ */
+class TVM_DLLAPI FirstOrderProvider : public graph::abstract::Node<FirstOrderProvider>
+{
+public:
+  SET_OUTPUTS(FirstOrderProvider, Value, Jacobian)
+
+  /** \internal by default, these methods return the cached value.
+   * However, they are virtual in case the user might want to bypass the cache.
+   * This would be typically the case if he/she wants to directly return the
+   * output of another method, e.g. return the jacobian of an other Function.
+   */
+  /** Return the value of this entity*/
+  virtual const Eigen::VectorXd & value() const;
+  /** Return the jacobian matrix of this entity corresponding to the variable
+   * \p x
+   */
+  virtual const MatrixWithProperties & jacobian(const Variable & x) const;
+
+  /** Linearity w.r.t \p x*/
+  bool linearIn(const Variable & x) const;
+
+  const Space & imageSpace() const;
+
+  /** Return the image space size.*/
+  int size() const;
+  /** Size of the output value (representation size of the image space).*/
+  int rSize() const;
+  /** Size of the tangent space to the image space (or equivalently row size of the jacobian matrices).*/
+  int tSize() const;
+
+  /** Return the variables*/
+  const VariableVector & variables() const;
+
+protected:
+  /** Constructor for a function/constraint with value in \f$ \mathbb{R}^m \f$.
+   *
+   * \param m the size of the function/constraint image space, i.e. the row
+   * size of the jacobians (or equivalently in this case the size of the
+   * output value).
+   */
+  FirstOrderProvider(int m);
+
+  /** Constructor for a function/constraint with value in a specified space.
+   *
+   * \param image Description of the image space
+   */
+  FirstOrderProvider(Space image);
+
+  /** Resize all cache members corresponding to active outputs.
+   *
+   * This can be overriden in case you do not need all of the default
+   * mechanism (typically if you will not use part of the cache).
+   * If you override to perform additional operations, do not forget to
+   * call this base version in the derived classes.
+   */
+  virtual void resizeCache();
+
+  /** Sub-methods of resizeCache resizing the value cache vector (if used).
+   * To be used by derived classes that need this level of granularity.
+   */
+  void resizeValueCache();
+  /** Sub-methods of resizeCache resizing the jacobian cache matrices (if
+   * used).
+   * To be used by derived classes that need this level of granularity.
+   */
+  void resizeJacobianCache();
+
+  /** Add a variable. Cache is automatically updated.
+   * \param v The variable to add
+   * \param linear Specify that the entity is depending linearly on the
+   * variable or not.
+   */
+  void addVariable(VariablePtr v, bool linear);
+  /** Remove variable \p v. Cache is automatically updated. */
+  void removeVariable(VariablePtr v);
+
+  /** Add a variable vector.
+   *
+   * Convenience function similar to adding each elements of the vector individually with the same linear parameter
+   *
+   * \see addVariable(VariablePtr, bool)
+   *
+   */
+  void addVariable(const VariableVector & v, bool linear);
+
+  /** To be overriden by derived classes that need to react to
+   * the addition of a variable. Called at the end of addVariable();
+   */
+  virtual void addVariable_(VariablePtr);
+
+  /** To be overriden by derived classes that need to react to
+   * the removal of a variable. Called at the end of removeVariable();
+   */
+  virtual void removeVariable_(VariablePtr);
+
+  /** Split a jacobian matrix J into its components Ji corresponding to the
+   * provided variables.
+   *
+   * \param J The matrix to be split
+   * \param vars The vector of variables giving the layout of J. It is the
+   * user's responsibility to ensure these variables are part of variables_
+   * and that J has the correct size.
+   * \param keepProperties If true, the properties associated with matrices
+   * Ji are kept, if not they are reset to default.
+   */
+  void splitJacobian(const MatrixConstRef & J, const std::vector<VariablePtr> & vars, bool keepProperties = false);
+
+  /** Overload for VariableVector operations */
+  inline void splitJacobian(const MatrixConstRef & J, const VariableVector & vars, bool keepProperties = false)
   {
-  public:
-    SET_OUTPUTS(FirstOrderProvider, Value, Jacobian)
-
-    /** \internal by default, these methods return the cached value.
-      * However, they are virtual in case the user might want to bypass the cache.
-      * This would be typically the case if he/she wants to directly return the
-      * output of another method, e.g. return the jacobian of an other Function.
-      */
-    /** Return the value of this entity*/
-    virtual const Eigen::VectorXd& value() const;
-    /** Return the jacobian matrix of this entity corresponding to the variable
-      * \p x
-      */
-    virtual const MatrixWithProperties& jacobian(const Variable& x) const;
-
-    /** Linearity w.r.t \p x*/
-    bool linearIn(const Variable& x) const;
-
-    const Space& imageSpace() const;
-
-    /** Return the image space size.*/
-    int size() const;
-    /** Size of the output value (representation size of the image space).*/
-    int rSize() const;
-    /** Size of the tangent space to the image space (or equivalently row size of the jacobian matrices).*/
-    int tSize() const;
-
-    /** Return the variables*/
-    const VariableVector& variables() const;
-
-  protected:
-    /** Constructor for a function/constraint with value in \f$ \mathbb{R}^m \f$.
-      *
-      * \param m the size of the function/constraint image space, i.e. the row
-      * size of the jacobians (or equivalently in this case the size of the
-      * output value).
-      */
-    FirstOrderProvider(int m);
-
-    /** Constructor for a function/constraint with value in a specified space.
-      *
-      * \param image Description of the image space
-      */
-    FirstOrderProvider(Space image);
-
-    /** Resize all cache members corresponding to active outputs.
-      *
-      * This can be overriden in case you do not need all of the default
-      * mechanism (typically if you will not use part of the cache).
-      * If you override to perform additional operations, do not forget to
-      * call this base version in the derived classes.
-      */
-    virtual void resizeCache();
-
-    /** Sub-methods of resizeCache resizing the value cache vector (if used).
-      * To be used by derived classes that need this level of granularity.
-      */
-    void resizeValueCache();
-    /** Sub-methods of resizeCache resizing the jacobian cache matrices (if
-      * used).
-      * To be used by derived classes that need this level of granularity.
-      */
-    void resizeJacobianCache();
-
-    /** Add a variable. Cache is automatically updated.
-      * \param v The variable to add
-      * \param linear Specify that the entity is depending linearly on the
-      * variable or not.
-      */
-    void addVariable(VariablePtr v, bool linear);
-    /** Remove variable \p v. Cache is automatically updated. */
-    void removeVariable(VariablePtr v);
-
-    /** Add a variable vector.
-      *
-      * Convenience function similar to adding each elements of the vector individually with the same linear parameter
-      *
-      * \see addVariable(VariablePtr, bool)
-      *
-      */
-    void addVariable(const VariableVector & v, bool linear);
-
-    /** To be overriden by derived classes that need to react to
-      * the addition of a variable. Called at the end of addVariable();
-      */
-    virtual void addVariable_(VariablePtr);
-
-    /** To be overriden by derived classes that need to react to
-      * the removal of a variable. Called at the end of removeVariable();
-      */
-    virtual void removeVariable_(VariablePtr);
-
-    /** Split a jacobian matrix J into its components Ji corresponding to the
-      * provided variables. 
-      *
-      * \param J The matrix to be split
-      * \param vars The vector of variables giving the layout of J. It is the
-      * user's responsibility to ensure these variables are part of variables_
-      * and that J has the correct size.
-      * \param keepProperties If true, the properties associated with matrices
-      * Ji are kept, if not they are reset to default.
-      */
-    void splitJacobian(const MatrixConstRef& J, const std::vector<VariablePtr>& vars, bool keepProperties = false);
-
-    /** Overload for VariableVector operations */
-    inline void splitJacobian(const MatrixConstRef& J, const VariableVector& vars, bool keepProperties = false)
-    {
-      splitJacobian(J, vars.variables(), keepProperties);
-    }
-
-    // cache
-    Eigen::VectorXd value_;
-    utils::internal::map<Variable const*, MatrixWithProperties> jacobian_;
-  protected:
-    /** Resize the function */
-    void resize(int m);
-
-    Space imageSpace_; //output space
-    VariableVector variables_;
-    utils::internal::map<Variable const*, bool> linear_;
-  };
-
-
-  inline const Eigen::VectorXd& FirstOrderProvider::value() const
-  {
-    return value_;
+    splitJacobian(J, vars.variables(), keepProperties);
   }
 
-  inline const MatrixWithProperties& FirstOrderProvider::jacobian(const Variable& x) const
-  {
-    return jacobian_.at(&x);
-  }
+  // cache
+  Eigen::VectorXd value_;
+  utils::internal::map<Variable const *, MatrixWithProperties> jacobian_;
 
-  inline bool FirstOrderProvider::linearIn(const Variable& x) const
-  {
-    return linear_.at(&x);
-  }
+protected:
+  /** Resize the function */
+  void resize(int m);
 
-  inline const Space& FirstOrderProvider::imageSpace() const
-  {
-    return imageSpace_;
-  }
+  Space imageSpace_; // output space
+  VariableVector variables_;
+  utils::internal::map<Variable const *, bool> linear_;
+};
 
-  inline int FirstOrderProvider::size() const
-  {
-    return imageSpace_.size();
-  }
+inline const Eigen::VectorXd & FirstOrderProvider::value() const { return value_; }
 
-  inline int FirstOrderProvider::rSize() const
-  {
-    return imageSpace_.rSize();
-  }
-  inline int FirstOrderProvider::tSize() const
-  {
-    return imageSpace_.tSize();
-  }
+inline const MatrixWithProperties & FirstOrderProvider::jacobian(const Variable & x) const { return jacobian_.at(&x); }
 
-  inline const VariableVector& FirstOrderProvider::variables() const
-  {
-    return variables_;
-  }
+inline bool FirstOrderProvider::linearIn(const Variable & x) const { return linear_.at(&x); }
 
-}  // namespace internal
+inline const Space & FirstOrderProvider::imageSpace() const { return imageSpace_; }
 
-}  // namespace tvm
+inline int FirstOrderProvider::size() const { return imageSpace_.size(); }
+
+inline int FirstOrderProvider::rSize() const { return imageSpace_.rSize(); }
+inline int FirstOrderProvider::tSize() const { return imageSpace_.tSize(); }
+
+inline const VariableVector & FirstOrderProvider::variables() const { return variables_; }
+
+} // namespace internal
+
+} // namespace tvm

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
+#include <tvm/defs.h>
+
 #include <tvm/Variable.h>
 #include <tvm/VariableVector.h>
-#include <tvm/defs.h>
 #include <tvm/graph/abstract/Node.h>
 #include <tvm/internal/MatrixWithProperties.h>
 #include <tvm/utils/internal/map.h>

--- a/include/tvm/internal/IdProvider.h
+++ b/include/tvm/internal/IdProvider.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/internal/IdProvider.h
+++ b/include/tvm/internal/IdProvider.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,22 +38,22 @@ namespace tvm
 
 namespace internal
 {
-  /** A small helper class to provide unique ids.*/
-  class TVM_DLLAPI IdProvider
-  {
-  public:
-    int makeId();
-  private:
-    std::mutex mutex_;
-    int id_ = 0;
-  };
+/** A small helper class to provide unique ids.*/
+class TVM_DLLAPI IdProvider
+{
+public:
+  int makeId();
 
+private:
+  std::mutex mutex_;
+  int id_ = 0;
+};
 
-  inline int IdProvider::makeId()
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return id_++;
-  }
-}  // namespace internal
+inline int IdProvider::makeId()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return id_++;
+}
+} // namespace internal
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/internal/MatrixProperties.h
+++ b/include/tvm/internal/MatrixProperties.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/internal/MatrixProperties.h
+++ b/include/tvm/internal/MatrixProperties.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,301 +39,240 @@ namespace tvm
 namespace internal
 {
 
-  /** This class describes some mathematical properties of a matrix. */
-  class TVM_DLLAPI MatrixProperties
+/** This class describes some mathematical properties of a matrix. */
+class TVM_DLLAPI MatrixProperties
+{
+public:
+  /** Shape of a matrix*/
+  enum Shape
   {
-  public:
-    /** Shape of a matrix*/
-    enum Shape
-    {
-      /** general shape. This includes all other shapes. */
-      GENERAL,
-      /** lower triangular matrix. This includes diagonal matrices. */
-      LOWER_TRIANGULAR,
-      /** upper triangular matrix. This includes diagonal matrices. */
-      UPPER_TRIANGULAR,
-      /** diagonal matrices. This includes multiple of the identity matrices
-        * (including zero matrix).
-        */
-      DIAGONAL,
-      /** a*I, where a is a real number. This includes the case a=-1, a=0, and a=1. */
-      MULTIPLE_OF_IDENTITY,
-      /** identity matrix I */
-      IDENTITY,
-      /** -I */
-      MINUS_IDENTITY,
-      /** Zero matrix.*/
-      ZERO
-    };
-
-    /** Positiveness property of the matrix. Any options other than NA implies
-      * that the matrix is symmetric
-      */
-    enum Positiveness
-    {
-      /** not applicable (matrix is not symmetric) / unknown */
-      NA,
-      /** all eigenvalues are >=0 */
-      POSITIVE_SEMIDEFINITE,
-      /** all eigenvalues are >0 */
-      POSITIVE_DEFINITE,
-      /** all eigenvalues are <=0 */
-      NEGATIVE_SEMIDEFINITE,
-      /** all eigenvalues are <0 */
-      NEGATIVE_DEFINITE,
-      /** eigenvalues are a mix of positive, negative and 0 */
-      INDEFINITE,
-      /** eigenvalues are a mix of positive, negative but not 0 */
-      NON_ZERO_INDEFINITE
-    };
-
-    /** A wrapper over a boolean representing the constness of a matrix.*/
-    struct Constness
-    {
-    public:
-      Constness(bool b = false) : b_(b) {}
-      operator bool() const { return b_; }
-    private:
-      bool b_;
-    };
-
-    /** A wrapper over a boolean representing the invertibility of a matrix.*/
-    struct Invertibility
-    {
-    public:
-      Invertibility(bool b = false) : b_(b) {}
-      operator bool() const { return b_; }
-    private:
-      bool b_;
-    };
-
-    /** The data given to the constructors may be redundant. For example an
-      * identity matrix is constant, invertible and positive definite. The
-      * constructors are deducing automatically all what they can from the
-      * shape and the positiveness.
-      * The constructors use user-given data when they add information to what
-      * they can deduce. If the user-given data are less precise but compatible
-      * with what has been deduced, they are discarded. If they are
-      * contradicting the deductions, an assertion is fired.
-      *
-      * Here are some examples:
-      * - a multiple-of-identity matrix can only be said to be symmetric and
-      * undefinite. If the user specifies it is positive-semidefinite, this
-      * will be recorded. If additionnally it is specified to be invertible, it
-      * will be deduced that the matrix is positive definite.
-      * - if a minus-identity matrix is said to be non-zero undefinite, this
-      * caracteristic will be discarded as it can be automatically deduced that
-      * the matrix is negative definite. If it is said to be positive definite,
-      * non constant or non invertible, an assertion will be fire as this
-      * contradicts what can be deduced.
-      * - if a matrix is triangular and symmetric, then it is diagonal.
-      */
-    MatrixProperties();
-    template<typename ... Args>
-    MatrixProperties(Args && ... args);
-
-    Shape shape() const;
-    Positiveness positiveness() const;
-    Constness constness() const;
-    Invertibility invertibility() const;
-
-    bool isConstant() const;
-    bool isInvertible() const;
-    bool isTriangular() const;
-    bool isLowerTriangular() const;
-    bool isUpperTriangular() const;
-    bool isDiagonal() const;
-    bool isMultipleOfIdentity() const;
-    bool isIdentity() const;
-    bool isMinusIdentity() const;
-    bool isZero() const;
-    bool isSymmetric() const;
-    bool isPositiveSemiDefinite() const;
-    bool isPositiveDefinite() const;
-    bool isNegativeSemidefinite() const;
-    bool isNegativeDefinite() const;
-    bool isIndefinite() const;
-    bool isNonZeroIndefinite() const;
-
-  private:
-    /** This macro adds a member of type T named \a member to a struct, and
-      * a method \a processArgs to process it when it appears in a list of
-      * arguments.
-      * processArgs return a pair of boolean that is the memberwise "or" of
-      * another pair it gets by recursive call and {b1, b2}
-      */
-#define ADD_ARGUMENT(T, member, b1, b2) \
-    T member = T(); \
-    template<typename ... Args> \
-    std::pair<bool,bool> processArgs(const T& m, const Args& ... args) \
-    { \
-      static_assert(!check_args<T, Args...>(), \
-                    #T" has already been specified"); \
-      member = m; \
-      auto p = processArgs(args...); \
-      return {p.first || b1, p.second || b2}; \
-    }
-
-    struct Arguments
-    {
-      ADD_ARGUMENT(Shape, shape, false, false)
-      ADD_ARGUMENT(Positiveness, positiveness, false, false)
-      ADD_ARGUMENT(Constness, constant, true, false)
-      ADD_ARGUMENT(Invertibility, invertible, false, true)
-
-      std::pair<bool, bool> processArgs() { return{ false, false }; }
-
-    private:
-      template<typename T, typename Arg0, typename ... Args>
-      static constexpr bool check_args()
-      {
-        return std::is_same<T, Arg0>::value || check_args<T, Args...>();
-      }
-
-      template<typename T>
-      static constexpr bool check_args()
-      {
-        return false;
-      }
-    };
-
-    void build(const Arguments& args, const std::pair<bool, bool>& checks);
-
-    bool        constant_;
-    bool        invertible_;
-    Shape       shape_;
-    bool        symmetric_;
-    Positiveness positiveness_;
+    /** general shape. This includes all other shapes. */
+    GENERAL,
+    /** lower triangular matrix. This includes diagonal matrices. */
+    LOWER_TRIANGULAR,
+    /** upper triangular matrix. This includes diagonal matrices. */
+    UPPER_TRIANGULAR,
+    /** diagonal matrices. This includes multiple of the identity matrices
+     * (including zero matrix).
+     */
+    DIAGONAL,
+    /** a*I, where a is a real number. This includes the case a=-1, a=0, and a=1. */
+    MULTIPLE_OF_IDENTITY,
+    /** identity matrix I */
+    IDENTITY,
+    /** -I */
+    MINUS_IDENTITY,
+    /** Zero matrix.*/
+    ZERO
   };
 
-
-  // operators
-  TVM_DLLAPI MatrixProperties operator-(const MatrixProperties&);
-  TVM_DLLAPI MatrixProperties operator*(double, const MatrixProperties&);
-  TVM_DLLAPI MatrixProperties operator+(const MatrixProperties&, const MatrixProperties&);
-  TVM_DLLAPI MatrixProperties operator-(const MatrixProperties&, const MatrixProperties&);
-  TVM_DLLAPI MatrixProperties operator*(const MatrixProperties&, const MatrixProperties&);
-
-  template<typename ... Args>
-  inline MatrixProperties::MatrixProperties(Args && ... args)
+  /** Positiveness property of the matrix. Any options other than NA implies
+   * that the matrix is symmetric
+   */
+  enum Positiveness
   {
-    Arguments a;
-    auto p = a.processArgs(args...);
-    build(a, p);
+    /** not applicable (matrix is not symmetric) / unknown */
+    NA,
+    /** all eigenvalues are >=0 */
+    POSITIVE_SEMIDEFINITE,
+    /** all eigenvalues are >0 */
+    POSITIVE_DEFINITE,
+    /** all eigenvalues are <=0 */
+    NEGATIVE_SEMIDEFINITE,
+    /** all eigenvalues are <0 */
+    NEGATIVE_DEFINITE,
+    /** eigenvalues are a mix of positive, negative and 0 */
+    INDEFINITE,
+    /** eigenvalues are a mix of positive, negative but not 0 */
+    NON_ZERO_INDEFINITE
+  };
+
+  /** A wrapper over a boolean representing the constness of a matrix.*/
+  struct Constness
+  {
+  public:
+    Constness(bool b = false) : b_(b) {}
+    operator bool() const { return b_; }
+
+  private:
+    bool b_;
+  };
+
+  /** A wrapper over a boolean representing the invertibility of a matrix.*/
+  struct Invertibility
+  {
+  public:
+    Invertibility(bool b = false) : b_(b) {}
+    operator bool() const { return b_; }
+
+  private:
+    bool b_;
+  };
+
+  /** The data given to the constructors may be redundant. For example an
+   * identity matrix is constant, invertible and positive definite. The
+   * constructors are deducing automatically all what they can from the
+   * shape and the positiveness.
+   * The constructors use user-given data when they add information to what
+   * they can deduce. If the user-given data are less precise but compatible
+   * with what has been deduced, they are discarded. If they are
+   * contradicting the deductions, an assertion is fired.
+   *
+   * Here are some examples:
+   * - a multiple-of-identity matrix can only be said to be symmetric and
+   * undefinite. If the user specifies it is positive-semidefinite, this
+   * will be recorded. If additionnally it is specified to be invertible, it
+   * will be deduced that the matrix is positive definite.
+   * - if a minus-identity matrix is said to be non-zero undefinite, this
+   * caracteristic will be discarded as it can be automatically deduced that
+   * the matrix is negative definite. If it is said to be positive definite,
+   * non constant or non invertible, an assertion will be fire as this
+   * contradicts what can be deduced.
+   * - if a matrix is triangular and symmetric, then it is diagonal.
+   */
+  MatrixProperties();
+  template<typename... Args>
+  MatrixProperties(Args &&... args);
+
+  Shape shape() const;
+  Positiveness positiveness() const;
+  Constness constness() const;
+  Invertibility invertibility() const;
+
+  bool isConstant() const;
+  bool isInvertible() const;
+  bool isTriangular() const;
+  bool isLowerTriangular() const;
+  bool isUpperTriangular() const;
+  bool isDiagonal() const;
+  bool isMultipleOfIdentity() const;
+  bool isIdentity() const;
+  bool isMinusIdentity() const;
+  bool isZero() const;
+  bool isSymmetric() const;
+  bool isPositiveSemiDefinite() const;
+  bool isPositiveDefinite() const;
+  bool isNegativeSemidefinite() const;
+  bool isNegativeDefinite() const;
+  bool isIndefinite() const;
+  bool isNonZeroIndefinite() const;
+
+private:
+  /** This macro adds a member of type T named \a member to a struct, and
+   * a method \a processArgs to process it when it appears in a list of
+   * arguments.
+   * processArgs return a pair of boolean that is the memberwise "or" of
+   * another pair it gets by recursive call and {b1, b2}
+   */
+#define ADD_ARGUMENT(T, member, b1, b2)                                         \
+  T member = T();                                                               \
+  template<typename... Args>                                                    \
+  std::pair<bool, bool> processArgs(const T & m, const Args &... args)          \
+  {                                                                             \
+    static_assert(!check_args<T, Args...>(), #T " has already been specified"); \
+    member = m;                                                                 \
+    auto p = processArgs(args...);                                              \
+    return {p.first || b1, p.second || b2};                                     \
   }
 
-
-  inline MatrixProperties::Shape MatrixProperties::shape() const
+  struct Arguments
   {
-    return shape_;
-  }
+    ADD_ARGUMENT(Shape, shape, false, false)
+    ADD_ARGUMENT(Positiveness, positiveness, false, false)
+    ADD_ARGUMENT(Constness, constant, true, false)
+    ADD_ARGUMENT(Invertibility, invertible, false, true)
 
-  inline MatrixProperties::Positiveness MatrixProperties::positiveness() const
-  {
-    return positiveness_;
-  }
+    std::pair<bool, bool> processArgs() { return {false, false}; }
 
-  inline MatrixProperties::Constness MatrixProperties::constness() const
-  {
-    return constant_;
-  }
+  private:
+    template<typename T, typename Arg0, typename... Args>
+    static constexpr bool check_args()
+    {
+      return std::is_same<T, Arg0>::value || check_args<T, Args...>();
+    }
 
-  inline MatrixProperties::Invertibility MatrixProperties::invertibility() const
-  {
-    return invertible_;
-  }
+    template<typename T>
+    static constexpr bool check_args()
+    {
+      return false;
+    }
+  };
 
-  inline bool MatrixProperties::isConstant() const
-  {
-    return constant_;
-  }
+  void build(const Arguments & args, const std::pair<bool, bool> & checks);
 
-  inline bool MatrixProperties::isInvertible() const
-  {
-    return invertible_;
-  }
+  bool constant_;
+  bool invertible_;
+  Shape shape_;
+  bool symmetric_;
+  Positiveness positiveness_;
+};
 
-  inline bool MatrixProperties::isTriangular() const
-  {
-    return shape_ >= Shape::LOWER_TRIANGULAR;
-  }
+// operators
+TVM_DLLAPI MatrixProperties operator-(const MatrixProperties &);
+TVM_DLLAPI MatrixProperties operator*(double, const MatrixProperties &);
+TVM_DLLAPI MatrixProperties operator+(const MatrixProperties &, const MatrixProperties &);
+TVM_DLLAPI MatrixProperties operator-(const MatrixProperties &, const MatrixProperties &);
+TVM_DLLAPI MatrixProperties operator*(const MatrixProperties &, const MatrixProperties &);
 
-  inline bool MatrixProperties::isLowerTriangular() const
-  {
-    return shape_ == Shape::LOWER_TRIANGULAR || isDiagonal();
-  }
+template<typename... Args>
+inline MatrixProperties::MatrixProperties(Args &&... args)
+{
+  Arguments a;
+  auto p = a.processArgs(args...);
+  build(a, p);
+}
 
-  inline bool MatrixProperties::isUpperTriangular() const
-  {
-    return shape_ >= Shape::UPPER_TRIANGULAR;
-  }
+inline MatrixProperties::Shape MatrixProperties::shape() const { return shape_; }
 
-  inline bool MatrixProperties::isDiagonal() const
-  {
-    return shape_ >= Shape::DIAGONAL;
-  }
+inline MatrixProperties::Positiveness MatrixProperties::positiveness() const { return positiveness_; }
 
-  inline bool MatrixProperties::isMultipleOfIdentity() const
-  {
-    return shape_ >= Shape::MULTIPLE_OF_IDENTITY;
-  }
+inline MatrixProperties::Constness MatrixProperties::constness() const { return constant_; }
 
-  inline bool MatrixProperties::isIdentity() const
-  {
-    return shape_ == Shape::IDENTITY;
-  }
+inline MatrixProperties::Invertibility MatrixProperties::invertibility() const { return invertible_; }
 
-  inline bool MatrixProperties::isMinusIdentity() const
-  {
-    return shape_ == Shape::MINUS_IDENTITY;
-  }
+inline bool MatrixProperties::isConstant() const { return constant_; }
 
-  inline bool MatrixProperties::isZero() const
-  {
-    return shape_ == Shape::ZERO;
-  }
+inline bool MatrixProperties::isInvertible() const { return invertible_; }
 
-  inline bool MatrixProperties::isSymmetric() const
-  {
-    return symmetric_;
-  }
+inline bool MatrixProperties::isTriangular() const { return shape_ >= Shape::LOWER_TRIANGULAR; }
 
-  inline bool MatrixProperties::isPositiveSemiDefinite() const
-  {
-    return positiveness_ == Positiveness::POSITIVE_SEMIDEFINITE
-        || isPositiveDefinite()
-        || isZero();
-  }
+inline bool MatrixProperties::isLowerTriangular() const { return shape_ == Shape::LOWER_TRIANGULAR || isDiagonal(); }
 
-  inline bool MatrixProperties::isPositiveDefinite() const
-  {
-    return positiveness_ == Positiveness::POSITIVE_DEFINITE;
-  }
+inline bool MatrixProperties::isUpperTriangular() const { return shape_ >= Shape::UPPER_TRIANGULAR; }
 
-  inline bool MatrixProperties::isNegativeSemidefinite() const
-  {
-    return positiveness_ == Positiveness::NEGATIVE_SEMIDEFINITE
-        || isNegativeDefinite()
-        || isZero();
-  }
+inline bool MatrixProperties::isDiagonal() const { return shape_ >= Shape::DIAGONAL; }
 
-  inline bool MatrixProperties::isNegativeDefinite() const
-  {
-    return positiveness_ == Positiveness::NEGATIVE_DEFINITE;
-  }
+inline bool MatrixProperties::isMultipleOfIdentity() const { return shape_ >= Shape::MULTIPLE_OF_IDENTITY; }
 
-  inline bool MatrixProperties::isIndefinite() const
-  {
-    return positiveness_ != Positiveness::NA;
-  }
+inline bool MatrixProperties::isIdentity() const { return shape_ == Shape::IDENTITY; }
 
-  inline bool MatrixProperties::isNonZeroIndefinite() const
-  {
-    return positiveness_ == Positiveness::NON_ZERO_INDEFINITE
-        || isPositiveDefinite()
-        || isNegativeDefinite();
-  }
+inline bool MatrixProperties::isMinusIdentity() const { return shape_ == Shape::MINUS_IDENTITY; }
 
-}  // namespace internal
+inline bool MatrixProperties::isZero() const { return shape_ == Shape::ZERO; }
 
-}  // namespace tvm
+inline bool MatrixProperties::isSymmetric() const { return symmetric_; }
+
+inline bool MatrixProperties::isPositiveSemiDefinite() const
+{
+  return positiveness_ == Positiveness::POSITIVE_SEMIDEFINITE || isPositiveDefinite() || isZero();
+}
+
+inline bool MatrixProperties::isPositiveDefinite() const { return positiveness_ == Positiveness::POSITIVE_DEFINITE; }
+
+inline bool MatrixProperties::isNegativeSemidefinite() const
+{
+  return positiveness_ == Positiveness::NEGATIVE_SEMIDEFINITE || isNegativeDefinite() || isZero();
+}
+
+inline bool MatrixProperties::isNegativeDefinite() const { return positiveness_ == Positiveness::NEGATIVE_DEFINITE; }
+
+inline bool MatrixProperties::isIndefinite() const { return positiveness_ != Positiveness::NA; }
+
+inline bool MatrixProperties::isNonZeroIndefinite() const
+{
+  return positiveness_ == Positiveness::NON_ZERO_INDEFINITE || isPositiveDefinite() || isNegativeDefinite();
+}
+
+} // namespace internal
+
+} // namespace tvm

--- a/include/tvm/internal/MatrixWithProperties.h
+++ b/include/tvm/internal/MatrixWithProperties.h
@@ -58,8 +58,7 @@ public:
   template<typename OtherDerived>
   ObjectWithProperties(const Eigen::MatrixBase<OtherDerived> & other, const MatrixProperties & p)
   : MatrixType(other), properties_(p)
-  {
-  }
+  {}
 
   template<typename OtherDerived>
   ObjectWithProperties & operator=(const Eigen::MatrixBase<OtherDerived> & other)

--- a/include/tvm/internal/MatrixWithProperties.h
+++ b/include/tvm/internal/MatrixWithProperties.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/internal/MatrixWithProperties.h
+++ b/include/tvm/internal/MatrixWithProperties.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,108 +38,111 @@ namespace tvm
 
 namespace internal
 {
-  //forward declaration
-  template<typename MatrixType>
-  class ObjectWithProperties;
+// forward declaration
+template<typename MatrixType>
+class ObjectWithProperties;
 
-  /** A lightweight proxy for indicating if the assignement of an Eigen
-    * expression to a MatrixWithProperties should reset the properties (which is
-    * the default behavior.
-    *
-    * \internal FIXME? Have a version which is compatible with Eigen::NoAlias (if needed).
-    */
-  template<typename MatrixType>
-  class KeepProperties
-  {
-  public:
-    /** Create the proxy.
-      *
-      * \param M The MatrixWithProperties
-      * \param keep Specifies if the properties should be kept (\p true) or not
-      * (\p false)
-      */
-    KeepProperties(ObjectWithProperties<MatrixType>& M, bool keep) : M_(M), keep_(keep) {}
+/** A lightweight proxy for indicating if the assignement of an Eigen
+ * expression to a MatrixWithProperties should reset the properties (which is
+ * the default behavior.
+ *
+ * \internal FIXME? Have a version which is compatible with Eigen::NoAlias (if needed).
+ */
+template<typename MatrixType>
+class KeepProperties
+{
+public:
+  /** Create the proxy.
+   *
+   * \param M The MatrixWithProperties
+   * \param keep Specifies if the properties should be kept (\p true) or not
+   * (\p false)
+   */
+  KeepProperties(ObjectWithProperties<MatrixType> & M, bool keep) : M_(M), keep_(keep) {}
 
-    /** The assignment operator for Eigen's expression*/
-    template<typename OtherDerived>
-    ObjectWithProperties<MatrixType>& operator=(const Eigen::MatrixBase<OtherDerived>& other);
-
-    /** We delete this operator so that it cannot be used for the classical copy
-      * operator of MatrixWithProperties. */
-    ObjectWithProperties<MatrixType>& operator=(const ObjectWithProperties<MatrixType>&) = delete;
-
-  private:
-    ObjectWithProperties<MatrixType>& M_;
-    const bool keep_;
-  };
-
-  /** An Eigen object together with MatrixProperties. */
-  template<typename MatrixType>
-  class ObjectWithProperties : public MatrixType
-  {
-  public:
-    using MatrixType::MatrixType;
-
-    ObjectWithProperties() {}
-
-    template<typename OtherDerived>
-    ObjectWithProperties(const Eigen::MatrixBase<OtherDerived>& other, const MatrixProperties& p)
-      : MatrixType(other), properties_(p)
-    {
-    }
-
-    template<typename OtherDerived>
-    ObjectWithProperties& operator=(const Eigen::MatrixBase<OtherDerived>& other)
-    {
-      assert(this->rows() == other.rows() && this->cols() == other.cols()
-        && "It is not allowed to assign an expression with a different size. Please explicitely resize the matrix before.");
-      this->MatrixType::operator=(other);
-      properties_ = MatrixProperties();
-      return *this;
-    }
-
-    template<typename OtherDerived>
-    ObjectWithProperties& assignKeepProperties(const Eigen::MatrixBase<OtherDerived>& other)
-    {
-      assert(this->rows() == other.rows() && this->cols() == other.cols()
-        && "It is not allowed to assign an expression with a different size. Please explicitely resize the matrix before.");
-      this->MatrixType::operator=(other);
-      return *this;
-    }
-
-    const MatrixProperties& properties() const { return properties_; }
-    void properties(const MatrixProperties& p) { properties_ = p; }
-
-    /** Create a proxy to specify wether an assignement should preserve the
-      * properties of the matrix. 
-      *
-      * \param keep true it the properties should be left untouched, false
-      * otherwise.
-      */
-    KeepProperties<MatrixType> keepProperties(bool keep) { return { *this, keep }; }
-
-  private:
-    MatrixProperties properties_;
-  };
-
-  template<typename MatrixType>
+  /** The assignment operator for Eigen's expression*/
   template<typename OtherDerived>
-  inline ObjectWithProperties<MatrixType>& KeepProperties<MatrixType>::operator=(const Eigen::MatrixBase<OtherDerived>& other)
+  ObjectWithProperties<MatrixType> & operator=(const Eigen::MatrixBase<OtherDerived> & other);
+
+  /** We delete this operator so that it cannot be used for the classical copy
+   * operator of MatrixWithProperties. */
+  ObjectWithProperties<MatrixType> & operator=(const ObjectWithProperties<MatrixType> &) = delete;
+
+private:
+  ObjectWithProperties<MatrixType> & M_;
+  const bool keep_;
+};
+
+/** An Eigen object together with MatrixProperties. */
+template<typename MatrixType>
+class ObjectWithProperties : public MatrixType
+{
+public:
+  using MatrixType::MatrixType;
+
+  ObjectWithProperties() {}
+
+  template<typename OtherDerived>
+  ObjectWithProperties(const Eigen::MatrixBase<OtherDerived> & other, const MatrixProperties & p)
+  : MatrixType(other), properties_(p)
   {
-    if (keep_)
-    {
-      M_.assignKeepProperties(other);
-    }
-    else
-    {
-      M_ = other;
-    }
-    return M_;
   }
 
-  using MatrixWithProperties = ObjectWithProperties<Eigen::MatrixXd>;
-  using VectorWithProperties = ObjectWithProperties<Eigen::VectorXd>;
+  template<typename OtherDerived>
+  ObjectWithProperties & operator=(const Eigen::MatrixBase<OtherDerived> & other)
+  {
+    assert(this->rows() == other.rows() && this->cols() == other.cols()
+           && "It is not allowed to assign an expression with a different size. Please explicitely resize the matrix "
+              "before.");
+    this->MatrixType::operator=(other);
+    properties_ = MatrixProperties();
+    return *this;
+  }
 
-}  // namespace internal
+  template<typename OtherDerived>
+  ObjectWithProperties & assignKeepProperties(const Eigen::MatrixBase<OtherDerived> & other)
+  {
+    assert(this->rows() == other.rows() && this->cols() == other.cols()
+           && "It is not allowed to assign an expression with a different size. Please explicitely resize the matrix "
+              "before.");
+    this->MatrixType::operator=(other);
+    return *this;
+  }
 
-}  // namespace tvm
+  const MatrixProperties & properties() const { return properties_; }
+  void properties(const MatrixProperties & p) { properties_ = p; }
+
+  /** Create a proxy to specify wether an assignement should preserve the
+   * properties of the matrix.
+   *
+   * \param keep true it the properties should be left untouched, false
+   * otherwise.
+   */
+  KeepProperties<MatrixType> keepProperties(bool keep) { return {*this, keep}; }
+
+private:
+  MatrixProperties properties_;
+};
+
+template<typename MatrixType>
+template<typename OtherDerived>
+inline ObjectWithProperties<MatrixType> & KeepProperties<MatrixType>::operator=(
+    const Eigen::MatrixBase<OtherDerived> & other)
+{
+  if(keep_)
+  {
+    M_.assignKeepProperties(other);
+  }
+  else
+  {
+    M_ = other;
+  }
+  return M_;
+}
+
+using MatrixWithProperties = ObjectWithProperties<Eigen::MatrixXd>;
+using VectorWithProperties = ObjectWithProperties<Eigen::VectorXd>;
+
+} // namespace internal
+
+} // namespace tvm

--- a/include/tvm/internal/ObjWithId.h
+++ b/include/tvm/internal/ObjWithId.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/internal/ObjWithId.h
+++ b/include/tvm/internal/ObjWithId.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,23 +39,23 @@ namespace tvm
 namespace internal
 {
 
-  /** A class with a unique id.*/
-  class TVM_DLLAPI ObjWithId
-  {
-  public:
-    ObjWithId(const ObjWithId&) = delete;
-    ObjWithId& operator=(const ObjWithId&) = delete;
+/** A class with a unique id.*/
+class TVM_DLLAPI ObjWithId
+{
+public:
+  ObjWithId(const ObjWithId &) = delete;
+  ObjWithId & operator=(const ObjWithId &) = delete;
 
-    int id() const { return id_; }
+  int id() const { return id_; }
 
-  protected:
-    ObjWithId() : id_(ObjWithId::idProvider_.makeId()) {}
+protected:
+  ObjWithId() : id_(ObjWithId::idProvider_.makeId()) {}
 
-  private:
-    static IdProvider idProvider_;
-    int id_;
-  };
+private:
+  static IdProvider idProvider_;
+  int id_;
+};
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/internal/PairElementToken.h
+++ b/include/tvm/internal/PairElementToken.h
@@ -8,146 +8,138 @@
 
 namespace tvm::internal
 {
-  class PairElementToken;
+class PairElementToken;
 
-  /** Proxy over a PairElementToken from which can be create a paired token.
-    *
-    * \internal This class allows to delay the construction of the second element
-    * a pair of token, avoiding constructions and moves
-    */
-  class PairElementTokenHandle
+/** Proxy over a PairElementToken from which can be create a paired token.
+ *
+ * \internal This class allows to delay the construction of the second element
+ * a pair of token, avoiding constructions and moves
+ */
+class PairElementTokenHandle
+{
+public:
+  PairElementTokenHandle() = delete;
+  PairElementTokenHandle(const PairElementTokenHandle &) = delete;
+  PairElementTokenHandle(PairElementTokenHandle &&) = delete;
+  PairElementTokenHandle & operator=(const PairElementTokenHandle &) = delete;
+  PairElementTokenHandle & operator=(PairElementTokenHandle &&) = delete;
+
+  explicit PairElementTokenHandle(PairElementToken & t) noexcept;
+
+  bool isValid() const { return token_ != nullptr; }
+
+private:
+  void invalidate() { token_ = nullptr; }
+
+  PairElementToken * token_;
+
+  friend PairElementToken;
+};
+
+/** A class for representing a token that can be paired with another one.
+ * Paired tokens inform each other in case they are moved or destroyed so that
+ * they can keep track of one another.
+ * Each Token must be unique and therefore cannot be copied.
+ */
+class PairElementToken
+{
+public:
+  PairElementToken() noexcept {}
+  PairElementToken(const PairElementToken &) = delete; // To keep a pair valid we cannot duplicate tokens
+  PairElementToken & operator=(const PairElementToken &) = delete; // idem
+
+  /** Move constructor.*/
+  PairElementToken(PairElementToken && other) noexcept : otherPairElement_(other.otherPairElement_)
   {
-  public:
-    PairElementTokenHandle() = delete;
-    PairElementTokenHandle(const PairElementTokenHandle&) = delete;
-    PairElementTokenHandle(PairElementTokenHandle&&) = delete;
-    PairElementTokenHandle& operator=(const PairElementTokenHandle&) = delete;
-    PairElementTokenHandle& operator=(PairElementTokenHandle&&) = delete;
-
-    explicit PairElementTokenHandle(PairElementToken& t) noexcept;
-
-    bool isValid() const { return token_ != nullptr; }
-
-  private:
-    void invalidate() { token_ = nullptr; }
-
-    PairElementToken* token_;
-
-    friend PairElementToken;
-  };
-
-  /** A class for representing a token that can be paired with another one.
-    * Paired tokens inform each other in case they are moved or destroyed so that
-    * they can keep track of one another.
-    * Each Token must be unique and therefore cannot be copied.
-    */
-  class PairElementToken
-  {
-  public:
-    PairElementToken() noexcept {}
-    PairElementToken(const PairElementToken&) = delete;             // To keep a pair valid we cannot duplicate tokens
-    PairElementToken& operator=(const PairElementToken&) = delete;  // idem
-
-    /** Move constructor.*/
-    PairElementToken(PairElementToken&& other) noexcept
-      : otherPairElement_(other.otherPairElement_)
-    {
-      other.otherPairElement_ = nullptr; // we need to leave the previous token in an unpaired state.
-      if (isPaired())
-        otherPairElement_->notifyMove(this); // if paired, we need to notify to otherPairElement_ that this changed place.
-    }
-
-    /** Construction from a PairElementTokenHandle. The token constructed and the
-      * token pointed to by the handle are paired.
-      */
-    PairElementToken(PairElementTokenHandle&& h) noexcept
-      : otherPairElement_(h.token_)
-    {
-      assert(h.isValid());
-      h.token_->otherPairElement_ = this;
-      h.invalidate();
-    }
-
-    /** Move-assign operator*/
-    PairElementToken& operator=(PairElementToken&& other) noexcept
-    {
-      if (isPaired())                 // If we move into an already paired token, we basically erase it and its paired element must be notified
-        otherPairElement_->notifyDeath();
-      otherPairElement_ = other.otherPairElement_;
-      other.otherPairElement_ = nullptr;   // we need to leave the previous token in an unpaired state.
-      if (isPaired())
-        otherPairElement_->notifyMove(this); // if paired, we need to notify to otherPairElement_ that this changed place.
-      return *this;
-    }
-
-    /** Move-assign-like operator for PairElementTokenHandle. The token assigned
-      * to and the token pointed to by the handle are paired.
-      */
-    PairElementToken& operator=(PairElementTokenHandle&& h) noexcept
-    {
-      assert(h.isValid());
-      if (isPaired())                 // If we move into an already paired token, we basically erase it and its  paired element must be notified
-        otherPairElement_->notifyDeath();
-      otherPairElement_ = h.token_;
-      h.token_->otherPairElement_ = this;
-      h.invalidate();                 // we need to leave the handle in an invalid state.
-      return *this;
-    }
-
-    ~PairElementToken()
-    {
-      if (isPaired())
-        otherPairElement_->notifyDeath();
-    }
-
-    /** Pair this with other. Throw if this object is already paired.*/
-    void pairWith(PairElementToken& other)
-    {
-      if (isPaired() || other.isPaired())
-        throw std::runtime_error("Can only pair if both tokens are unpaired.");
-      otherPairElement_ = &other;
-      other.otherPairElement_ = this;
-    }
-
-    /** Is this token paired? */
-    bool isPaired() const { return otherPairElement_ != nullptr; }
-
-    /** Is this token paired with other? */
-    bool isPairedWith(const PairElementToken& other) const { return otherPairElement_ == &other; }
-
-    /** Return the other element of the pair. Throw if this object is not paired*/
-    const PairElementToken& otherPairElement() const
-    {
-      if (!isPaired())
-        throw std::runtime_error("This token is not paired.");
-      return *otherPairElement_;
-    }
-
-  private:
-    /** Create a token paired with \p other*/
-    PairElementToken(PairElementToken* other) 
-      : otherPairElement_(other) 
-    { 
-      assert(!other->isPaired());
-      other->otherPairElement_ = this;
-    }
-
-    void notifyMove(PairElementToken* newAddress)
-    {
-      otherPairElement_ = newAddress;
-    }
-
-    void notifyDeath()
-    {
-      otherPairElement_ = nullptr;
-    }
-
-    PairElementToken* otherPairElement_ = nullptr;
-  };
-
-
-  inline PairElementTokenHandle::PairElementTokenHandle(PairElementToken& t) noexcept : token_(&t)
-  {
-    assert(!t.isPaired() && "Input token is already paired.");
+    other.otherPairElement_ = nullptr; // we need to leave the previous token in an unpaired state.
+    if(isPaired())
+      otherPairElement_->notifyMove(this); // if paired, we need to notify to otherPairElement_ that this changed place.
   }
+
+  /** Construction from a PairElementTokenHandle. The token constructed and the
+   * token pointed to by the handle are paired.
+   */
+  PairElementToken(PairElementTokenHandle && h) noexcept : otherPairElement_(h.token_)
+  {
+    assert(h.isValid());
+    h.token_->otherPairElement_ = this;
+    h.invalidate();
+  }
+
+  /** Move-assign operator*/
+  PairElementToken & operator=(PairElementToken && other) noexcept
+  {
+    if(isPaired()) // If we move into an already paired token, we basically erase it and its paired element must be
+                   // notified
+      otherPairElement_->notifyDeath();
+    otherPairElement_ = other.otherPairElement_;
+    other.otherPairElement_ = nullptr; // we need to leave the previous token in an unpaired state.
+    if(isPaired())
+      otherPairElement_->notifyMove(this); // if paired, we need to notify to otherPairElement_ that this changed place.
+    return *this;
+  }
+
+  /** Move-assign-like operator for PairElementTokenHandle. The token assigned
+   * to and the token pointed to by the handle are paired.
+   */
+  PairElementToken & operator=(PairElementTokenHandle && h) noexcept
+  {
+    assert(h.isValid());
+    if(isPaired()) // If we move into an already paired token, we basically erase it and its  paired element must be
+                   // notified
+      otherPairElement_->notifyDeath();
+    otherPairElement_ = h.token_;
+    h.token_->otherPairElement_ = this;
+    h.invalidate(); // we need to leave the handle in an invalid state.
+    return *this;
+  }
+
+  ~PairElementToken()
+  {
+    if(isPaired())
+      otherPairElement_->notifyDeath();
+  }
+
+  /** Pair this with other. Throw if this object is already paired.*/
+  void pairWith(PairElementToken & other)
+  {
+    if(isPaired() || other.isPaired())
+      throw std::runtime_error("Can only pair if both tokens are unpaired.");
+    otherPairElement_ = &other;
+    other.otherPairElement_ = this;
+  }
+
+  /** Is this token paired? */
+  bool isPaired() const { return otherPairElement_ != nullptr; }
+
+  /** Is this token paired with other? */
+  bool isPairedWith(const PairElementToken & other) const { return otherPairElement_ == &other; }
+
+  /** Return the other element of the pair. Throw if this object is not paired*/
+  const PairElementToken & otherPairElement() const
+  {
+    if(!isPaired())
+      throw std::runtime_error("This token is not paired.");
+    return *otherPairElement_;
+  }
+
+private:
+  /** Create a token paired with \p other*/
+  PairElementToken(PairElementToken * other) : otherPairElement_(other)
+  {
+    assert(!other->isPaired());
+    other->otherPairElement_ = this;
+  }
+
+  void notifyMove(PairElementToken * newAddress) { otherPairElement_ = newAddress; }
+
+  void notifyDeath() { otherPairElement_ = nullptr; }
+
+  PairElementToken * otherPairElement_ = nullptr;
+};
+
+inline PairElementTokenHandle::PairElementTokenHandle(PairElementToken & t) noexcept : token_(&t)
+{
+  assert(!t.isPaired() && "Input token is already paired.");
 }
+} // namespace tvm::internal

--- a/include/tvm/internal/PairElementToken.h
+++ b/include/tvm/internal/PairElementToken.h
@@ -45,7 +45,7 @@ class PairElementToken
 {
 public:
   PairElementToken() noexcept {}
-  PairElementToken(const PairElementToken &) = delete; // To keep a pair valid we cannot duplicate tokens
+  PairElementToken(const PairElementToken &) = delete;             // To keep a pair valid we cannot duplicate tokens
   PairElementToken & operator=(const PairElementToken &) = delete; // idem
 
   /** Move constructor.*/

--- a/include/tvm/internal/enums.h
+++ b/include/tvm/internal/enums.h
@@ -1,36 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 // Disable ISO C99 requires rest arguments to be used
 #ifndef WIN32
-# pragma GCC system_header
+#  pragma GCC system_header
 #endif
 
 namespace tvm
@@ -50,26 +50,25 @@ namespace utils
  *
  */
 template<unsigned int N>
-constexpr unsigned int count_va_args(const char(&s)[N], unsigned int i = 0, unsigned int ret = 0)
+constexpr unsigned int count_va_args(const char (&s)[N], unsigned int i = 0, unsigned int ret = 0)
 {
-    return s[i] == '\0' ? ( i == 0 ? 0 : ret + 1 ) : count_va_args(s, i + 1, ret + (s[i] == ','));
+  return s[i] == '\0' ? (i == 0 ? 0 : ret + 1) : count_va_args(s, i + 1, ret + (s[i] == ','));
 }
 /** Macro call to count_va_args */
-#define COUNT_VA_ARGS(...) tvm::utils::count_va_args(""#__VA_ARGS__)
+#define COUNT_VA_ARGS(...) tvm::utils::count_va_args("" #__VA_ARGS__)
 
 // Check the macro expansion
 static_assert(COUNT_VA_ARGS() == 0, "COUNT_VA_ARGS failed for 0 argument.");
 static_assert(COUNT_VA_ARGS(1) == 1, "COUNT_VA_ARGS failed for 1 argument.");
-static_assert(COUNT_VA_ARGS(1,2,3) == 3, "COUNT_VA_ARGS failed for 3 arguments.");
+static_assert(COUNT_VA_ARGS(1, 2, 3) == 3, "COUNT_VA_ARGS failed for 3 arguments.");
 
 /** PP_NARG achieves the same as COUNT_VA_ARGS but it does
  * not work with empty arguments. However, it performs text
  * substitution which we will need where it is used */
-#define PP_NARG(...) \
-           PP_ID(PP_NARG_(__VA_ARGS__,PP_RSEQ_N()))
-#define PP_NARG_(...) \
-           PP_ID(PP_ARG_N(__VA_ARGS__))
-#define PP_ARG_N( \
+#define PP_NARG(...) PP_ID(PP_NARG_(__VA_ARGS__, PP_RSEQ_N()))
+#define PP_NARG_(...) PP_ID(PP_ARG_N(__VA_ARGS__))
+// clang-format off
+#define PP_ARG_N(                          \
   _1, _2, _3, _4, _5, _6, _7, _8, _9,_10,  \
   _11,_12,_13,_14,_15,_16,_17,_18,_19,_20, \
   _21,_22,_23,_24,_25,_26,_27,_28,_29,_30, \
@@ -77,18 +76,17 @@ static_assert(COUNT_VA_ARGS(1,2,3) == 3, "COUNT_VA_ARGS failed for 3 arguments."
   _41,_42,_43,_44,_45,_46,_47,_48,_49,_50, \
   _51,_52,_53,_54,_55,_56,_57,_58,_59,_60, \
   _61,_62,_63,_64,N,...) N
-#define PP_RSEQ_N() \
-  64,63,62,61,60,                   \
+#define PP_RSEQ_N()              \
+  64,63,62,61,60,                \
   59,58,57,56,55,54,53,52,51,50, \
   49,48,47,46,45,44,43,42,41,40, \
   39,38,37,36,35,34,33,32,31,30, \
   29,28,27,26,25,24,23,22,21,20, \
   19,18,17,16,15,14,13,12,11,10, \
   9,8,7,6,5,4,3,2,1,0
+// clang-format on
 
-#define PP_MAP(macro, data, ...) \
-  PP_ID(PP_APPLY(PP_CHOOSE_MAP_START, PP_NARG(__VA_ARGS__)) \
-          (macro, data, __VA_ARGS__))
+#define PP_MAP(macro, data, ...) PP_ID(PP_APPLY(PP_CHOOSE_MAP_START, PP_NARG(__VA_ARGS__))(macro, data, __VA_ARGS__))
 
 #define PP_CHOOSE_MAP_START(count) PP_MAP##count
 
@@ -161,37 +159,49 @@ static_assert(COUNT_VA_ARGS(1,2,3) == 3, "COUNT_VA_ARGS failed for 3 arguments."
 
 #define PP_ID(x) x
 
-#define ENUM_NAME(EnumT, name) \
-  v == EnumT##_::name ? #name :
+#define ENUM_NAME(EnumT, name) v == EnumT##_::name ? #name:
 
 #define DECLARE_ENUM(EnumName, Enum0, ...) \
-  enum class EnumName##_ { Enum0 = EnumName##Parent::EnumName##Size, ## __VA_ARGS__ };
+  enum class EnumName##_{Enum0 = EnumName##Parent::EnumName##Size, ##__VA_ARGS__};
 
-#define DECLARE_STRUCT(EnumT, name) \
-  constexpr static EnumT##_ name = EnumT##_::name;
+#define DECLARE_STRUCT(EnumT, name) constexpr static EnumT##_ name = EnumT##_::name;
 
-#define EXTEND_ENUM(EnumName, SelfT, ...)\
-  using EnumName##Parent = SelfT::EnumName##Base; \
-  PP_ID(DECLARE_ENUM(EnumName, __VA_ARGS__))\
-  struct EnumName : public EnumName##Parent::EnumName { PP_ID(PP_MAP(DECLARE_STRUCT, EnumName, __VA_ARGS__)) }; \
+#define EXTEND_ENUM(EnumName, SelfT, ...)                                                                              \
+  using EnumName##Parent = SelfT::EnumName##Base;                                                                      \
+  PP_ID(DECLARE_ENUM(EnumName, __VA_ARGS__))                                                                           \
+  struct EnumName : public EnumName##Parent::EnumName                                                                  \
+  {                                                                                                                    \
+    PP_ID(PP_MAP(DECLARE_STRUCT, EnumName, __VA_ARGS__))                                                               \
+  };                                                                                                                   \
   static constexpr unsigned int EnumName##Size = EnumName##Parent::EnumName##Size + PP_ID(COUNT_VA_ARGS(__VA_ARGS__)); \
-  using EnumName##Parent::EnumName##Name; \
-  static constexpr const char * EnumName##Name(EnumName##_ v) { return PP_ID(PP_MAP(ENUM_NAME, EnumName, __VA_ARGS__)) "INVALID"; } \
-  using EnumName##Base = SelfT; \
+  using EnumName##Parent::EnumName##Name;                                                                              \
+  static constexpr const char * EnumName##Name(EnumName##_ v)                                                          \
+  {                                                                                                                    \
+    return PP_ID(PP_MAP(ENUM_NAME, EnumName, __VA_ARGS__)) "INVALID";                                                  \
+  }                                                                                                                    \
+  using EnumName##Base = SelfT;                                                                                        \
   static constexpr auto EnumName##BaseName = #SelfT;
 
-#define DISABLE_SIGNALS(EnumName, ...)\
-  bool is##EnumName##StaticallyEnabled(int v) const override { return PP_ID(PP_MAP(DISABLE_SIGNALS_BODY, EnumName, __VA_ARGS__)) true; } \
-  template<typename EnumT> \
-  static constexpr bool EnumName##StaticallyEnabled(EnumT v) { return PP_ID(PP_MAP(DISABLE_SIGNALS_BODY, EnumName, __VA_ARGS__)) true; }
+#define DISABLE_SIGNALS(EnumName, ...)                                      \
+  bool is##EnumName##StaticallyEnabled(int v) const override                \
+  {                                                                         \
+    return PP_ID(PP_MAP(DISABLE_SIGNALS_BODY, EnumName, __VA_ARGS__)) true; \
+  }                                                                         \
+  template<typename EnumT>                                                  \
+  static constexpr bool EnumName##StaticallyEnabled(EnumT v)                \
+  {                                                                         \
+    return PP_ID(PP_MAP(DISABLE_SIGNALS_BODY, EnumName, __VA_ARGS__)) true; \
+  }
 
-#define DISABLE_SIGNALS_BODY(EnumT, name) \
-  static_cast<int>(v) == static_cast<int>(name) ? false :
+#define DISABLE_SIGNALS_BODY(EnumT, name) static_cast<int>(v) == static_cast<int>(name) ? false:
 
-#define CLEAR_DISABLED_SIGNALS(EnumName) \
-  bool is##EnumName##StaticallyEnabled(int) const override { return true; }\
-  template<typename EnumT> \
-  static constexpr bool EnumName##StaticallyEnabled(EnumT) { return true; }
+#define CLEAR_DISABLED_SIGNALS(EnumName)                                    \
+  bool is##EnumName##StaticallyEnabled(int) const override { return true; } \
+  template<typename EnumT>                                                  \
+  static constexpr bool EnumName##StaticallyEnabled(EnumT)                  \
+  {                                                                         \
+    return true;                                                            \
+  }
 
 } // namespace utils
 

--- a/include/tvm/internal/enums.h
+++ b/include/tvm/internal/enums.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 // Disable ISO C99 requires rest arguments to be used

--- a/include/tvm/internal/meta.h
+++ b/include/tvm/internal/meta.h
@@ -32,17 +32,14 @@
   {                                                                                      \
   private:                                                                               \
     struct Dummy                                                                         \
-    {                                                                                    \
-    };                                                                                   \
+    {};                                                                                  \
     struct Fallback                                                                      \
     {                                                                                    \
       struct Type                                                                        \
-      {                                                                                  \
-      };                                                                                 \
+      {};                                                                                \
     };                                                                                   \
     struct Derived : std::conditional<std::is_class<T>::value, T, Dummy>::type, Fallback \
-    {                                                                                    \
-    };                                                                                   \
+    {};                                                                                  \
                                                                                          \
     template<class U>                                                                    \
     static std::false_type test(typename U::Type *);                                     \
@@ -113,13 +110,11 @@ using enable_for_templated_t = std::enable_if_t<(... || derives_from<T, Base>())
 /** A sink, whose value is always true. */
 template<typename T>
 class always_true : public std::true_type
-{
-};
+{};
 
 /** A sink, whose value is always false. */
 template<typename T>
 class always_false : public std::false_type
-{
-};
+{};
 } // namespace internal
 } // namespace tvm

--- a/include/tvm/internal/meta.h
+++ b/include/tvm/internal/meta.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/internal/meta.h
+++ b/include/tvm/internal/meta.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,7 +38,7 @@
  * Adapted from https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector
  * (section Detecting member types):
  *
- * > An overload set of two test functions is then created, just like the other 
+ * > An overload set of two test functions is then created, just like the other
  * > examples. The first version can only be instantiated if the type of U::Type
  * > can be used unambiguously. This type can be used only if there is exactly
  * > one instance of Type in Derived, i.e. there is no Type in T. If T has a
@@ -51,88 +51,102 @@
  * step, were T is kept as is if it is a class and replace by an empty \a Dummy
  * class otherwise.
  */
-#define TVM_CREATE_HAS_MEMBER_TYPE_TRAIT_FOR(Type)                            \
-namespace tvm::internal                                                       \
-{                                                                             \
-template <typename T>                                                         \
-class has_member_type_##Type                                                  \
-{                                                                             \
-private:                                                                      \
-  struct Dummy {};                                                            \
-  struct Fallback { struct Type {}; };                                        \
-  struct Derived :                                                            \
-    std::conditional<std::is_class<T>::value,T,Dummy>::type, Fallback {};     \
-                                                                              \
-  template<class U>                                                           \
-  static std::false_type test(typename U::Type*);                             \
-  template<typename U>                                                        \
-  static std::true_type test(U*);                                             \
-public:                                                                       \
-  static constexpr bool value = decltype(test<Derived>(nullptr))::value;      \
-};                                                                            \
-}
+#define TVM_CREATE_HAS_MEMBER_TYPE_TRAIT_FOR(Type)                                       \
+  namespace tvm::internal                                                                \
+  {                                                                                      \
+  template<typename T>                                                                   \
+  class has_member_type_##Type                                                           \
+  {                                                                                      \
+  private:                                                                               \
+    struct Dummy                                                                         \
+    {                                                                                    \
+    };                                                                                   \
+    struct Fallback                                                                      \
+    {                                                                                    \
+      struct Type                                                                        \
+      {                                                                                  \
+      };                                                                                 \
+    };                                                                                   \
+    struct Derived : std::conditional<std::is_class<T>::value, T, Dummy>::type, Fallback \
+    {                                                                                    \
+    };                                                                                   \
+                                                                                         \
+    template<class U>                                                                    \
+    static std::false_type test(typename U::Type *);                                     \
+    template<typename U>                                                                 \
+    static std::true_type test(U *);                                                     \
+                                                                                         \
+  public:                                                                                \
+    static constexpr bool value = decltype(test<Derived>(nullptr))::value;               \
+  };                                                                                     \
+  }
 
 namespace tvm
 {
 namespace internal
 {
-  /** An helper struct used by derives_from.*/
-  template<template<typename...> class Base>
-  struct is_base
-  {
-    /** Accept any class derived from Base<T...>.*/
-    template<typename... T>
-    static std::true_type check(Base<T...> const volatile&);
-    /** Fallback function that will be used for type not deriving from Base<T...>. */
-    static std::false_type check(...);
-  };
+/** An helper struct used by derives_from.*/
+template<template<typename...> class Base>
+struct is_base
+{
+  /** Accept any class derived from Base<T...>.*/
+  template<typename... T>
+  static std::true_type check(Base<T...> const volatile &);
+  /** Fallback function that will be used for type not deriving from Base<T...>. */
+  static std::false_type check(...);
+};
 
-  /** Check if class \t T derives from the templated class \t Base.
-    *
-    * This relies on tvm::internal::is_base::check: if T derives from \t Base,
-    * the overload returning \a std::true_type will be selected, otherwise, it 
-    * will be the one returning \a std::false_type.
-    *
-    * Adapted from https://stackoverflow.com/a/5998303/11611648
-    */
-  template <typename T, template<typename...> class Base>
-  constexpr bool derives_from() {
-    return decltype(is_base<Base>::check(std::declval<const T&>()))::value;
-  }
-
-  /** Check if class \t T derives from the non-templated class \t Base 
-    * This returns \a false if \t Base is not a class.
-    */
-  template <typename T, typename Base>
-  constexpr bool derives_from() {
-    return std::is_base_of_v<Base, T>;
-  }
-
-  /** Used to enable a function for a list of types.
-    *
-    * To have a function work for T equal or deriving from any B1, B2, ... or Bk
-    * where Bi are types.
-    * Use as template<typename T, enable_for_t<T,B1, B2, ..., ..., Bk>=0>
-    */
-  template<typename T, typename... Base>
-  using enable_for_t = std::enable_if_t<(... || (std::is_same_v<T, Base> || derives_from<T, Base>())), int>;
-
-
-  /** Used to enable a function for a list of templated classes.
-    *
-    * To have a function work for T equal or deriving from any B1, B2, ... or Bk
-    * where Bi are a templated classes.
-    * Use as template<typename T, enable_for_templated_t<T,B1, B2, ..., ..., Bk>=0>
-    */
-  template<typename T, template<typename...> class... Base>
-  using enable_for_templated_t = std::enable_if_t<(... || derives_from<T, Base>()), int>;
-
-  /** A sink, whose value is always true. */
-  template<typename T>
-  class always_true : public std::true_type {};
-
-  /** A sink, whose value is always false. */
-  template<typename T>
-  class always_false : public std::false_type {};
+/** Check if class \t T derives from the templated class \t Base.
+ *
+ * This relies on tvm::internal::is_base::check: if T derives from \t Base,
+ * the overload returning \a std::true_type will be selected, otherwise, it
+ * will be the one returning \a std::false_type.
+ *
+ * Adapted from https://stackoverflow.com/a/5998303/11611648
+ */
+template<typename T, template<typename...> class Base>
+constexpr bool derives_from()
+{
+  return decltype(is_base<Base>::check(std::declval<const T &>()))::value;
 }
+
+/** Check if class \t T derives from the non-templated class \t Base
+ * This returns \a false if \t Base is not a class.
+ */
+template<typename T, typename Base>
+constexpr bool derives_from()
+{
+  return std::is_base_of_v<Base, T>;
 }
+
+/** Used to enable a function for a list of types.
+ *
+ * To have a function work for T equal or deriving from any B1, B2, ... or Bk
+ * where Bi are types.
+ * Use as template<typename T, enable_for_t<T,B1, B2, ..., ..., Bk>=0>
+ */
+template<typename T, typename... Base>
+using enable_for_t = std::enable_if_t<(... || (std::is_same_v<T, Base> || derives_from<T, Base>())), int>;
+
+/** Used to enable a function for a list of templated classes.
+ *
+ * To have a function work for T equal or deriving from any B1, B2, ... or Bk
+ * where Bi are a templated classes.
+ * Use as template<typename T, enable_for_templated_t<T,B1, B2, ..., ..., Bk>=0>
+ */
+template<typename T, template<typename...> class... Base>
+using enable_for_templated_t = std::enable_if_t<(... || derives_from<T, Base>()), int>;
+
+/** A sink, whose value is always true. */
+template<typename T>
+class always_true : public std::true_type
+{
+};
+
+/** A sink, whose value is always false. */
+template<typename T>
+class always_false : public std::false_type
+{
+};
+} // namespace internal
+} // namespace tvm

--- a/include/tvm/requirements/AnisotropicWeight.h
+++ b/include/tvm/requirements/AnisotropicWeight.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/requirements/AnisotropicWeight.h
+++ b/include/tvm/requirements/AnisotropicWeight.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,48 +39,48 @@ namespace tvm
 namespace requirements
 {
 
-  /** This class represents an anisotropic weight to give more or less
-   * importance to the different rows of a constraint. It is given as a
-   * vector w. It results in the violation v(x) of the constraint being
-   * multiplied by diag(w'), where w' depends on the constraint violation
-   * evaluation chosen.  w' is such that if w was a uniform vector with all
-   * components equal to alpha, the result would be coherent with using a
-   * Weight with value alpha.
-   *
-   * This class can be redundant with Weight, as having a Weight alpha and
-   * an AnisotropicWeight w is the same as having a just an
-   * AnisotropicWeight w.  As a guideline, it should be used only to
-   * discriminate between the rows of a constraint, while Weight would be
-   * used to discriminate between different constraints. As such the
-   * "mean" value of w should be 1.
-   *
-   * This class replaces the notion of dimWeight in Tasks.
-   *
-   * The default value for this class is weights of 1 on every row.
-   *
-   * \internal FIXME Do we want to implement some kind of mechanism for constraints
-   * whose size can change?
-   */
-  template<bool Lightweight = true>
-  class AnisotropicWeightBase : public abstract::SingleSolvingRequirement<Eigen::VectorXd, Lightweight>
+/** This class represents an anisotropic weight to give more or less
+ * importance to the different rows of a constraint. It is given as a
+ * vector w. It results in the violation v(x) of the constraint being
+ * multiplied by diag(w'), where w' depends on the constraint violation
+ * evaluation chosen.  w' is such that if w was a uniform vector with all
+ * components equal to alpha, the result would be coherent with using a
+ * Weight with value alpha.
+ *
+ * This class can be redundant with Weight, as having a Weight alpha and
+ * an AnisotropicWeight w is the same as having a just an
+ * AnisotropicWeight w.  As a guideline, it should be used only to
+ * discriminate between the rows of a constraint, while Weight would be
+ * used to discriminate between different constraints. As such the
+ * "mean" value of w should be 1.
+ *
+ * This class replaces the notion of dimWeight in Tasks.
+ *
+ * The default value for this class is weights of 1 on every row.
+ *
+ * \internal FIXME Do we want to implement some kind of mechanism for constraints
+ * whose size can change?
+ */
+template<bool Lightweight = true>
+class AnisotropicWeightBase : public abstract::SingleSolvingRequirement<Eigen::VectorXd, Lightweight>
+{
+public:
+  /** Default constructor: all elements of w are 1*/
+  AnisotropicWeightBase() : abstract::SingleSolvingRequirement<Eigen::VectorXd, Lightweight>(Eigen::VectorXd(), true) {}
+
+  /** Constructor for a given vector of weights \p w*/
+  AnisotropicWeightBase(const Eigen::VectorXd & w)
+  : abstract::SingleSolvingRequirement<Eigen::VectorXd, Lightweight>(w, false)
   {
-  public:
-    /** Default constructor: all elements of w are 1*/
-    AnisotropicWeightBase() : abstract::SingleSolvingRequirement<Eigen::VectorXd, Lightweight>(Eigen::VectorXd(), true) {}
+    if((w.array() < 0).any())
+      throw std::runtime_error("weights must be non-negative.");
+  }
 
-    /** Constructor for a given vector of weights \p w*/
-    AnisotropicWeightBase(const Eigen::VectorXd& w)
-      : abstract::SingleSolvingRequirement<Eigen::VectorXd, Lightweight>(w, false)
-    {
-      if ((w.array() < 0).any())
-        throw std::runtime_error("weights must be non-negative.");
-    }
+  TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(AnisotropicWeightBase, Eigen::VectorXd, Lightweight)
+};
 
-    TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(AnisotropicWeightBase, Eigen::VectorXd, Lightweight)
-  };
+using AnisotropicWeight = AnisotropicWeightBase<true>;
 
-  using AnisotropicWeight = AnisotropicWeightBase<true>;
+} // namespace requirements
 
-}  // namespace requirements
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/requirements/PriorityLevel.h
+++ b/include/tvm/requirements/PriorityLevel.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/requirements/PriorityLevel.h
+++ b/include/tvm/requirements/PriorityLevel.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -37,29 +37,28 @@ namespace tvm
 namespace requirements
 {
 
-  /** This class represents the priority level of a constraint.
-    * The default priority level is 0
-    */
-  template<bool Lightweight = true>
-  class PriorityLevelBase : public abstract::SingleSolvingRequirement<int, Lightweight>
+/** This class represents the priority level of a constraint.
+ * The default priority level is 0
+ */
+template<bool Lightweight = true>
+class PriorityLevelBase : public abstract::SingleSolvingRequirement<int, Lightweight>
+{
+public:
+  /** Default constructor p=0 */
+  PriorityLevelBase() : abstract::SingleSolvingRequirement<int, Lightweight>(0, true) {}
+
+  /** Priority level p>=0*/
+  PriorityLevelBase(int p) : abstract::SingleSolvingRequirement<int, Lightweight>(p, false)
   {
-  public:
-    /** Default constructor p=0 */
-    PriorityLevelBase(): abstract::SingleSolvingRequirement<int, Lightweight>(0, true) {}
+    if(p < 0)
+      throw std::runtime_error("Priority level must be non-negative.");
+  }
 
-    /** Priority level p>=0*/
-    PriorityLevelBase(int p)
-      : abstract::SingleSolvingRequirement<int, Lightweight>(p, false)
-    {
-      if (p < 0)
-        throw std::runtime_error("Priority level must be non-negative.");
-    }
+  TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(PriorityLevelBase, int, Lightweight)
+};
 
-    TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(PriorityLevelBase, int, Lightweight)
-  };
+using PriorityLevel = PriorityLevelBase<true>;
 
-  using PriorityLevel = PriorityLevelBase<true>;
+} // namespace requirements
 
-}  // namespace requirements
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/requirements/SolvingRequirements.h
+++ b/include/tvm/requirements/SolvingRequirements.h
@@ -119,8 +119,7 @@ public:
 
   explicit SolvingRequirementsWithCallbacks(const SolvingRequirements & req)
   : SolvingRequirementsBase(req.priorityLevel(), req.weight(), req.anisotropicWeight(), req.violationEvaluation())
-  {
-  }
+  {}
 };
 
 #undef ADD_REQUIREMENT

--- a/include/tvm/requirements/SolvingRequirements.h
+++ b/include/tvm/requirements/SolvingRequirements.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/requirements/SolvingRequirements.h
+++ b/include/tvm/requirements/SolvingRequirements.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,118 +42,116 @@ namespace tvm
 namespace requirements
 {
 
-  /** \internal when adding a task to a problem, the user will want to specify
-   * part or all of the following: priority level, (global) weight,
-   * different weights for each dimension, type of norm to consider (and
-   * maybe more in the future). The method through which tasks are added
-   * need then to be able to accomodate these specifications.
-   *
-   * The classes in this file are meant to fulfill the following points:
-   *
-   *  - having strongly typed notions of weight, priority, ...
-   *
-   *  - leting the user specify only part of those notions and rely on
-   *  default value for the others.
-   *
-   *  - allowing to use any order to give the arguments
-   *
-   *  - while not having to multiply the overload for the method adding
-   *  the task (there are 65 combinations!).
-   *
-   * FIXME: should we add the notion of row selection here as well ?
+/** \internal when adding a task to a problem, the user will want to specify
+ * part or all of the following: priority level, (global) weight,
+ * different weights for each dimension, type of norm to consider (and
+ * maybe more in the future). The method through which tasks are added
+ * need then to be able to accomodate these specifications.
+ *
+ * The classes in this file are meant to fulfill the following points:
+ *
+ *  - having strongly typed notions of weight, priority, ...
+ *
+ *  - leting the user specify only part of those notions and rely on
+ *  default value for the others.
+ *
+ *  - allowing to use any order to give the arguments
+ *
+ *  - while not having to multiply the overload for the method adding
+ *  the task (there are 65 combinations!).
+ *
+ * FIXME: should we add the notion of row selection here as well ?
+ */
+
+/** This macro adds a member of type \p T named \p member to a class, and a
+ * method \p name to access this member.
+ */
+#define ADD_REQUIREMENT(T, name, member)                                                             \
+public:                                                                                              \
+  const T<Lightweight> & name() const { return member; }                                             \
+  T<Lightweight> & name() { return member; }                                                         \
+                                                                                                     \
+private:                                                                                             \
+  T<Lightweight> member;                                                                             \
+  template<typename... Args>                                                                         \
+  void build(const T<Lightweight> & m, const Args &... args)                                         \
+  {                                                                                                  \
+    static_assert(!check_args<T<Lightweight>, Args...>() && !check_args<T<!Lightweight>, Args...>(), \
+                  #T " has already been specified");                                                 \
+    member = m;                                                                                      \
+    build(args...);                                                                                  \
+  }                                                                                                  \
+  template<typename... Args>                                                                         \
+  void build(const T<!Lightweight> & m, const Args &... args)                                        \
+  {                                                                                                  \
+    static_assert(!check_args<T<Lightweight>, Args...>() && !check_args<T<!Lightweight>, Args...>(), \
+                  #T " has already been specified");                                                 \
+    member = m;                                                                                      \
+    build(args...);                                                                                  \
+  }
+
+/** This class groups a PriorityLevel, a Weight, an AnisotropicWeight and a
+ * ViolationEvaluation, to describe the way a constraint need to be solved
+ * and interact with other constraints.
+ */
+template<bool Lightweight = true>
+class SolvingRequirementsBase
+{
+public:
+  /** Constructor. The arguments can be a PriorityLevel, a Weight, an
+   * AnisotropicWeight, or a ViolationEvaluation, or any combination of these
+   * objects, in any order, provided an instance of each type appears at most
+   * once.
+   * If an instance of a type is not given, the default value is taken.
+   * \sa PriorityLevel, Weight, AnisotropicWeight, ViolationEvaluation
    */
-
-  /** This macro adds a member of type \p T named \p member to a class, and a
-    * method \p name to access this member.
-    */
-  #define ADD_REQUIREMENT(T, name, member)                        \
-  public:                                                         \
-    const T<Lightweight>& name() const { return member; }         \
-    T<Lightweight>& name() { return member; }                     \
-  private:                                                        \
-    T<Lightweight> member;                                        \
-    template<typename ... Args>                                   \
-    void build(const T<Lightweight>& m, const Args& ... args)     \
-    {                                                             \
-      static_assert(!check_args<T<Lightweight>, Args...>()        \
-                    && !check_args<T<!Lightweight>, Args...>(),   \
-                    #T" has already been specified");             \
-      member = m;                                                 \
-      build(args...);                                             \
-    }                                                             \
-    template<typename ... Args>                                   \
-    void build(const T<!Lightweight>& m, const Args& ... args)    \
-    {                                                             \
-      static_assert(!check_args<T<Lightweight>, Args...>()        \
-                    && !check_args<T<!Lightweight>, Args...>(),   \
-                    #T" has already been specified");             \
-      member = m;                                                 \
-      build(args...);                                             \
-    }
-
-
-  /** This class groups a PriorityLevel, a Weight, an AnisotropicWeight and a
-    * ViolationEvaluation, to describe the way a constraint need to be solved
-    * and interact with other constraints.
-    */
-  template<bool Lightweight = true>
-  class SolvingRequirementsBase
+  template<typename... Args>
+  SolvingRequirementsBase(const Args &... args)
   {
-  public:
-    /** Constructor. The arguments can be a PriorityLevel, a Weight, an
-      * AnisotropicWeight, or a ViolationEvaluation, or any combination of these
-      * objects, in any order, provided an instance of each type appears at most
-      * once.
-      * If an instance of a type is not given, the default value is taken.
-      * \sa PriorityLevel, Weight, AnisotropicWeight, ViolationEvaluation
-      */
-    template<typename ... Args>
-    SolvingRequirementsBase(const Args & ... args)
-    {
-      build(args...);
-    }
+    build(args...);
+  }
 
-  private:
-    template<typename T, typename Arg0, typename ... Args>
-    static constexpr bool check_args()
-    {
-      return std::is_same<T, Arg0>::value || check_args<T, Args...>();
-    }
-
-    template<typename T>
-    static constexpr bool check_args()
-    {
-      return false;
-    }
-
-    ADD_REQUIREMENT(PriorityLevelBase, priorityLevel, priority_)
-    ADD_REQUIREMENT(WeightBase, weight, weight_)
-    ADD_REQUIREMENT(AnisotropicWeightBase, anisotropicWeight, aWeight_)
-    ADD_REQUIREMENT(ViolationEvaluationBase, violationEvaluation, evalType_)
-
-    void build() {}
-  };
-
-  class SolvingRequirements : public SolvingRequirementsBase<true>
+private:
+  template<typename T, typename Arg0, typename... Args>
+  static constexpr bool check_args()
   {
-    using SolvingRequirementsBase::SolvingRequirementsBase;
-  };
+    return std::is_same<T, Arg0>::value || check_args<T, Args...>();
+  }
 
-  class SolvingRequirementsWithCallbacks : public SolvingRequirementsBase<false>
+  template<typename T>
+  static constexpr bool check_args()
   {
-  public:
-    using SolvingRequirementsBase::SolvingRequirementsBase;
-    SolvingRequirementsWithCallbacks(const SolvingRequirementsWithCallbacks&) = delete;
-    SolvingRequirementsWithCallbacks& operator=(const SolvingRequirementsWithCallbacks&) = delete;
+    return false;
+  }
 
-    explicit SolvingRequirementsWithCallbacks(const SolvingRequirements& req)
-      : SolvingRequirementsBase(req.priorityLevel(), req.weight(), req.anisotropicWeight(), req.violationEvaluation())
-    {
-    }
-  };
+  ADD_REQUIREMENT(PriorityLevelBase, priorityLevel, priority_)
+  ADD_REQUIREMENT(WeightBase, weight, weight_)
+  ADD_REQUIREMENT(AnisotropicWeightBase, anisotropicWeight, aWeight_)
+  ADD_REQUIREMENT(ViolationEvaluationBase, violationEvaluation, evalType_)
 
-  #undef ADD_REQUIREMENT
+  void build() {}
+};
 
-}  // namespace requirements
+class SolvingRequirements : public SolvingRequirementsBase<true>
+{
+  using SolvingRequirementsBase::SolvingRequirementsBase;
+};
 
-}  // namespace tvm
+class SolvingRequirementsWithCallbacks : public SolvingRequirementsBase<false>
+{
+public:
+  using SolvingRequirementsBase::SolvingRequirementsBase;
+  SolvingRequirementsWithCallbacks(const SolvingRequirementsWithCallbacks &) = delete;
+  SolvingRequirementsWithCallbacks & operator=(const SolvingRequirementsWithCallbacks &) = delete;
+
+  explicit SolvingRequirementsWithCallbacks(const SolvingRequirements & req)
+  : SolvingRequirementsBase(req.priorityLevel(), req.weight(), req.anisotropicWeight(), req.violationEvaluation())
+  {
+  }
+};
+
+#undef ADD_REQUIREMENT
+
+} // namespace requirements
+
+} // namespace tvm

--- a/include/tvm/requirements/ViolationEvaluation.h
+++ b/include/tvm/requirements/ViolationEvaluation.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/requirements/ViolationEvaluation.h
+++ b/include/tvm/requirements/ViolationEvaluation.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,47 +39,49 @@ namespace tvm
 namespace requirements
 {
 
-  /** Given a constraint, let the vector v(x) be its componentwise
-    * violation.
-    *
-    * For example, for the constraint c(x) = 0, we simply have v(x) = c(x),
-    * for c(x) >= b, we have v(x) = max(b-c(x),0).
-    *
-    * This enumeration specifies how v(x) is made into a scalar measure
-    * f(x) of this violation.
-    */
-  enum class ViolationEvaluationType
+/** Given a constraint, let the vector v(x) be its componentwise
+ * violation.
+ *
+ * For example, for the constraint c(x) = 0, we simply have v(x) = c(x),
+ * for c(x) >= b, we have v(x) = max(b-c(x),0).
+ *
+ * This enumeration specifies how v(x) is made into a scalar measure
+ * f(x) of this violation.
+ */
+enum class ViolationEvaluationType
+{
+  /** f(x) = sum(abs(v_i(x))) */
+  L1,
+  /** f(x) = v(x)^T*v(x) */
+  L2,
+  /** f(x) = max(abs(v_i(x))) */
+  LINF
+};
+
+/** A class specifying how a constraint violation should be handled.
+ * By default the L2 norm of the violation is used.
+ * \sa ViolationEvaluationType
+ */
+template<bool Lightweight = true>
+class ViolationEvaluationBase : public abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>
+{
+public:
+  /** Default value: ViolationEvaluationType::L2*/
+  ViolationEvaluationBase()
+  : abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>(ViolationEvaluationType::L2, true)
   {
-    /** f(x) = sum(abs(v_i(x))) */
-    L1,
-    /** f(x) = v(x)^T*v(x) */
-    L2,
-    /** f(x) = max(abs(v_i(x))) */
-    LINF
-  };
+  }
 
-  /** A class specifying how a constraint violation should be handled.
-    * By default the L2 norm of the violation is used.
-    * \sa ViolationEvaluationType
-    */
-  template<bool Lightweight = true>
-  class ViolationEvaluationBase : public abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>
+  ViolationEvaluationBase(ViolationEvaluationType t)
+  : abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>(t, false)
   {
-  public:
-    /** Default value: ViolationEvaluationType::L2*/
-    ViolationEvaluationBase() 
-      : abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>(ViolationEvaluationType::L2, true) 
-    {}
+  }
 
-    ViolationEvaluationBase(ViolationEvaluationType t) 
-      : abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>(t, false) 
-    {}
+  TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(ViolationEvaluationBase, ViolationEvaluationType, Lightweight)
+};
 
-    TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(ViolationEvaluationBase, ViolationEvaluationType, Lightweight)
-  };
+using ViolationEvaluation = ViolationEvaluationBase<true>;
 
-  using ViolationEvaluation = ViolationEvaluationBase<true>;
+} // namespace requirements
 
-}  // namespace requirements
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/requirements/ViolationEvaluation.h
+++ b/include/tvm/requirements/ViolationEvaluation.h
@@ -42,13 +42,11 @@ public:
   /** Default value: ViolationEvaluationType::L2*/
   ViolationEvaluationBase()
   : abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>(ViolationEvaluationType::L2, true)
-  {
-  }
+  {}
 
   ViolationEvaluationBase(ViolationEvaluationType t)
   : abstract::SingleSolvingRequirement<ViolationEvaluationType, Lightweight>(t, false)
-  {
-  }
+  {}
 
   TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(ViolationEvaluationBase, ViolationEvaluationType, Lightweight)
 };

--- a/include/tvm/requirements/Weight.h
+++ b/include/tvm/requirements/Weight.h
@@ -1,32 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
-
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,34 +37,33 @@ namespace tvm
 namespace requirements
 {
 
-  /** This class represents the scalar weight alpha of a constraint,
-    * within its priority level. It is meant to ajust the influence of
-    * several constraints at the same level.
-    *
-    * Given a scalar weight \p alpha, and a constraint violation measurement
-    * f(x), the product alpha*f(x) will be minimized.
-    *
-    * By default the weight is 1.
-    */
-  template<bool Lightweight = true>
-  class WeightBase : public abstract::SingleSolvingRequirement<double, Lightweight>
+/** This class represents the scalar weight alpha of a constraint,
+ * within its priority level. It is meant to ajust the influence of
+ * several constraints at the same level.
+ *
+ * Given a scalar weight \p alpha, and a constraint violation measurement
+ * f(x), the product alpha*f(x) will be minimized.
+ *
+ * By default the weight is 1.
+ */
+template<bool Lightweight = true>
+class WeightBase : public abstract::SingleSolvingRequirement<double, Lightweight>
+{
+public:
+  /** Default weight = 1*/
+  WeightBase() : abstract::SingleSolvingRequirement<double, Lightweight>(1.0, true) {}
+
+  WeightBase(double alpha) : abstract::SingleSolvingRequirement<double, Lightweight>(alpha, false)
   {
-  public:
-    /** Default weight = 1*/
-    WeightBase() : abstract::SingleSolvingRequirement<double, Lightweight>(1.0, true) {}
+    if(alpha < 0)
+      throw std::runtime_error("weight must be non negative.");
+  }
 
-    WeightBase(double alpha)
-      : abstract::SingleSolvingRequirement<double, Lightweight>(alpha, false)
-    {
-      if (alpha < 0)
-        throw std::runtime_error("weight must be non negative.");
-    }
+  TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(WeightBase, double, Lightweight)
+};
 
-    TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(WeightBase, double, Lightweight)
-  };
+using Weight = WeightBase<true>;
 
-  using Weight = WeightBase<true>;
+} // namespace requirements
 
-}  // namespace requirements
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/requirements/Weight.h
+++ b/include/tvm/requirements/Weight.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/requirements/abstract/SingleSolvingRequirement.h
+++ b/include/tvm/requirements/abstract/SingleSolvingRequirement.h
@@ -49,8 +49,7 @@ protected:
 
   SingleSolvingRequirement(const SingleSolvingRequirement<T, !Lightweight> & other)
   : value_(other.value()), default_(other.isDefault())
-  {
-  }
+  {}
 
   SingleSolvingRequirement & operator=(const SingleSolvingRequirement<T, !Lightweight> & other)
   {

--- a/include/tvm/requirements/abstract/SingleSolvingRequirement.h
+++ b/include/tvm/requirements/abstract/SingleSolvingRequirement.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/requirements/abstract/SingleSolvingRequirement.h
+++ b/include/tvm/requirements/abstract/SingleSolvingRequirement.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,76 +42,77 @@ namespace requirements
 namespace abstract
 {
 
-  /** A class representing the way a constraint has to be solved and how it
-    * interacts with other constraints in term of hierarchical and weighted
-    * priorities.
-    *
-    * This is a base class for the sole purpose of conveniency.
-    */
-  template<typename T, bool Lightweight = true>
-  class SingleSolvingRequirement : public std::conditional_t<Lightweight, std::monostate, internal::CallbackManager>
+/** A class representing the way a constraint has to be solved and how it
+ * interacts with other constraints in term of hierarchical and weighted
+ * priorities.
+ *
+ * This is a base class for the sole purpose of conveniency.
+ */
+template<typename T, bool Lightweight = true>
+class SingleSolvingRequirement : public std::conditional_t<Lightweight, std::monostate, internal::CallbackManager>
+{
+  using Base = std::conditional_t<Lightweight, std::monostate, internal::CallbackManager>;
+
+public:
+  /** Get the current value. */
+  const T & value() const { return value_; }
+
+  /** Change the current value */
+  void value(const T & val)
   {
-    using Base = std::conditional_t<Lightweight, std::monostate, internal::CallbackManager>;
-
-  public:
-    /** Get the current value. */
-    const T& value() const { return value_; }
-
-    /** Change the current value */
-    void value(const T& val)
+    value_ = val;
+    default_ = false;
+    if constexpr(!Lightweight)
     {
-      value_ = val;
-      default_ = false;
-      if constexpr (!Lightweight)
-      {
-        Base::run();
-      }
+      Base::run();
     }
+  }
 
-    /** check it the requirement is at its default value. */
-    bool isDefault() const { return default_; }
+  /** check it the requirement is at its default value. */
+  bool isDefault() const { return default_; }
 
-  protected:
-    SingleSolvingRequirement(const T& val, bool isDefault)
-      : default_(isDefault), value_(val)
-    {}
+protected:
+  SingleSolvingRequirement(const T & val, bool isDefault) : default_(isDefault), value_(val) {}
 
-    SingleSolvingRequirement(const SingleSolvingRequirement<T, !Lightweight>& other)
-      : value_(other.value()), default_(other.isDefault())
-    {}
+  SingleSolvingRequirement(const SingleSolvingRequirement<T, !Lightweight> & other)
+  : value_(other.value()), default_(other.isDefault())
+  {
+  }
 
-    SingleSolvingRequirement& operator=(const SingleSolvingRequirement<T, !Lightweight>& other)
-    {
-      value_ = other.value();
-      default_ = other.isDefault();
-      return *this;
-    }
+  SingleSolvingRequirement & operator=(const SingleSolvingRequirement<T, !Lightweight> & other)
+  {
+    value_ = other.value();
+    default_ = other.isDefault();
+    return *this;
+  }
 
-    SingleSolvingRequirement& operator=(const T& val) { value(val); return *this; }
+  SingleSolvingRequirement & operator=(const T & val)
+  {
+    value(val);
+    return *this;
+  }
 
-    /** Is this requirement at its default value?*/
-    bool default_;
+  /** Is this requirement at its default value?*/
+  bool default_;
 
-    T value_;
-  };
+  T value_;
+};
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace requirements
+} // namespace requirements
 
-}  // namespace tvm
+} // namespace tvm
 
-
-#define TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(className, T, L)  \
-  className(const className<!L>& other)                         \
-   : abstract::SingleSolvingRequirement<T,L>(other) {}          \
-  className& operator=(const className<!L>& other)              \
-  {                                                             \
-    abstract::SingleSolvingRequirement<T,L>::operator=(other);  \
-    return *this;                                               \
-  }                                                             \
-  className& operator=(const T& val)                            \
-  {                                                             \
-    abstract::SingleSolvingRequirement<T, L>::operator=(val);   \
-    return *this;                                               \
+#define TVM_DEFINE_LW_NON_LW_CONVERSION_OPERATORS(className, T, L)                            \
+  className(const className<!L> & other) : abstract::SingleSolvingRequirement<T, L>(other) {} \
+  className & operator=(const className<!L> & other)                                          \
+  {                                                                                           \
+    abstract::SingleSolvingRequirement<T, L>::operator=(other);                               \
+    return *this;                                                                             \
+  }                                                                                           \
+  className & operator=(const T & val)                                                        \
+  {                                                                                           \
+    abstract::SingleSolvingRequirement<T, L>::operator=(val);                                 \
+    return *this;                                                                             \
   }

--- a/include/tvm/robot/CoMFunction.h
+++ b/include/tvm/robot/CoMFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/CoMFunction.h
+++ b/include/tvm/robot/CoMFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -41,43 +41,44 @@ namespace tvm
 namespace robot
 {
 
-  /** This class implements a CoM function for a given robot */
-  class TVM_DLLAPI CoMFunction : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(CoMFunction, Value, Velocity, Jacobian, NormalAcceleration, JDot)
+/** This class implements a CoM function for a given robot */
+class TVM_DLLAPI CoMFunction : public function::abstract::Function
+{
+public:
+  SET_UPDATES(CoMFunction, Value, Velocity, Jacobian, NormalAcceleration, JDot)
 
-    /** Constructor
-     *
-     * Set the objective to the current CoM of robot
-     *
-     */
-    CoMFunction(RobotPtr robot);
+  /** Constructor
+   *
+   * Set the objective to the current CoM of robot
+   *
+   */
+  CoMFunction(RobotPtr robot);
 
-    /** Set the target CoM to the current robot's CoM */
-    void reset();
+  /** Set the target CoM to the current robot's CoM */
+  void reset();
 
-    /** Get the current objective */
-    inline const Eigen::Vector3d & com() const { return com_; }
+  /** Get the current objective */
+  inline const Eigen::Vector3d & com() const { return com_; }
 
-    /** Set the objective */
-    inline void com(const Eigen::Vector3d & com) { com_ = com; }
-  protected:
-    void updateValue();
-    void updateVelocity();
-    void updateJacobian();
-    void updateNormalAcceleration();
-    void updateJDot();
+  /** Set the objective */
+  inline void com(const Eigen::Vector3d & com) { com_ = com; }
 
-    RobotPtr robot_;
+protected:
+  void updateValue();
+  void updateVelocity();
+  void updateJacobian();
+  void updateNormalAcceleration();
+  void updateJDot();
 
-    /** Target */
-    Eigen::Vector3d com_;
+  RobotPtr robot_;
 
-    /** CoM jacobian */
-    rbd::CoMJacobian jac_;
-  };
+  /** Target */
+  Eigen::Vector3d com_;
 
-}
+  /** CoM jacobian */
+  rbd::CoMJacobian jac_;
+};
 
-}
+} // namespace robot
+
+} // namespace tvm

--- a/include/tvm/robot/CoMInConvexFunction.h
+++ b/include/tvm/robot/CoMInConvexFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/CoMInConvexFunction.h
+++ b/include/tvm/robot/CoMInConvexFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,50 +42,51 @@ namespace tvm
 namespace robot
 {
 
-  /** This function computes the distance of the CoM to a set of planes.
+/** This function computes the distance of the CoM to a set of planes.
+ *
+ * By providing a consistent set of planes, the function can be used to keep
+ * the CoM in a convex region of space.
+ */
+class TVM_DLLAPI CoMInConvexFunction : public function::abstract::Function
+{
+public:
+  SET_UPDATES(CoMInConvexFunction, Value, Velocity, Jacobian, NormalAcceleration)
+
+  /** Constructor
    *
-   * By providing a consistent set of planes, the function can be used to keep
-   * the CoM in a convex region of space.
+   * By default, this function computes nothing
+   *
    */
-  class TVM_DLLAPI CoMInConvexFunction : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(CoMInConvexFunction, Value, Velocity, Jacobian, NormalAcceleration)
+  CoMInConvexFunction(RobotPtr robot);
 
-    /** Constructor
-     *
-     * By default, this function computes nothing
-     *
-     */
-    CoMInConvexFunction(RobotPtr robot);
+  /** Add a plane.
+   *
+   * This will add one dimension to the function output. This new value is
+   * the distance to that plane.
+   *
+   * This function does not check whether this is consistent with planes that
+   * were added previously.
+   */
+  void addPlane(geometry::PlanePtr plane);
 
-    /** Add a plane.
-     *
-     * This will add one dimension to the function output. This new value is
-     * the distance to that plane.
-     *
-     * This function does not check whether this is consistent with planes that
-     * were added previously.
-     */
-    void addPlane(geometry::PlanePtr plane);
+  /** Remove all planes */
+  void reset();
 
-    /** Remove all planes */
-    void reset();
-  protected:
-    void updateValue();
-    void updateVelocity();
-    void updateJacobian();
-    void updateNormalAcceleration();
+protected:
+  void updateValue();
+  void updateVelocity();
+  void updateJacobian();
+  void updateNormalAcceleration();
 
-    RobotPtr robot_;
+  RobotPtr robot_;
 
-    /** Set of planes */
-    std::vector<geometry::PlanePtr> planes_;
+  /** Set of planes */
+  std::vector<geometry::PlanePtr> planes_;
 
-    /** CoM jacobian */
-    rbd::CoMJacobian jac_;
-    Eigen::Vector3d comSpeed_;
-  };
+  /** CoM jacobian */
+  rbd::CoMJacobian jac_;
+  Eigen::Vector3d comSpeed_;
+};
 
 } // namespace robot
 

--- a/include/tvm/robot/CollisionFunction.h
+++ b/include/tvm/robot/CollisionFunction.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/function/abstract/Function.h>
 #include <tvm/robot/ConvexHull.h>
 

--- a/include/tvm/robot/CollisionFunction.h
+++ b/include/tvm/robot/CollisionFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/CollisionFunction.h
+++ b/include/tvm/robot/CollisionFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -40,66 +40,67 @@ namespace tvm
 namespace robot
 {
 
-  /** This class implements a collision function for two given objects */
-  class TVM_DLLAPI CollisionFunction : public function::abstract::Function
+/** This class implements a collision function for two given objects */
+class TVM_DLLAPI CollisionFunction : public function::abstract::Function
+{
+public:
+  SET_UPDATES(CollisionFunction, Value, Velocity, Jacobian, Time, NormalAcceleration)
+
+  /** Constructor
+   *
+   * \param dt Timestep
+   *
+   */
+  CollisionFunction(Clock & clock);
+
+  /** Add a collision
+   *
+   * \param ch1 convex hull object for the first object
+   *
+   * \param ch2 convex hull object for the second object
+   *
+   */
+  void addCollision(ConvexHullPtr ch1, ConvexHullPtr ch2);
+
+  /** Remove all collisions */
+  void reset();
+
+protected:
+  /* Update functions */
+  void updateValue();
+  void updateVelocity();
+  void updateJacobian();
+  void updateTimeDependency();
+  void updateNormalAcceleration();
+
+  Clock & clock_;
+  uint64_t last_tick_ = 0;
+
+  struct CollisionData
   {
-  public:
-    SET_UPDATES(CollisionFunction, Value, Velocity, Jacobian, Time, NormalAcceleration)
-
-    /** Constructor
-     *
-     * \param dt Timestep
-     *
-     */
-    CollisionFunction(Clock & clock);
-
-    /** Add a collision
-     *
-     * \param ch1 convex hull object for the first object
-     *
-     * \param ch2 convex hull object for the second object
-     *
-     */
-    void addCollision(ConvexHullPtr ch1, ConvexHullPtr ch2);
-
-    /** Remove all collisions */
-    void reset();
-  protected:
-    /* Update functions */
-    void updateValue();
-    void updateVelocity();
-    void updateJacobian();
-    void updateTimeDependency();
-    void updateNormalAcceleration();
-
-    Clock & clock_;
-    uint64_t last_tick_ = 0;
-
-    struct CollisionData
+    struct ObjectData
     {
-      struct ObjectData
-      {
-        Eigen::Vector3d nearestPoint_; // In body coordinates
-        rbd::Jacobian jac_;
-      };
-      std::vector<ObjectData> objects_;
-      ConvexHullPtr ch_[2];
-      sch::CD_Pair pair_;
-      Eigen::Vector3d normVecDist_;
-      Eigen::Vector3d prevNormVecDist_ = Eigen::Vector3d::Zero();
-      Eigen::Vector3d speedVec_ = Eigen::Vector3d::Zero();
-
-      CollisionData();
-
-      CollisionData(CollisionFunction & fn, ConvexHullPtr ch1, ConvexHullPtr ch2);
+      Eigen::Vector3d nearestPoint_; // In body coordinates
+      rbd::Jacobian jac_;
     };
-    std::vector<CollisionData> colls_;
+    std::vector<ObjectData> objects_;
+    ConvexHullPtr ch_[2];
+    sch::CD_Pair pair_;
+    Eigen::Vector3d normVecDist_;
+    Eigen::Vector3d prevNormVecDist_ = Eigen::Vector3d::Zero();
+    Eigen::Vector3d speedVec_ = Eigen::Vector3d::Zero();
 
-    /** Intermediate computation */
-    Eigen::Vector3d closestPoints_[2];
-    Eigen::MatrixXd fullJac_;
-    Eigen::MatrixXd distJac_;
+    CollisionData();
+
+    CollisionData(CollisionFunction & fn, ConvexHullPtr ch1, ConvexHullPtr ch2);
   };
+  std::vector<CollisionData> colls_;
+
+  /** Intermediate computation */
+  Eigen::Vector3d closestPoints_[2];
+  Eigen::MatrixXd fullJac_;
+  Eigen::MatrixXd distJac_;
+};
 
 } // namespace robot
 

--- a/include/tvm/robot/Contact.h
+++ b/include/tvm/robot/Contact.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/Contact.h
+++ b/include/tvm/robot/Contact.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -40,120 +40,126 @@ namespace tvm
 namespace robot
 {
 
-  /** Represent a contact between two frames
-   *
-   * The node forwards the signals of each frame.
-   *
-   * Outputs:
-   * - F1Position/F1Jacobian/F1Velocity/F1NormalAcceleration: proxy for the
-   *   first frame Position/Jacobian/Velocity/NormalAcceleration signals
-   * - F2Position/F2Jacobian/F2Velocity/F2NormalAcceleration: proxy for the
-   *   second frame Position/Jacobian/Velocity/NormalAcceleration signals
-   *
-   */
-  class TVM_DLLAPI Contact : public graph::abstract::Node<Contact>
+/** Represent a contact between two frames
+ *
+ * The node forwards the signals of each frame.
+ *
+ * Outputs:
+ * - F1Position/F1Jacobian/F1Velocity/F1NormalAcceleration: proxy for the
+ *   first frame Position/Jacobian/Velocity/NormalAcceleration signals
+ * - F2Position/F2Jacobian/F2Velocity/F2NormalAcceleration: proxy for the
+ *   second frame Position/Jacobian/Velocity/NormalAcceleration signals
+ *
+ */
+class TVM_DLLAPI Contact : public graph::abstract::Node<Contact>
+{
+public:
+  /** Uniquely identifies a contact */
+  struct Id
   {
-  public:
-    /** Uniquely identifies a contact */
-    struct Id
+    /** First robot name */
+    std::string r1;
+    /** First robot's frame name */
+    std::string f1;
+    /** Second robot name */
+    std::string r2;
+    /** Second robot's frame name */
+    std::string f2;
+    /** Allow to distinguish the same contact */
+    int ambiguityId;
+    /** Comparison to use Id in map/set */
+    inline bool operator<(const Id & rhs) const
     {
-      /** First robot name */
-      std::string r1;
-      /** First robot's frame name */
-      std::string f1;
-      /** Second robot name */
-      std::string r2;
-      /** Second robot's frame name */
-      std::string f2;
-      /** Allow to distinguish the same contact */
-      int ambiguityId;
-      /** Comparison to use Id in map/set */
-      inline bool operator<(const Id & rhs) const
-      {
+      // clang-format off
         return r1 < rhs.r1 ||
           ( r1 == rhs.r1 && f1 < rhs.f1 ) ||
           ( r1 == rhs.r1 && f1 == rhs.f1 && r2 < rhs.r2 ) ||
           ( r1 == rhs.r1 && f1 == rhs.f1 && r2 == rhs.r2 && f2 < rhs.f2 ) ||
           ( r1 == rhs.r1 && f1 == rhs.f1 && r2 == rhs.f2 && f2 == rhs.f2 && ambiguityId < rhs.ambiguityId );
-      }
-      inline bool operator==(const Id & rhs) const
-      {
-        return ( r1 == rhs.r1 && f1 == rhs.f1 && r2 == rhs.r2 && f2 == rhs.f2 && ambiguityId == rhs.ambiguityId );
-      }
-    };
-
-    /** Allows to view a contact from one frame perspective */
-    struct View
+      // clang-format on
+    }
+    inline bool operator==(const Id & rhs) const
     {
-      const Id & id;
-      const FramePtr & f;
-      const std::vector<sva::PTransformd> & points;
-    };
-
-    SET_OUTPUTS(Contact,
-                F1Position, F1Jacobian, F1Velocity, F1NormalAcceleration,
-                F2Position, F2Jacobian, F2Velocity, F2NormalAcceleration
-    )
-
-    /** Constructor
-     *
-     * Represent a contact between frame f1 and f2, the contacts points are
-     * provided in f1 frame. Importantly, it assumes the frame position are
-     * already known.
-     *
-     * \param f1 Contact frame f1
-     *
-     * \param f2 Contact frame f2
-     *
-     * \param points Contact points expressed in f1
-     *
-     * \param ambiguityId If the "same" contact must exist multiple times
-     *
-     */
-    Contact(FramePtr f1, FramePtr f2,
-            std::vector<sva::PTransformd> points,
-            int ambiguityId = 0);
-
-    /** Return the first frame in the contact */
-    inline const Frame & f1() const { return *f1_; }
-
-    /** Return the second frame in the contact */
-    inline const Frame & f2() const { return *f2_; }
-
-    /** Return the contact points in f1 */
-    inline const std::vector<sva::PTransformd> & f1Points() const { return f1Points_; }
-
-    /** Initial transformation between frame 1 and frame 2 */
-    inline const sva::PTransformd & X_f1_f2() const { return X_f1_f2_; }
-
-    /** Initial transformation between frame 2 and frame 1 */
-    inline const sva::PTransformd & X_f2_f1() const { return X_f2_f1_; }
-
-    /** Return the contact points in f2 */
-    inline const std::vector<sva::PTransformd> & f2Points() const { return f2Points_; }
-
-    /** Return a contact view from f1 perspective */
-    inline const View f1View() const { return {id_, f1_, f1Points_}; };
-
-    /** Return a contact view from f2 perspective */
-    inline const View f2View() const { return {id_, f2_, f2Points_}; };
-
-    /** Return the contact's unique id */
-    inline const Id & id() const { return id_; }
-  private:
-    FramePtr f1_;
-    FramePtr f2_;
-    sva::PTransformd X_f1_f2_;
-    sva::PTransformd X_f2_f1_;
-    std::vector<sva::PTransformd> f1Points_;
-    std::vector<sva::PTransformd> f2Points_;
-    Id id_;
+      return (r1 == rhs.r1 && f1 == rhs.f1 && r2 == rhs.r2 && f2 == rhs.f2 && ambiguityId == rhs.ambiguityId);
+    }
   };
 
-  using ContactPtr = std::shared_ptr<Contact>;
-}
+  /** Allows to view a contact from one frame perspective */
+  struct View
+  {
+    const Id & id;
+    const FramePtr & f;
+    const std::vector<sva::PTransformd> & points;
+  };
 
-}
+  SET_OUTPUTS(Contact,
+              F1Position,
+              F1Jacobian,
+              F1Velocity,
+              F1NormalAcceleration,
+              F2Position,
+              F2Jacobian,
+              F2Velocity,
+              F2NormalAcceleration)
+
+  /** Constructor
+   *
+   * Represent a contact between frame f1 and f2, the contacts points are
+   * provided in f1 frame. Importantly, it assumes the frame position are
+   * already known.
+   *
+   * \param f1 Contact frame f1
+   *
+   * \param f2 Contact frame f2
+   *
+   * \param points Contact points expressed in f1
+   *
+   * \param ambiguityId If the "same" contact must exist multiple times
+   *
+   */
+  Contact(FramePtr f1, FramePtr f2, std::vector<sva::PTransformd> points, int ambiguityId = 0);
+
+  /** Return the first frame in the contact */
+  inline const Frame & f1() const { return *f1_; }
+
+  /** Return the second frame in the contact */
+  inline const Frame & f2() const { return *f2_; }
+
+  /** Return the contact points in f1 */
+  inline const std::vector<sva::PTransformd> & f1Points() const { return f1Points_; }
+
+  /** Initial transformation between frame 1 and frame 2 */
+  inline const sva::PTransformd & X_f1_f2() const { return X_f1_f2_; }
+
+  /** Initial transformation between frame 2 and frame 1 */
+  inline const sva::PTransformd & X_f2_f1() const { return X_f2_f1_; }
+
+  /** Return the contact points in f2 */
+  inline const std::vector<sva::PTransformd> & f2Points() const { return f2Points_; }
+
+  /** Return a contact view from f1 perspective */
+  inline const View f1View() const { return {id_, f1_, f1Points_}; };
+
+  /** Return a contact view from f2 perspective */
+  inline const View f2View() const { return {id_, f2_, f2Points_}; };
+
+  /** Return the contact's unique id */
+  inline const Id & id() const { return id_; }
+
+private:
+  FramePtr f1_;
+  FramePtr f2_;
+  sva::PTransformd X_f1_f2_;
+  sva::PTransformd X_f2_f1_;
+  std::vector<sva::PTransformd> f1Points_;
+  std::vector<sva::PTransformd> f2Points_;
+  Id id_;
+};
+
+using ContactPtr = std::shared_ptr<Contact>;
+} // namespace robot
+
+} // namespace tvm
 
 /** Output stream operator for Contact::Id */
 std::ostream & operator<<(std::ostream & os, const tvm::robot::Contact::Id & c);

--- a/include/tvm/robot/ConvexHull.h
+++ b/include/tvm/robot/ConvexHull.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/ConvexHull.h
+++ b/include/tvm/robot/ConvexHull.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -40,60 +40,61 @@ namespace tvm
 namespace robot
 {
 
-  /** Represent a convex hull attached to a frame
+/** Represent a convex hull attached to a frame
+ *
+ * Outputs:
+ *
+ * - Position: keep the convex hull position up-to-date
+ *
+ */
+class TVM_DLLAPI ConvexHull : public graph::abstract::Node<ConvexHull>
+{
+public:
+  SET_OUTPUTS(ConvexHull, Position)
+  SET_UPDATES(ConvexHull, Position)
+
+  /** Constructor with a given S_Object instance
    *
-   * Outputs:
+   * \param o sch-core object representing the convex hull
    *
-   * - Position: keep the convex hull position up-to-date
+   * \param f frame to which the object is attached
+   *
+   * \param X_f_o \p o position will be set at each iteration to \f$ {}^{o}X_{f} f.position() \f$
    *
    */
-  class TVM_DLLAPI ConvexHull : public graph::abstract::Node<ConvexHull>
-  {
-  public:
-    SET_OUTPUTS(ConvexHull, Position)
-    SET_UPDATES(ConvexHull, Position)
+  ConvexHull(std::shared_ptr<sch::S_Object> o, FramePtr f, const sva::PTransformd & X_f_o);
 
-    /** Constructor with a given S_Object instance
-     *
-     * \param o sch-core object representing the convex hull
-     *
-     * \param f frame to which the object is attached
-     *
-     * \param X_f_o \p o position will be set at each iteration to \f$ {}^{o}X_{f} f.position() \f$
-     *
-     */
-    ConvexHull(std::shared_ptr<sch::S_Object> o, FramePtr f, const sva::PTransformd & X_f_o);
+  /** Constructor with the path to the convex hull
+   *
+   * This assumes you are loading an sch::S_Polyhedron object.
+   *
+   * \param path path to the sch-object
+   *
+   * \param f frame to which the object is attached
+   *
+   * \param X_f_o \p o position will be set at each iteration to \f$ {}^{o}X_{f} f.position() \f$
+   *
+   */
+  ConvexHull(const std::string & path, FramePtr f, const sva::PTransformd & X_f_o);
 
-    /** Constructor with the path to the convex hull
-     *
-     * This assumes you are loading an sch::S_Polyhedron object.
-     *
-     * \param path path to the sch-object
-     *
-     * \param f frame to which the object is attached
-     *
-     * \param X_f_o \p o position will be set at each iteration to \f$ {}^{o}X_{f} f.position() \f$
-     *
-     */
-    ConvexHull(const std::string & path, FramePtr f, const sva::PTransformd & X_f_o);
+  /** Make a sch::CD_Pair from a second ConvexHull */
+  sch::CD_Pair makePair(const ConvexHull & hull) const;
 
-    /** Make a sch::CD_Pair from a second ConvexHull */
-    sch::CD_Pair makePair(const ConvexHull & hull) const;
+  /** Access the underlying frame (const) */
+  const Frame & frame() const;
 
-    /** Access the underlying frame (const) */
-    const Frame & frame() const;
+  /** Access the underlying frame */
+  Frame & frame();
 
-    /** Access the underlying frame */
-    Frame & frame();
-  private:
-    std::shared_ptr<sch::S_Object> o_;
-    FramePtr f_;
-    sva::PTransformd X_f_o_;
+private:
+  std::shared_ptr<sch::S_Object> o_;
+  FramePtr f_;
+  sva::PTransformd X_f_o_;
 
-    void updatePosition();
-  };
+  void updatePosition();
+};
 
-  using ConvexHullPtr = std::shared_ptr<ConvexHull>;
+using ConvexHullPtr = std::shared_ptr<ConvexHull>;
 
 } // namespace robot
 

--- a/include/tvm/robot/Frame.h
+++ b/include/tvm/robot/Frame.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/function/abstract/Function.h>
 
 #include <RBDyn/Jacobian.h>

--- a/include/tvm/robot/Frame.h
+++ b/include/tvm/robot/Frame.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/Frame.h
+++ b/include/tvm/robot/Frame.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -41,91 +41,89 @@ namespace tvm
 namespace robot
 {
 
-  /** A frame belonging to a robot
+/** A frame belonging to a robot
+ *
+ * Provides the frame position, jacobian, velocity and normal acceleration.
+ * These signals are correctly initialized on the object's creation.
+ *
+ * Outputs:
+ * - Position: position of the frame in world coordinates
+ * - Jacobian: jacobian of the frame in world coordinates
+ * - Velocity: velocity of the frame in world coordinates
+ * - NormalAcceleration: normal acceleration of the frame in world
+ *   coordinates
+ *
+ */
+class TVM_DLLAPI Frame : public graph::abstract::Node<Frame>
+{
+public:
+  SET_OUTPUTS(Frame, Position, Jacobian, Velocity, NormalAcceleration)
+  SET_UPDATES(Frame, Position, Jacobian, Velocity, NormalAcceleration)
+
+  /** Constructor
    *
-   * Provides the frame position, jacobian, velocity and normal acceleration.
-   * These signals are correctly initialized on the object's creation.
+   * Creates a frame belonging to a robot
    *
-   * Outputs:
-   * - Position: position of the frame in world coordinates
-   * - Jacobian: jacobian of the frame in world coordinates
-   * - Velocity: velocity of the frame in world coordinates
-   * - NormalAcceleration: normal acceleration of the frame in world
-   *   coordinates
+   * \param name Name of the frame
+   *
+   * \param robot Robot to which the frame is attached
+   *
+   * \param body Parent body of the frame
+   *
+   * \param X_b_f Static transformation from the body to the frame
    *
    */
-  class TVM_DLLAPI Frame : public graph::abstract::Node<Frame>
-  {
-  public:
-    SET_OUTPUTS(Frame, Position, Jacobian, Velocity, NormalAcceleration)
-    SET_UPDATES(Frame, Position, Jacobian, Velocity, NormalAcceleration)
+  Frame(std::string name, RobotPtr robot, const std::string & body, sva::PTransformd X_b_f);
 
-    /** Constructor
-     *
-     * Creates a frame belonging to a robot
-     *
-     * \param name Name of the frame
-     *
-     * \param robot Robot to which the frame is attached
-     *
-     * \param body Parent body of the frame
-     *
-     * \param X_b_f Static transformation from the body to the frame
-     *
-     */
-    Frame(std::string name,
-          RobotPtr robot,
-          const std::string & body,
-          sva::PTransformd X_b_f);
+  /** Access the robot to which this frame belongs (const) */
+  inline const Robot & robot() const { return *robot_; }
 
-    /** Access the robot to which this frame belongs (const) */
-    inline const Robot & robot() const { return *robot_; }
+  /** Access the robot to which this frame belongs */
+  inline Robot & robot() { return *robot_; }
 
-    /** Access the robot to which this frame belongs */
-    inline Robot & robot() { return *robot_; }
+  /** Access the internal Jacobian object to perform extra-computation */
+  inline rbd::Jacobian & rbdJacobian() { return jac_; }
 
-    /** Access the internal Jacobian object to perform extra-computation */
-    inline rbd::Jacobian & rbdJacobian() { return jac_; }
+  /** Access the internal Jacobian object to perform extra-computation (const) */
+  inline const rbd::Jacobian & rbdJacobian() const { return jac_; }
 
-    /** Access the internal Jacobian object to perform extra-computation (const) */
-    inline const rbd::Jacobian & rbdJacobian() const { return jac_; }
+  /** The frame's name */
+  inline const std::string & name() const { return name_; }
+  /** The frame's position in world coordinates */
+  inline const sva::PTransformd & position() const { return position_; }
+  /** The frame's jacobian in world coordinates */
+  inline const tvm::internal::MatrixWithProperties & jacobian() const { return jacobian_; }
+  /** The frame's velocity in world coordinates */
+  inline const sva::MotionVecd & velocity() const { return velocity_; }
+  /** The frame's normal acceleration in world coordinates */
+  inline const sva::MotionVecd & normalAcceleration() const { return normalAcceleration_; }
+  /** Returns the frame's parent body */
+  const std::string & body() const;
 
-    /** The frame's name */
-    inline const std::string & name() const { return name_; }
-    /** The frame's position in world coordinates */
-    inline const sva::PTransformd & position() const { return position_; }
-    /** The frame's jacobian in world coordinates */
-    inline const tvm::internal::MatrixWithProperties & jacobian() const { return jacobian_; }
-    /** The frame's velocity in world coordinates */
-    inline const sva::MotionVecd & velocity() const { return velocity_; }
-    /** The frame's normal acceleration in world coordinates */
-    inline const sva::MotionVecd & normalAcceleration() const { return normalAcceleration_; }
-    /** Returns the frame's parent body */
-    const std::string & body() const;
-  private:
-    std::string name_;
-    RobotPtr robot_;
-    unsigned int bodyId_;
-    rbd::Jacobian jac_;
-    sva::PTransformd X_b_f_;
+private:
+  std::string name_;
+  RobotPtr robot_;
+  unsigned int bodyId_;
+  rbd::Jacobian jac_;
+  sva::PTransformd X_b_f_;
 
-    /** Update functions and cache data */
-    void updatePosition();
-    sva::PTransformd position_;
+  /** Update functions and cache data */
+  void updatePosition();
+  sva::PTransformd position_;
 
-    void updateJacobian();
-    Eigen::MatrixXd jacTmp_;
-    tvm::internal::MatrixWithProperties jacobian_;
+  void updateJacobian();
+  Eigen::MatrixXd jacTmp_;
+  tvm::internal::MatrixWithProperties jacobian_;
 
-    void updateVelocity();
-    sva::MotionVecd velocity_;
+  void updateVelocity();
+  sva::MotionVecd velocity_;
 
-    void updateNormalAcceleration();
-    sva::MotionVecd normalAcceleration_;
-  };
+  void updateNormalAcceleration();
+  sva::MotionVecd normalAcceleration_;
+};
 
-  using FramePtr = std::shared_ptr<Frame>;
+using FramePtr = std::shared_ptr<Frame>;
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/include/tvm/robot/JointsSelector.h
+++ b/include/tvm/robot/JointsSelector.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/JointsSelector.h
+++ b/include/tvm/robot/JointsSelector.h
@@ -1,36 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/defs.h>
 #include <tvm/Robot.h>
+#include <tvm/defs.h>
 
 #include <tvm/function/abstract/Function.h>
 
@@ -40,65 +40,74 @@ namespace tvm
 namespace robot
 {
 
-  /** This class implements joints' selection on a given fucntion */
-  class TVM_DLLAPI JointsSelector : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(JointsSelector, Jacobian, JDot)
+/** This class implements joints' selection on a given fucntion */
+class TVM_DLLAPI JointsSelector : public function::abstract::Function
+{
+public:
+  SET_UPDATES(JointsSelector, Jacobian, JDot)
 
-    /** Construct a JointsSelector from a vector of active joints
-     *
-     * \param f Function selected by this JointsSelector
-     *
-     * \param robot Robot controlled by \p f
-     *
-     * \param activeJoints Joints active in this selector
-     *
-     * \throws If \p does not depend on \p robot or any joint in activeJoints
-     * is not part of \p robot
-     */
-    static std::unique_ptr<JointsSelector> ActiveJoints(FunctionPtr f, RobotPtr robot, const std::vector<std::string> & activeJoints);
+  /** Construct a JointsSelector from a vector of active joints
+   *
+   * \param f Function selected by this JointsSelector
+   *
+   * \param robot Robot controlled by \p f
+   *
+   * \param activeJoints Joints active in this selector
+   *
+   * \throws If \p does not depend on \p robot or any joint in activeJoints
+   * is not part of \p robot
+   */
+  static std::unique_ptr<JointsSelector> ActiveJoints(FunctionPtr f,
+                                                      RobotPtr robot,
+                                                      const std::vector<std::string> & activeJoints);
 
-    /** Construct a JointsSelector from a vector of inactive joints
-     *
-     * \param f Function selected by this JointsSelector
-     *
-     * \param robot Robot controlled by \p f
-     *
-     * \param inactiveJoints Joints not active in this selector
-     *
-     * \throws If \p does not depend on \p robot or any joint in activeJoints
-     * is not part of \p robot
-     */
-    static std::unique_ptr<JointsSelector> InactiveJoints(FunctionPtr f, RobotPtr robot, const std::vector<std::string> & inactiveJoints);
+  /** Construct a JointsSelector from a vector of inactive joints
+   *
+   * \param f Function selected by this JointsSelector
+   *
+   * \param robot Robot controlled by \p f
+   *
+   * \param inactiveJoints Joints not active in this selector
+   *
+   * \throws If \p does not depend on \p robot or any joint in activeJoints
+   * is not part of \p robot
+   */
+  static std::unique_ptr<JointsSelector> InactiveJoints(FunctionPtr f,
+                                                        RobotPtr robot,
+                                                        const std::vector<std::string> & inactiveJoints);
 
-    const Eigen::VectorXd & value() const override { return f_->value(); }
-    const Eigen::VectorXd & velocity() const override { return f_->velocity(); }
-    const Eigen::VectorXd & normalAcceleration() const override { return f_->normalAcceleration(); }
-  protected:
-    /** Constructor
-     *
-     * \param f Function selected by this JointsSelector
-     *
-     * \param robot Robot controlled by \p f
-     *
-     * \param ffActive True if the selected joints include the free-flyer
-     *
-     * \param activeIndex For regular joints selected by this JointsSelector,
-     * this iss a list of (start, size) pair corresponding to the list of
-     * joints
-     *
-     */
-    JointsSelector(FunctionPtr f, RobotPtr robot, bool ffActive, const std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> & activeIndex);
-  protected:
-    void updateJacobian();
-    void updateJDot();
+  const Eigen::VectorXd & value() const override { return f_->value(); }
+  const Eigen::VectorXd & velocity() const override { return f_->velocity(); }
+  const Eigen::VectorXd & normalAcceleration() const override { return f_->normalAcceleration(); }
 
-    FunctionPtr f_;
-    RobotPtr robot_;
-    bool ffActive_;
-    std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> activeIndex_;
-  };
+protected:
+  /** Constructor
+   *
+   * \param f Function selected by this JointsSelector
+   *
+   * \param robot Robot controlled by \p f
+   *
+   * \param ffActive True if the selected joints include the free-flyer
+   *
+   * \param activeIndex For regular joints selected by this JointsSelector,
+   * this iss a list of (start, size) pair corresponding to the list of
+   * joints
+   *
+   */
+  JointsSelector(FunctionPtr f,
+                 RobotPtr robot,
+                 bool ffActive,
+                 const std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> & activeIndex);
+
+protected:
+  void updateJacobian();
+  void updateJDot();
+
+  FunctionPtr f_;
+  RobotPtr robot_;
+  bool ffActive_;
+  std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> activeIndex_;
+};
 
 } // namespace robot
 

--- a/include/tvm/robot/JointsSelector.h
+++ b/include/tvm/robot/JointsSelector.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include <tvm/Robot.h>
 #include <tvm/defs.h>
 
+#include <tvm/Robot.h>
 #include <tvm/function/abstract/Function.h>
 
 namespace tvm

--- a/include/tvm/robot/OrientationFunction.h
+++ b/include/tvm/robot/OrientationFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/OrientationFunction.h
+++ b/include/tvm/robot/OrientationFunction.h
@@ -1,36 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/robot/Frame.h>
 #include <tvm/function/abstract/Function.h>
+#include <tvm/robot/Frame.h>
 
 namespace tvm
 {
@@ -38,38 +38,39 @@ namespace tvm
 namespace robot
 {
 
-  /** This class implements an orientation function for a given frame */
-  class TVM_DLLAPI OrientationFunction : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(OrientationFunction, Value, Velocity, Jacobian, NormalAcceleration)
+/** This class implements an orientation function for a given frame */
+class TVM_DLLAPI OrientationFunction : public function::abstract::Function
+{
+public:
+  SET_UPDATES(OrientationFunction, Value, Velocity, Jacobian, NormalAcceleration)
 
-    /** Constructor
-     *
-     * Set the objective to the current frame orientation
-     *
-     */
-    OrientationFunction(FramePtr frame);
+  /** Constructor
+   *
+   * Set the objective to the current frame orientation
+   *
+   */
+  OrientationFunction(FramePtr frame);
 
-    /** Set the target orientation to the current frame orientation */
-    void reset();
+  /** Set the target orientation to the current frame orientation */
+  void reset();
 
-    /** Get the current objective */
-    inline const Eigen::Matrix3d & orientation() const { return ori_; }
+  /** Get the current objective */
+  inline const Eigen::Matrix3d & orientation() const { return ori_; }
 
-    /** Set the objective */
-    inline void orientation(const Eigen::Matrix3d & ori) { ori_ = ori; }
-  protected:
-    void updateValue();
-    void updateVelocity();
-    void updateJacobian();
-    void updateNormalAcceleration();
+  /** Set the objective */
+  inline void orientation(const Eigen::Matrix3d & ori) { ori_ = ori; }
 
-    FramePtr frame_;
+protected:
+  void updateValue();
+  void updateVelocity();
+  void updateJacobian();
+  void updateNormalAcceleration();
 
-    /** Target */
-    Eigen::Matrix3d ori_;
-  };
+  FramePtr frame_;
+
+  /** Target */
+  Eigen::Matrix3d ori_;
+};
 
 } // namespace robot
 

--- a/include/tvm/robot/PositionFunction.h
+++ b/include/tvm/robot/PositionFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/PositionFunction.h
+++ b/include/tvm/robot/PositionFunction.h
@@ -1,36 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/robot/Frame.h>
 #include <tvm/function/abstract/Function.h>
+#include <tvm/robot/Frame.h>
 
 namespace tvm
 {
@@ -38,38 +38,39 @@ namespace tvm
 namespace robot
 {
 
-  /** This class implements a position function for a given frame */
-  class TVM_DLLAPI PositionFunction : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(PositionFunction, Value, Velocity, Jacobian, NormalAcceleration)
+/** This class implements a position function for a given frame */
+class TVM_DLLAPI PositionFunction : public function::abstract::Function
+{
+public:
+  SET_UPDATES(PositionFunction, Value, Velocity, Jacobian, NormalAcceleration)
 
-    /** Constructor
-     *
-     * Set the objective to the current frame orientation
-     *
-     */
-    PositionFunction(FramePtr frame);
+  /** Constructor
+   *
+   * Set the objective to the current frame orientation
+   *
+   */
+  PositionFunction(FramePtr frame);
 
-    /** Set the target position to the current frame position */
-    void reset();
+  /** Set the target position to the current frame position */
+  void reset();
 
-    /** Get the current objective */
-    inline const Eigen::Vector3d & position() const { return pos_; }
+  /** Get the current objective */
+  inline const Eigen::Vector3d & position() const { return pos_; }
 
-    /** Set the objective */
-    inline void position(const Eigen::Vector3d & pos) { pos_ = pos; }
-  protected:
-    void updateValue();
-    void updateVelocity();
-    void updateJacobian();
-    void updateNormalAcceleration();
+  /** Set the objective */
+  inline void position(const Eigen::Vector3d & pos) { pos_ = pos; }
 
-    FramePtr frame_;
+protected:
+  void updateValue();
+  void updateVelocity();
+  void updateJacobian();
+  void updateNormalAcceleration();
 
-    /** Target */
-    Eigen::Vector3d pos_;
-  };
+  FramePtr frame_;
+
+  /** Target */
+  Eigen::Vector3d pos_;
+};
 
 } // namespace robot
 

--- a/include/tvm/robot/PostureFunction.h
+++ b/include/tvm/robot/PostureFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/PostureFunction.h
+++ b/include/tvm/robot/PostureFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,47 +39,48 @@ namespace tvm
 namespace robot
 {
 
-  /** This class implements a posture function for a given robot */
-  class TVM_DLLAPI PostureFunction : public function::abstract::Function
-  {
-  public:
-    SET_UPDATES(PostureFunction, Value, Velocity)
+/** This class implements a posture function for a given robot */
+class TVM_DLLAPI PostureFunction : public function::abstract::Function
+{
+public:
+  SET_UPDATES(PostureFunction, Value, Velocity)
 
-    /** Constructor
-     *
-     * Set the objective to the current posture of robot
-     *
-     */
-    PostureFunction(RobotPtr robot);
+  /** Constructor
+   *
+   * Set the objective to the current posture of robot
+   *
+   */
+  PostureFunction(RobotPtr robot);
 
-    /** Set the target posture to the current robot's posture */
-    void reset();
+  /** Set the target posture to the current robot's posture */
+  void reset();
 
-    /** Set the target for a given joint
-     *
-     *  \param j Joint name
-     *
-     *  \param q Target configuration
-     *
-     */
-    void posture(const std::string & j, const std::vector<double> & q);
+  /** Set the target for a given joint
+   *
+   *  \param j Joint name
+   *
+   *  \param q Target configuration
+   *
+   */
+  void posture(const std::string & j, const std::vector<double> & q);
 
-    /** Set the fully body posture */
-    void posture(const std::vector<std::vector<double>> & p);
-  protected:
-    void updateValue();
+  /** Set the fully body posture */
+  void posture(const std::vector<std::vector<double>> & p);
 
-    void updateVelocity();
+protected:
+  void updateValue();
 
-    RobotPtr robot_;
+  void updateVelocity();
 
-    /** Target */
-    std::vector<std::vector<double>> posture_;
+  RobotPtr robot_;
 
-    /** Starting joint */
-    int j0_;
-  };
+  /** Target */
+  std::vector<std::vector<double>> posture_;
 
-}
+  /** Starting joint */
+  int j0_;
+};
 
-}
+} // namespace robot
+
+} // namespace tvm

--- a/include/tvm/robot/enums.h
+++ b/include/tvm/robot/enums.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -35,40 +35,40 @@ namespace tvm
 namespace robot
 {
 
-  /** For a given contact, specify the type of constraint that is applied:
-   *
-   * - Acceleration: constraint the two frames relative-acceleration to remain
-   *   the same
-   * - Velocity: constraint the two frames relative-velocity to remain the same
-   * - Position: constrant the two frames relative-position to remain the same
-   *
-   * This is done by specifiying different coefficient to the task's dynamics.
-   *
-   * This only applies to contacts that include a geometric component.
-   *
-   */
-  enum class ContactConstraintType
-  {
-    Acceleration,
-    Velocity,
-    Position
-  };
+/** For a given contact, specify the type of constraint that is applied:
+ *
+ * - Acceleration: constraint the two frames relative-acceleration to remain
+ *   the same
+ * - Velocity: constraint the two frames relative-velocity to remain the same
+ * - Position: constrant the two frames relative-position to remain the same
+ *
+ * This is done by specifiying different coefficient to the task's dynamics.
+ *
+ * This only applies to contacts that include a geometric component.
+ *
+ */
+enum class ContactConstraintType
+{
+  Acceleration,
+  Velocity,
+  Position
+};
 
-  /** Specify the type of contact:
-   *
-   * - Regular: both Force and Geometric
-   * - Force: force-only contact (no geometric constraint)
-   * - Geometric: geometric-only contact (no additional forces applied by the
-   *   robots onto each other)
-   *
-   */
-  enum class ContactType
-  {
-    Regular,
-    Force,
-    Geometric
-  };
+/** Specify the type of contact:
+ *
+ * - Regular: both Force and Geometric
+ * - Force: force-only contact (no geometric constraint)
+ * - Geometric: geometric-only contact (no additional forces applied by the
+ *   robots onto each other)
+ *
+ */
+enum class ContactType
+{
+  Regular,
+  Force,
+  Geometric
+};
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/include/tvm/robot/enums.h
+++ b/include/tvm/robot/enums.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/internal/DynamicFunction.h
+++ b/include/tvm/robot/internal/DynamicFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/internal/DynamicFunction.h
+++ b/include/tvm/robot/internal/DynamicFunction.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <tvm/Robot.h>
 #include <tvm/api.h>
+
+#include <tvm/Robot.h>
 
 #include <tvm/function/abstract/LinearFunction.h>
 

--- a/include/tvm/robot/internal/DynamicFunction.h
+++ b/include/tvm/robot/internal/DynamicFunction.h
@@ -1,43 +1,42 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-
-#include <tvm/api.h>
 #include <tvm/Robot.h>
+#include <tvm/api.h>
 
 #include <tvm/function/abstract/LinearFunction.h>
 
 #include <tvm/robot/enums.h>
-#include <tvm/robot/internal/GeometricContactFunction.h>
 #include <tvm/robot/internal/FrictionCone.h>
+#include <tvm/robot/internal/GeometricContactFunction.h>
 
 #include <RBDyn/FD.h>
 
@@ -52,118 +51,117 @@ namespace robot
 namespace internal
 {
 
-  /** Implement the equation of motion for a given robot.
+/** Implement the equation of motion for a given robot.
+ *
+ * It can be given contacts that will be integrated into the equation of
+ * motion (\see DynamicFunction::addContact) or contacts that will be removed
+ * from the equation (\see DynamicFunction::removeContact).
+ *
+ * It manages the force variables related to these contacts.
+ *
+ * It also takes care of linearizing the contacts, either by having them in a
+ * linearized form in the solver (lambdas) or as forces. The related
+ * constraint (mu*f_n >= ||f_t||) can be added to the problem through this
+ * function.
+ *
+ * Notably, it does not take care of enforcing Newton 3rd law of motion when
+ * two actuated robots are in contact.
+ *
+ */
+class TVM_DLLAPI DynamicFunction : public function::abstract::LinearFunction
+{
+public:
+  using Output = function::abstract::LinearFunction::Output;
+  DISABLE_OUTPUTS(Output::JDot)
+  SET_UPDATES(DynamicFunction, Jacobian, B)
+
+  /** Construct the equation of motion for a given robot */
+  DynamicFunction(RobotPtr robot);
+
+  /** Add a contact to the function
    *
-   * It can be given contacts that will be integrated into the equation of
-   * motion (\see DynamicFunction::addContact) or contacts that will be removed
-   * from the equation (\see DynamicFunction::removeContact).
+   * This adds forces variables for every contact point belonging to the
+   * robot of this dynamic function.
    *
-   * It manages the force variables related to these contacts.
+   * \param contact Contact that will be added
    *
-   * It also takes care of linearizing the contacts, either by having them in a
-   * linearized form in the solver (lambdas) or as forces. The related
-   * constraint (mu*f_n >= ||f_t||) can be added to the problem through this
-   * function.
+   * \param linearize If true, linearize the friction cone using generatrices
    *
-   * Notably, it does not take care of enforcing Newton 3rd law of motion when
-   * two actuated robots are in contact.
+   * \param mu Friction coefficient
+   *
+   * \param nrGen Number of generatrices for the cone (only applicable when
+   * linearize is true)
+   *
+   * Returns true if a contact has been added */
+  bool addContact(ContactPtr contact, bool linearize, double mu, unsigned int nrGen);
+
+  /** Remove a contact
+   *
+   * This has no effect if this contact was not added before
    *
    */
-  class TVM_DLLAPI DynamicFunction : public function::abstract::LinearFunction
+  void removeContact(const Contact::Id & id);
+
+  /** Return the contact force at the contact.
+   *
+   * The force is null if this contact has not been added or does not
+   * concern the related robot.
+   */
+  sva::ForceVecd contactForce(const Contact::Id & id) const;
+
+  /** Add constraints to the given problem
+   *
+   * The constraints express that the contact should not slip, i.e. mu*f_n >
+   * ||f_t||, where mu was set when the contact was added.
+   *
+   */
+  void addPositiveLambdaToProblem(ControlProblem & problem);
+
+protected:
+  void updateb();
+
+  RobotPtr robot_;
+
+  /** Holds data for the force part of the motion equation */
+  struct ForceContact
   {
-  public:
-    using Output = function::abstract::LinearFunction::Output;
-    DISABLE_OUTPUTS(Output::JDot)
-    SET_UPDATES(DynamicFunction, Jacobian, B)
+    /** Contact id */
+    Contact::Id id_;
 
-    /** Construct the equation of motion for a given robot */
-    DynamicFunction(RobotPtr robot);
+    /** True if the contact has been linearized */
+    bool linearized_;
 
-    /** Add a contact to the function
+    /** Force (1 3d variable per contact point)
      *
-     * This adds forces variables for every contact point belonging to the
-     * robot of this dynamic function.
+     * OR
      *
-     * \param contact Contact that will be added
-     *
-     * \param linearize If true, linearize the friction cone using generatrices
-     *
-     * \param mu Friction coefficient
-     *
-     * \param nrGen Number of generatrices for the cone (only applicable when
-     * linearize is true)
-     *
-     * Returns true if a contact has been added */
-    bool addContact(ContactPtr contact,
-                    bool linearize, double mu, unsigned int nrGen);
-
-    /** Remove a contact
-     *
-     * This has no effect if this contact was not added before
+     * lambdas (1 nrGen-d variable per contact point)
      *
      */
-    void removeContact(const Contact::Id & id);
+    std::vector<tvm::VariablePtr> forces_;
 
-    /** Return the contact force at the contact.
-     *
-     * The force is null if this contact has not been added or does not
-     * concern the related robot.
-     */
-    sva::ForceVecd contactForce(const Contact::Id & id) const;
+    /** Compute the resulting force on the contact */
+    std::function<sva::ForceVecd(const ForceContact &)> force_;
 
-    /** Add constraints to the given problem
-     *
-     * The constraints express that the contact should not slip, i.e. mu*f_n >
-     * ||f_t||, where mu was set when the contact was added.
-     *
-     */
-    void addPositiveLambdaToProblem(ControlProblem & problem);
-  protected:
-    void updateb();
+    /** Used for intermediate Jacobian computation */
+    Eigen::MatrixXd force_jac_;
+    Eigen::MatrixXd full_jac_;
 
-    RobotPtr robot_;
-
-    /** Holds data for the force part of the motion equation */
-    struct ForceContact
-    {
-      /** Contact id */
-      Contact::Id id_;
-
-      /** True if the contact has been linearized */
-      bool linearized_;
-
-      /** Force (1 3d variable per contact point)
-       *
-       * OR
-       *
-       * lambdas (1 nrGen-d variable per contact point)
-       *
-       */
-      std::vector<tvm::VariablePtr> forces_;
-
-      /** Compute the resulting force on the contact */
-      std::function<sva::ForceVecd(const ForceContact&)> force_;
-
-      /** Used for intermediate Jacobian computation */
-      Eigen::MatrixXd force_jac_;
-      Eigen::MatrixXd full_jac_;
-
-      /** Update jacobians */
-      std::function<void(ForceContact&, DynamicFunction&)> updateJacobians_;
-    };
-    std::vector<ForceContact> contacts_;
-
-    void updateJacobian();
-
-    void addContact_(const Contact::View & contact, bool linearize,
-                     double mu, unsigned int nrGen, double dir);
-
-    std::vector<ForceContact>::iterator getContact(const Contact::Id & id);
-    std::vector<ForceContact>::const_iterator getContact(const Contact::Id & id) const;
+    /** Update jacobians */
+    std::function<void(ForceContact &, DynamicFunction &)> updateJacobians_;
   };
+  std::vector<ForceContact> contacts_;
 
-}
+  void updateJacobian();
 
-}
+  void addContact_(const Contact::View & contact, bool linearize, double mu, unsigned int nrGen, double dir);
 
-}
+  std::vector<ForceContact>::iterator getContact(const Contact::Id & id);
+  std::vector<ForceContact>::const_iterator getContact(const Contact::Id & id) const;
+};
+
+} // namespace internal
+
+} // namespace robot
+
+} // namespace tvm

--- a/include/tvm/robot/internal/FrictionCone.h
+++ b/include/tvm/robot/internal/FrictionCone.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/internal/FrictionCone.h
+++ b/include/tvm/robot/internal/FrictionCone.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -66,14 +66,13 @@ public:
    * \param dir Cone direction
    *
    */
-  FrictionCone(const Eigen::Matrix3d & frame,
-               unsigned int nrGen, double mu, double direction = 1.0);
+  FrictionCone(const Eigen::Matrix3d & frame, unsigned int nrGen, double mu, double direction = 1.0);
 
   std::vector<Eigen::Vector3d> generators;
 };
 
-}
+} // namespace internal
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/include/tvm/robot/internal/GeometricContactFunction.h
+++ b/include/tvm/robot/internal/GeometricContactFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,58 +42,58 @@ namespace robot
 namespace internal
 {
 
-  /** Represents a geometric contact function
+/** Represents a geometric contact function
+ *
+ * Given a Contact (f1, f2) belonging to (r1, r2) this is the difference
+ * between their current relative position and their initial relative
+ * position. This is a function of r1.q and r2.q if r1 or r2 is not actuated,
+ * then it is not taken into account in computations. If both are not
+ * actuated this does nothing.
+ *
+ * The degrees of freedom computed by this function can be specified through
+ * a 6x6 dof matrix.
+ *
+ * Outputs:
+ *
+ * - Value: dof*transformError(X_f1_f2, X_f1_f2_init)
+ * - Velocity: dof*(f1.velocity - f2.velocity)
+ * - NormalAcceleration: dof*(f1.NA - f2.NA)
+ * - Jacobian: defined for r1.q as dof*f1.J and for r2.q as -dof*f2.J
+ *
+ */
+class TVM_DLLAPI GeometricContactFunction : public function::abstract::Function
+{
+public:
+  using Output = function::abstract::Function::Output;
+  DISABLE_OUTPUTS(Output::JDot)
+  SET_UPDATES(GeometricContactFunction, Value, Velocity, NormalAcceleration, Jacobian)
+
+  /** Constructor
    *
-   * Given a Contact (f1, f2) belonging to (r1, r2) this is the difference
-   * between their current relative position and their initial relative
-   * position. This is a function of r1.q and r2.q if r1 or r2 is not actuated,
-   * then it is not taken into account in computations. If both are not
-   * actuated this does nothing.
+   * \param contact The Contact that this function computes
    *
-   * The degrees of freedom computed by this function can be specified through
-   * a 6x6 dof matrix.
-   *
-   * Outputs:
-   *
-   * - Value: dof*transformError(X_f1_f2, X_f1_f2_init)
-   * - Velocity: dof*(f1.velocity - f2.velocity)
-   * - NormalAcceleration: dof*(f1.NA - f2.NA)
-   * - Jacobian: defined for r1.q as dof*f1.J and for r2.q as -dof*f2.J
+   * \param dof The function dof matrix
    *
    */
-  class TVM_DLLAPI GeometricContactFunction : public function::abstract::Function
-  {
-  public:
-    using Output = function::abstract::Function::Output;
-    DISABLE_OUTPUTS(Output::JDot)
-    SET_UPDATES(GeometricContactFunction, Value, Velocity, NormalAcceleration, Jacobian)
+  GeometricContactFunction(ContactPtr contact, Eigen::Matrix6d dof);
 
-    /** Constructor
-     *
-     * \param contact The Contact that this function computes
-     *
-     * \param dof The function dof matrix
-     *
-     */
-    GeometricContactFunction(ContactPtr contact,
-                             Eigen::Matrix6d dof);
-  private:
-    ContactPtr contact_;
-    Eigen::Matrix6d dof_;
-    bool has_f1_;
-    bool has_f2_;
+private:
+  ContactPtr contact_;
+  Eigen::Matrix6d dof_;
+  bool has_f1_;
+  bool has_f2_;
 
-    bool first_update_ = true;
-    sva::PTransformd X_f1_f2_init_;
+  bool first_update_ = true;
+  sva::PTransformd X_f1_f2_init_;
 
-    void updateValue();
-    void updateVelocity();
-    void updateNormalAcceleration();
-    void updateJacobian();
-  };
+  void updateValue();
+  void updateVelocity();
+  void updateNormalAcceleration();
+  void updateJacobian();
+};
 
-}
+} // namespace internal
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/include/tvm/robot/internal/GeometricContactFunction.h
+++ b/include/tvm/robot/internal/GeometricContactFunction.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/function/abstract/Function.h>
 #include <tvm/robot/Contact.h>
 

--- a/include/tvm/robot/internal/GeometricContactFunction.h
+++ b/include/tvm/robot/internal/GeometricContactFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/utils.h
+++ b/include/tvm/robot/utils.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/robot/utils.h
+++ b/include/tvm/robot/utils.h
@@ -1,44 +1,43 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <tvm/api.h>
 #include <tvm/Clock.h>
 #include <tvm/Robot.h>
+#include <tvm/api.h>
 
 namespace tvm
 {
 
 namespace robot
 {
-
 
 /** Load a robot from a URDF file
  *
@@ -58,8 +57,10 @@ namespace robot
  *
  */
 
-std::unique_ptr<Robot> TVM_DLLAPI fromURDF(tvm::Clock & clock, const std::string & name,
-                                           const std::string & path, bool fixed,
+std::unique_ptr<Robot> TVM_DLLAPI fromURDF(tvm::Clock & clock,
+                                           const std::string & name,
+                                           const std::string & path,
+                                           bool fixed,
                                            const std::vector<std::string> & filteredLinks,
                                            const std::map<std::string, std::vector<double>> & q);
 

--- a/include/tvm/robot/utils.h
+++ b/include/tvm/robot/utils.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
+#include <tvm/api.h>
+
 #include <tvm/Clock.h>
 #include <tvm/Robot.h>
-#include <tvm/api.h>
 
 namespace tvm
 {

--- a/include/tvm/scheme/WeightedLeastSquares.h
+++ b/include/tvm/scheme/WeightedLeastSquares.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/WeightedLeastSquares.h
+++ b/include/tvm/scheme/WeightedLeastSquares.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -38,122 +38,131 @@
 // Creating a class tvm::internal::has_member_type_Factory<T>
 TVM_CREATE_HAS_MEMBER_TYPE_TRAIT_FOR(Factory)
 
-
 namespace tvm
 {
 
 namespace scheme
 {
-  /** A set of options for WeightedLeastSquares. */
-  class TVM_DLLAPI WeightedLeastSquaresOptions
+/** A set of options for WeightedLeastSquares. */
+class TVM_DLLAPI WeightedLeastSquaresOptions
+{
+  /** If \a true, a damping task is added when no constraint with level >=1 has been
+   * given.
+   */
+  TVM_ADD_NON_DEFAULT_OPTION(autoDamping, false)
+  /**  The factor to emulate priority for priority levels >= 1.
+   * E.g. if a task T1 has a weight w1 and priority 1, and a task T2 has a weight w2 and
+   * priority 2, the weighted least-squares problem will be assembled with weights
+   * \p scalarizationWeight * w1 and w2 for T1 and T2 respectively. */
+  TVM_ADD_NON_DEFAULT_OPTION(scalarizationWeight, 1000.)
+};
+
+/** This class implements the classic weighted least square scheme. */
+class TVM_DLLAPI WeightedLeastSquares : public abstract::LinearResolutionScheme<WeightedLeastSquares>
+{
+private:
+  struct Memory : public internal::LinearizedProblemComputationData
   {
-    /** If \a true, a damping task is added when no constraint with level >=1 has been
-      * given.
-      */
-    TVM_ADD_NON_DEFAULT_OPTION(autoDamping, false)
-    /**  The factor to emulate priority for priority levels >= 1.
-      * E.g. if a task T1 has a weight w1 and priority 1, and a task T2 has a weight w2 and
-      * priority 2, the weighted least-squares problem will be assembled with weights
-      * \p scalarizationWeight * w1 and w2 for T1 and T2 respectively. */
-    TVM_ADD_NON_DEFAULT_OPTION(scalarizationWeight, 1000.)
+    Memory(int solverId, std::unique_ptr<solver::abstract::LeastSquareSolver> solver);
 
-  };
+    std::unique_ptr<solver::abstract::LeastSquareSolver> solver;
 
-  /** This class implements the classic weighted least square scheme. */
-  class TVM_DLLAPI WeightedLeastSquares : public abstract::LinearResolutionScheme<WeightedLeastSquares>
-  {
-  private:
-    struct Memory : public internal::LinearizedProblemComputationData
-    {
-      Memory(int solverId, std::unique_ptr<solver::abstract::LeastSquareSolver> solver);
-
-      std::unique_ptr<solver::abstract::LeastSquareSolver> solver;
-
-      int maxp;
-
-    protected:
-      void setVariablesToSolution_(VariableVector& x) override;
-    };
-
-    const static internal::SchemeAbilities abilities_;
-
-    /** Check if T derives from LSSolverFactory. */
-    template<typename T> using isFactory = std::is_base_of<solver::abstract::LSSolverFactory, T>;
-    /** Helper struct for isOption .*/
-    template<typename T, bool> struct isOption_ : std::false_type {};
-    /** Helper struct specialization for isOption .*/
-    template<typename T> struct isOption_<T, true> { static const bool value = isFactory<typename T::Factory>::value;  };
-    /** Check if T has a member T::Factory and if so if T::Factory derives from LSSolverFactory.*/
-    template<typename T> using isOption = isOption_<T, tvm::internal::has_member_type_Factory<T>::value>;
-
-  public:
-    using ComputationDataType = Memory;
-
-    /** Constructor from a LSSolverFactory
-      * \tparam SolverFactory Any class deriving from LSSolverFactory.
-      * \param solverFactory A configuration for the solver to be used by the resolution scheme.
-      * \param schemeOptions Options for the schemes. See tvm::Scheme::WeightedLeastSquaresOptions. 
-      */
-    template<class SolverFactory, 
-      typename std::enable_if<isFactory<SolverFactory>::value, int>::type = 0>
-      WeightedLeastSquares(const SolverFactory& solverFactory, WeightedLeastSquaresOptions schemeOptions = {})
-      : LinearResolutionScheme<WeightedLeastSquares>(abilities_)
-      , options_(schemeOptions)
-      , solverFactory_(solverFactory.clone())
-    {
-    }
-
-    /** Constructor from a configuration class
-      * \tparam SolverOptions Any class representing solver options. The class must have a
-      *    member type \a Factory refering to a class C deriving from LSSolverFactory
-      *    and such that C can be constructed from SolverOptions.
-      * \param solverOptions A set of options for the solver to be used by the resolution scheme.
-      * \\param schemeOptions Options for the scheme. See tvm::Scheme::WeightedLeastSquaresOptions.
-      */
-    template<class SolverOptions,
-      typename std::enable_if<isOption<SolverOptions>::value, int>::type = 0>
-    WeightedLeastSquares(const SolverOptions& solverOptions, WeightedLeastSquaresOptions schemeOptions = {})
-      :WeightedLeastSquares(typename SolverOptions::Factory(solverOptions), schemeOptions)
-    {
-    }
-
-    /** A fallback constructor that is enabled when none of the others are. 
-      * It always fails at compilation time to provide a nice error message.
-      */
-    template<typename T, 
-      typename std::enable_if<!isFactory<T>::value && !isOption<T>::value, int>::type = 0>
-    WeightedLeastSquares(const T&, WeightedLeastSquaresOptions = {})
-      : LinearResolutionScheme<WeightedLeastSquares>(abilities_)
-    {
-      static_assert(tvm::internal::always_false<T>::value, 
-        "First argument can only be a LSSolverFactory or a solver configuration. "
-        "A configuration needs to have a Factory member type that is itself deriving from LSSolverFactory. "
-        "See LSSOLLSSolverOptions for an example.");
-    }
-
-    /** \internal Copy and move are deleted because of the unique_ptr members of
-      * the class on polymorphic types. If these semantics are needed, it should
-      * be possible to implement them with good care.
-      */
-    WeightedLeastSquares(const WeightedLeastSquares&) = delete;
-    WeightedLeastSquares(WeightedLeastSquares&&) = delete;
-    WeightedLeastSquares& operator=(const WeightedLeastSquares&) = delete;
-    WeightedLeastSquares& operator=(WeightedLeastSquares&&) = delete;
-
-    /** Private interface for CRTP*/
-    bool solve_(LinearizedControlProblem& problem, internal::ProblemComputationData* data) const;
-    void updateComputationData_(LinearizedControlProblem& problem, internal::ProblemComputationData* data) const;
-    std::unique_ptr<Memory> createComputationData_(const LinearizedControlProblem& problem) const;
+    int maxp;
 
   protected:
-    void addTask(LinearizedControlProblem& problem, Memory* memory, TaskWithRequirements* task, solver::internal::SolverEvents& se) const;
-    void removeTask(LinearizedControlProblem& problem, Memory* memory, TaskWithRequirements* task, solver::internal::SolverEvents& se) const;
-
-    WeightedLeastSquaresOptions options_;
-    /** The factory to create solvers attached to each problem. */
-    std::unique_ptr<solver::abstract::LSSolverFactory> solverFactory_;
+    void setVariablesToSolution_(VariableVector & x) override;
   };
 
-}  // namespace scheme
+  const static internal::SchemeAbilities abilities_;
 
-}  // namespace tvm
+  /** Check if T derives from LSSolverFactory. */
+  template<typename T>
+  using isFactory = std::is_base_of<solver::abstract::LSSolverFactory, T>;
+  /** Helper struct for isOption .*/
+  template<typename T, bool>
+  struct isOption_ : std::false_type
+  {
+  };
+  /** Helper struct specialization for isOption .*/
+  template<typename T>
+  struct isOption_<T, true>
+  {
+    static const bool value = isFactory<typename T::Factory>::value;
+  };
+  /** Check if T has a member T::Factory and if so if T::Factory derives from LSSolverFactory.*/
+  template<typename T>
+  using isOption = isOption_<T, tvm::internal::has_member_type_Factory<T>::value>;
+
+public:
+  using ComputationDataType = Memory;
+
+  /** Constructor from a LSSolverFactory
+   * \tparam SolverFactory Any class deriving from LSSolverFactory.
+   * \param solverFactory A configuration for the solver to be used by the resolution scheme.
+   * \param schemeOptions Options for the schemes. See tvm::Scheme::WeightedLeastSquaresOptions.
+   */
+  template<class SolverFactory, typename std::enable_if<isFactory<SolverFactory>::value, int>::type = 0>
+  WeightedLeastSquares(const SolverFactory & solverFactory, WeightedLeastSquaresOptions schemeOptions = {})
+  : LinearResolutionScheme<WeightedLeastSquares>(abilities_), options_(schemeOptions),
+    solverFactory_(solverFactory.clone())
+  {
+  }
+
+  /** Constructor from a configuration class
+   * \tparam SolverOptions Any class representing solver options. The class must have a
+   *    member type \a Factory refering to a class C deriving from LSSolverFactory
+   *    and such that C can be constructed from SolverOptions.
+   * \param solverOptions A set of options for the solver to be used by the resolution scheme.
+   * \\param schemeOptions Options for the scheme. See tvm::Scheme::WeightedLeastSquaresOptions.
+   */
+  template<class SolverOptions, typename std::enable_if<isOption<SolverOptions>::value, int>::type = 0>
+  WeightedLeastSquares(const SolverOptions & solverOptions, WeightedLeastSquaresOptions schemeOptions = {})
+  : WeightedLeastSquares(typename SolverOptions::Factory(solverOptions), schemeOptions)
+  {
+  }
+
+  /** A fallback constructor that is enabled when none of the others are.
+   * It always fails at compilation time to provide a nice error message.
+   */
+  template<typename T, typename std::enable_if<!isFactory<T>::value && !isOption<T>::value, int>::type = 0>
+  WeightedLeastSquares(const T &, WeightedLeastSquaresOptions = {})
+  : LinearResolutionScheme<WeightedLeastSquares>(abilities_)
+  {
+    static_assert(tvm::internal::always_false<T>::value,
+                  "First argument can only be a LSSolverFactory or a solver configuration. "
+                  "A configuration needs to have a Factory member type that is itself deriving from LSSolverFactory. "
+                  "See LSSOLLSSolverOptions for an example.");
+  }
+
+  /** \internal Copy and move are deleted because of the unique_ptr members of
+   * the class on polymorphic types. If these semantics are needed, it should
+   * be possible to implement them with good care.
+   */
+  WeightedLeastSquares(const WeightedLeastSquares &) = delete;
+  WeightedLeastSquares(WeightedLeastSquares &&) = delete;
+  WeightedLeastSquares & operator=(const WeightedLeastSquares &) = delete;
+  WeightedLeastSquares & operator=(WeightedLeastSquares &&) = delete;
+
+  /** Private interface for CRTP*/
+  bool solve_(LinearizedControlProblem & problem, internal::ProblemComputationData * data) const;
+  void updateComputationData_(LinearizedControlProblem & problem, internal::ProblemComputationData * data) const;
+  std::unique_ptr<Memory> createComputationData_(const LinearizedControlProblem & problem) const;
+
+protected:
+  void addTask(LinearizedControlProblem & problem,
+               Memory * memory,
+               TaskWithRequirements * task,
+               solver::internal::SolverEvents & se) const;
+  void removeTask(LinearizedControlProblem & problem,
+                  Memory * memory,
+                  TaskWithRequirements * task,
+                  solver::internal::SolverEvents & se) const;
+
+  WeightedLeastSquaresOptions options_;
+  /** The factory to create solvers attached to each problem. */
+  std::unique_ptr<solver::abstract::LSSolverFactory> solverFactory_;
+};
+
+} // namespace scheme
+
+} // namespace tvm

--- a/include/tvm/scheme/WeightedLeastSquares.h
+++ b/include/tvm/scheme/WeightedLeastSquares.h
@@ -54,8 +54,7 @@ private:
   /** Helper struct for isOption .*/
   template<typename T, bool>
   struct isOption_ : std::false_type
-  {
-  };
+  {};
   /** Helper struct specialization for isOption .*/
   template<typename T>
   struct isOption_<T, true>
@@ -78,8 +77,7 @@ public:
   WeightedLeastSquares(const SolverFactory & solverFactory, WeightedLeastSquaresOptions schemeOptions = {})
   : LinearResolutionScheme<WeightedLeastSquares>(abilities_), options_(schemeOptions),
     solverFactory_(solverFactory.clone())
-  {
-  }
+  {}
 
   /** Constructor from a configuration class
    * \tparam SolverOptions Any class representing solver options. The class must have a
@@ -91,8 +89,7 @@ public:
   template<class SolverOptions, typename std::enable_if<isOption<SolverOptions>::value, int>::type = 0>
   WeightedLeastSquares(const SolverOptions & solverOptions, WeightedLeastSquaresOptions schemeOptions = {})
   : WeightedLeastSquares(typename SolverOptions::Factory(solverOptions), schemeOptions)
-  {
-  }
+  {}
 
   /** A fallback constructor that is enabled when none of the others are.
    * It always fails at compilation time to provide a nice error message.

--- a/include/tvm/scheme/abstract/ResolutionScheme.h
+++ b/include/tvm/scheme/abstract/ResolutionScheme.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/abstract/ResolutionScheme.h
+++ b/include/tvm/scheme/abstract/ResolutionScheme.h
@@ -1,38 +1,38 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/VariableVector.h>
-#include <tvm/scheme/internal/SchemeAbilities.h>
 #include <tvm/scheme/internal/ProblemComputationData.h>
 #include <tvm/scheme/internal/ResolutionSchemeBase.h>
+#include <tvm/scheme/internal/SchemeAbilities.h>
 
 namespace tvm
 {
@@ -45,90 +45,88 @@ namespace scheme
 namespace abstract
 {
 
-  /** Resolution schemes may be defined only for a particular type of problems.
-    * We use CRTP for providing a common interface despite this, and
-    * performing some basic common operations.
-    *
-    * The Derived class must provide:
-    * - one or several void solve_(ProblemType&, ComputationData&)
-    *   methods (several if it handle differently several types of problems).
-    * - likewise, one or several createComputationData_(const ProblemType&)
-    *   methods returning a std::unique_ptr<ComputationDataType> where
-    *   ComputationDataType derives from ProblemComputationData.
-    *
-    * For a given problem, the solve_ methods is guaranteed to receive the
-    * ComputationData instance created by createComputationData_ for the same
-    * problem.
-    */
-  template<typename Derived>
-  class ResolutionScheme : public internal::ResolutionSchemeBase
-  {
-  public:
-    template<typename Problem>
-    bool solve(Problem& problem) const;
-
-    template<typename Problem>
-    std::unique_ptr<internal::ProblemComputationData> createComputationData(const Problem& problem) const;
-
-    /** Returns a reference to the derived object */
-    Derived& derived() { return *static_cast<Derived*>(this); }
-    /** Returns a const reference to the derived object */
-    const Derived& derived() const { return *static_cast<const Derived*>(this); }
-
-  protected:
-    ResolutionScheme(internal::SchemeAbilities abilities, double big = constant::big_number);
-  };
-
-
-  /** Base class for scheme solving linear problems
-    * For now, it is there only for allowing to differentiate with future
-    * non-linear schemes.
-    */
-  template<typename Derived>
-  class LinearResolutionScheme : public ResolutionScheme<Derived>
-  {
-  protected:
-    LinearResolutionScheme(internal::SchemeAbilities abilities, double big = constant::big_number);
-  };
-
-
-
-  template<typename Derived>
+/** Resolution schemes may be defined only for a particular type of problems.
+ * We use CRTP for providing a common interface despite this, and
+ * performing some basic common operations.
+ *
+ * The Derived class must provide:
+ * - one or several void solve_(ProblemType&, ComputationData&)
+ *   methods (several if it handle differently several types of problems).
+ * - likewise, one or several createComputationData_(const ProblemType&)
+ *   methods returning a std::unique_ptr<ComputationDataType> where
+ *   ComputationDataType derives from ProblemComputationData.
+ *
+ * For a given problem, the solve_ methods is guaranteed to receive the
+ * ComputationData instance created by createComputationData_ for the same
+ * problem.
+ */
+template<typename Derived>
+class ResolutionScheme : public internal::ResolutionSchemeBase
+{
+public:
   template<typename Problem>
-  inline bool ResolutionScheme<Derived>::solve(Problem& problem) const
-  {
-    auto data = getComputationData(problem, *this);
-    problem.update();
-    derived().updateComputationData_(problem, data);
-    bool b = derived().solve_(problem, data);
-    data->setVariablesToSolution();
-    problem.substitutions().updateVariableValues();
-    return b;
-  }
+  bool solve(Problem & problem) const;
 
-  template<typename Derived>
   template<typename Problem>
-  inline std::unique_ptr<internal::ProblemComputationData> ResolutionScheme<Derived>::createComputationData(const Problem& problem) const
-  {
-    return derived().createComputationData_(problem);
-  }
+  std::unique_ptr<internal::ProblemComputationData> createComputationData(const Problem & problem) const;
 
-  template<typename Derived>
-  inline ResolutionScheme<Derived>::ResolutionScheme(internal::SchemeAbilities abilities, double big)
-    :ResolutionSchemeBase(abilities, big)
-  {
-  }
+  /** Returns a reference to the derived object */
+  Derived & derived() { return *static_cast<Derived *>(this); }
+  /** Returns a const reference to the derived object */
+  const Derived & derived() const { return *static_cast<const Derived *>(this); }
 
-  template<typename Derived>
-  inline LinearResolutionScheme<Derived>::LinearResolutionScheme(internal::SchemeAbilities abilities, double big)
-    : ResolutionScheme<Derived>(abilities, big)
-  {
-  }
+protected:
+  ResolutionScheme(internal::SchemeAbilities abilities, double big = constant::big_number);
+};
 
-}  // namespace abstract
+/** Base class for scheme solving linear problems
+ * For now, it is there only for allowing to differentiate with future
+ * non-linear schemes.
+ */
+template<typename Derived>
+class LinearResolutionScheme : public ResolutionScheme<Derived>
+{
+protected:
+  LinearResolutionScheme(internal::SchemeAbilities abilities, double big = constant::big_number);
+};
 
-}  // namespace scheme
+template<typename Derived>
+template<typename Problem>
+inline bool ResolutionScheme<Derived>::solve(Problem & problem) const
+{
+  auto data = getComputationData(problem, *this);
+  problem.update();
+  derived().updateComputationData_(problem, data);
+  bool b = derived().solve_(problem, data);
+  data->setVariablesToSolution();
+  problem.substitutions().updateVariableValues();
+  return b;
+}
 
-}  // namespace tvm
+template<typename Derived>
+template<typename Problem>
+inline std::unique_ptr<internal::ProblemComputationData> ResolutionScheme<Derived>::createComputationData(
+    const Problem & problem) const
+{
+  return derived().createComputationData_(problem);
+}
+
+template<typename Derived>
+inline ResolutionScheme<Derived>::ResolutionScheme(internal::SchemeAbilities abilities, double big)
+: ResolutionSchemeBase(abilities, big)
+{
+}
+
+template<typename Derived>
+inline LinearResolutionScheme<Derived>::LinearResolutionScheme(internal::SchemeAbilities abilities, double big)
+: ResolutionScheme<Derived>(abilities, big)
+{
+}
+
+} // namespace abstract
+
+} // namespace scheme
+
+} // namespace tvm
 
 #include <tvm/scheme/internal/helpers.hpp>

--- a/include/tvm/scheme/abstract/ResolutionScheme.h
+++ b/include/tvm/scheme/abstract/ResolutionScheme.h
@@ -87,14 +87,12 @@ inline std::unique_ptr<internal::ProblemComputationData> ResolutionScheme<Derive
 template<typename Derived>
 inline ResolutionScheme<Derived>::ResolutionScheme(internal::SchemeAbilities abilities, double big)
 : ResolutionSchemeBase(abilities, big)
-{
-}
+{}
 
 template<typename Derived>
 inline LinearResolutionScheme<Derived>::LinearResolutionScheme(internal::SchemeAbilities abilities, double big)
 : ResolutionScheme<Derived>(abilities, big)
-{
-}
+{}
 
 } // namespace abstract
 

--- a/include/tvm/scheme/internal/Assignment.h
+++ b/include/tvm/scheme/internal/Assignment.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <tvm/api.h>
-#include <tvm/defs.h>
 #include <tvm/Variable.h> // Range
+#include <tvm/api.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
+#include <tvm/defs.h>
 #include <tvm/hint/internal/Substitutions.h>
 #include <tvm/requirements/SolvingRequirements.h>
 #include <tvm/scheme/internal/AssignmentTarget.h>
@@ -21,268 +21,290 @@
 namespace tvm::scheme::internal
 {
 
-  /** A class whose role is to assign efficiently the matrix and vector(s) of a
-    * LinearConstraint to a part of matrix and vector(s) specified by a
-    * ResolutionScheme and a mapping of variables. This is done while taking
-    * into account the possible convention differences between the constraint
-    * and the scheme, as well as the requirements on the constraint.
-    */
-  class TVM_DLLAPI Assignment
+/** A class whose role is to assign efficiently the matrix and vector(s) of a
+ * LinearConstraint to a part of matrix and vector(s) specified by a
+ * ResolutionScheme and a mapping of variables. This is done while taking
+ * into account the possible convention differences between the constraint
+ * and the scheme, as well as the requirements on the constraint.
+ */
+class TVM_DLLAPI Assignment
+{
+public:
+  /** Pointer type to a method of LinearConstraint returning a vector.
+   * It is used to make a selection between e(), l() and u().
+   */
+  using RHSFunction = const Eigen::VectorXd & (constraint::abstract::LinearConstraint::*)() const;
+
+  /** Pointer type to a method of AssignmentTarget returning a matrix block.
+   * It is used to make a selection between A(), AFirstHalf() and ASecondHalf().
+   */
+  using MatrixFunction = MatrixRef (AssignmentTarget::*)(int, int) const;
+
+  /** Pointer type to a method of AssignementTarget returning a vector segment.
+   * It is used to make a selection between b(), bFirstHalf(), bSecondHalf(),
+   * l() and u().
+   */
+  using VectorFunction = VectorRef (AssignmentTarget::*)() const;
+
+  /** \private Dummy struct serving as reminder*/
+  struct IWontForgetToCallUpdates
   {
-  public:
-    /** Pointer type to a method of LinearConstraint returning a vector.
-      * It is used to make a selection between e(), l() and u().
-      */
-    using RHSFunction = const Eigen::VectorXd& (constraint::abstract::LinearConstraint::*)() const;
-   
-    /** Pointer type to a method of AssignmentTarget returning a matrix block.
-      * It is used to make a selection between A(), AFirstHalf() and ASecondHalf().
-      */
-    using MatrixFunction = MatrixRef(AssignmentTarget::*)(int, int) const;
-
-    /** Pointer type to a method of AssignementTarget returning a vector segment.
-      * It is used to make a selection between b(), bFirstHalf(), bSecondHalf(),
-      * l() and u().
-      */
-    using VectorFunction = VectorRef(AssignmentTarget::*)() const;
-
-
-    /** \private Dummy struct serving as reminder*/
-    struct IWontForgetToCallUpdates {};
-
-    /** Assignment constructor
-      * \param source The linear constraints whose matrix and vector(s) will be
-      * assigned.
-      * \param req Solving requirements attached to this constraint.
-      * \param target The target of the assignment.
-      * \param variables The vector of variables corresponding to the target.
-      * It must be such that its total dimension is equal to the column size of
-      * the target matrix.
-      * \param scalarizationWeight An additional scalar weight to apply on the
-      * constraint, used by the solver to emulate priority.
-      */
-    Assignment(LinearConstraintPtr source, 
-               SolvingRequirementsPtr req,
-               const AssignmentTarget& target, 
-               const VariableVector& variables, 
-               const hint::internal::Substitutions* const subs = nullptr,
-               double scalarizationWeight = 1);
-
-    /** Version for bounds
-      * \param first wether this is the first assignement of bounds for this
-      * variable (first assignment just copy vectors while the following ones
-      * need to perform min/max operations).
-      */
-    Assignment(LinearConstraintPtr source, const AssignmentTarget& target, const VariablePtr& variables, bool first);
-
-    Assignment(const Assignment&) = delete;
-    Assignment(Assignment&&) = default;
-    Assignment& operator= (const Assignment&) = delete;
-    Assignment& operator= (Assignment&&) = default;
-
-    static Assignment reprocess(const Assignment&, const VariableVector&, const hint::internal::Substitutions* const);
-    static Assignment reprocess(const Assignment&, const VariablePtr&, bool);
-
-    AssignmentTarget& target(IWontForgetToCallUpdates = {});
-    /** Change the weight.*/
-    bool changeScalarWeightIsAllowed();
-    bool changeVectorWeightIsAllowed();
-
-    /** To be called when the source has been resized*/
-    void onUpdatedSource();
-    /** To be called when the target has been resized and/or range has changed*/
-    void onUpdatedTarget();
-    /** To be called when the variables change.*/
-    void onUpdatedMapping(const VariableVector& newVar, bool updateMatrixtarget = true);
-    /** To be called after changing the weights.*/
-    void onUpdateWeights(bool scalar=true, bool vector=true);
-
-    /** Perform the assignment.*/
-    void run();
-
-    static double big_;
-
-  private:
-    /** Check that the convention and size of the target are compatible with the
-      * convention and size of the source.
-      */
-    void checkTarget();
-
-    void checkBounds();
-
-    /** Generates the assignments for the general case.
-      * \param variables the set of variables for the problem.
-      */
-    void build(const VariableVector& variables);
-    
-    /** Generates the assignments for the bound case.
-      * \param variables the set of variables for the problem.
-      * \param first true if this is the first assignment for the bounds (first
-      * assignment makes copy, the following perform min/max
-      */
-    void build(const VariablePtr& variable, bool first);
-    
-    /** Build internal data from the requirements*/
-    void processRequirements();
-    
-    /** Creates a matrix assigment from the jacobian of \p source_ corresponding
-      * to variable \p x to the block of matrix described by \p M and \p range.
-      * \p flip indicates a sign change if \p true.
-      */
-    void addMatrixAssignment(Variable& x, MatrixFunction M, const Range& range, bool flip);
-    
-    /** Creates the assignements due to susbtituing the variable \p x by the
-      * linear expression given by \p sub. The target is given by \p M.
-      * \p flip indicates a sign change if \p true.
-      */
-    void addMatrixSubstitutionAssignments(const VariableVector& variables, Variable& x, MatrixFunction M, 
-                                          const function::BasicLinearFunction& sub, bool flip);
-    
-    /** Creates and assigment between the vector given by \p f and the one given
-      * by \p v, taking care of the RHS conventions for the source and the
-      * target. The assignement type is given by the template parameter \p A.
-      * \p flip indicates a sign change if \p true.
-      */
-    template<AssignType A = AssignType::COPY, typename From, typename To>
-    void addVectorAssignment(const From& f, To v, bool flip, bool useFRHS = true, bool useTRHS = true);
-
-    /** Creates and assigment between the vector given by \p f and the one given
-    * by \p v, taking care of the RHS conventions for the source and the
-    * target. The source is premultiplied by the inverse of the diagonal matrix
-    * \p D. The assignement type is given by the template parameter \p A.
-    * \p flip indicates a sign change if \p true.
-    */
-    template<AssignType A = AssignType::COPY, typename From, typename To>
-    void addVectorAssignment(const From& f, To v, const MatrixConstRef& D, bool flip,
-                             bool useFRHS = true, bool useTRHS = true);
-    
-    /** Creates the assignements due to the substitution of variable \p x by the
-      * linear expression \p sub. The target is given by \p v.
-      */
-    void addVectorSubstitutionAssignments(const function::BasicLinearFunction& sub, 
-                                          VectorFunction v, Variable& x, bool flip);
-    
-    /** Create a vector assignement where the source is a constant. The target
-      * is given by \p v and the type of assignement by \p A.
-      */
-    template<AssignType A = AssignType::COPY, typename To>
-    void addVectorAssignment(double d, To v, bool flip = false,
-                             bool useFRHS = true, bool useTRHS = true);
-
-    /** Create a vector assignement where the source is a constant that is
-      * premultiplied by the inverse of a diagonal matrix \p D.
-      * The target is given by \p v and the type of assignement by \p A.
-      */
-    template<AssignType A = AssignType::COPY, typename To>
-    void addVectorAssignment(double d, To v, const MatrixConstRef& D, bool flip = false,
-                             bool useFRHS = true, bool useTRHS = true);
-    
-    /** Creates an assignement setting to zero the matrix block given by \p M
-      * and \p range. The variable \p x is simply stored in the corresponding
-      * \p MatrixAssignment.
-      */
-    void addZeroAssignment(Variable& x, MatrixFunction M, const Range& range);
-    
-    /** Calls addAssignments(const VariableVector& variables, MatrixFunction M,
-      * RHSFunction f1, VectorFunction v1, RHSFunction f2, VectorFunction v2, 
-      * bool flip) for a single-sided case.
-      */
-    void addAssignments(const VariableVector& variables, MatrixFunction M,
-                        RHSFunction f, VectorFunction v, bool flip);
-
-    /** Calls addAssignments(const VariableVector& variables, MatrixFunction M,
-      * RHSFunction f1, VectorFunction v1, RHSFunction f2, VectorFunction v2, 
-      * bool flip) for a double-sided case.
-      */
-    void addAssignments(const VariableVector& variables, MatrixFunction M,
-                        RHSFunction f1, VectorFunction v1, 
-                        RHSFunction f2, VectorFunction v2);
-
-    /** Creates all the matrix assignements between the source and the target,
-      * as well as the vector assignements described by \p f1 and \p v1 and
-      * optionnally by \p f2 and \p v2 if those are not \p nullptr.
-      * This method is called after the constraint::Type conventions of the
-      * source and the target have been processed (resulting in the choice of
-      * \p M, \p f1, \p v1, \p f2, \p v2 and \p flip). It handles internally the
-      * substitutions.
-      */
-    void addAssignments(const VariableVector& variables, MatrixFunction M,
-                        RHSFunction f1, VectorFunction v1, 
-                        RHSFunction f2, VectorFunction v2, bool flip);
-
-    void addBound(const VariablePtr& variable, RHSFunction f, bool first);
-
-    template<typename L, typename U>
-    void addBounds(const VariablePtr& variable, L l, U u, bool first);
-
-    template<typename L, typename U, typename TL, typename TU>
-    void addBounds(const VariablePtr& variable, L l, U u, TL tl, TU tu, bool first);
-
-    /** Create the compiled assignment between \p from and \p to, taking into
-      * account the requirements and the possible sign flip indicated by 
-      * \p flip.
-      */
-    template<typename T, AssignType A, typename U>
-    CompiledAssignmentWrapper<T> createAssignment(const U& from, const Eigen::Ref<T>& to, bool flip = false);
-
-    /** Create the compiled substitution assignement to = Mult * from (vector 
-      * case) or to = from * mult (matrix case) taking into account the 
-      * requirements and \p flip
-      */
-    template<typename T, AssignType A, MatrixMult M = GENERAL, typename U, typename V>
-    CompiledAssignmentWrapper<T> createMultiplicationAssignment(const U& from, const Eigen::Ref<T>& to, const V& Mult, bool flip = false);
-
-    /** The source of the assignment.*/
-    LinearConstraintPtr source_;
-    /** The target of the assignment.*/
-    AssignmentTarget target_;
-    /** The weight used to emulate hierarchy in a weight scheme.*/
-    double scalarizationWeight_;
-    /** The requirements attached to the source.*/
-    SolvingRequirementsPtr requirements_;
-    /** Indicates if the requirements use a default weight AND the scalarizationWeight is 1.*/
-    bool useDefaultScalarWeight_;
-    /** Indicates if the requirements use a defautl anisotropic weight.*/
-    bool useDefaultAnisotropicWeight_;
-    /** All the assignements that are setting the initial values of the targeted blocks*/
-    std::vector<MatrixAssignment> matrixAssignments_;
-    /** All assignments due to substitutions. We separe them from matrixAssignments_
-      * because these assignements add to existing values, and we need to be sure
-      * that the assignements in matrixAssignments_ have been carried out before.
-      */
-    std::vector<MatrixAssignment> matrixSubstitutionAssignments_;
-    /** All the initial rhs assignments*/
-    std::vector<VectorAssignment> vectorAssignments_;
-    /** The additional rhs assignments due to substitutions. As for matrix
-      * assignments, they need to be carried out after those of vectorAssignments_.
-      */
-    std::vector<VectorSubstitutionAssignement> vectorSubstitutionAssignments_;
-
-    /** Data for substitutions */
-    VariableVector substitutedVariables_;
-    std::vector<std::shared_ptr<function::BasicLinearFunction>> variableSubstitutions_;
-
-    /** Helper structure grouping data whose adress should remain constant through
-      * a move
-      */
-    struct ReferenceableData
-    {
-      /** Processed requirements*/
-      double scalarWeight_ = 1;
-      double minusScalarWeight_  = -1;
-      Eigen::VectorXd anisotropicWeight_;
-      Eigen::VectorXd minusAnisotropicWeight_;
-
-      /** Temporary vectors for bound assignements*/
-      Eigen::VectorXd tmp1_;
-      Eigen::VectorXd tmp2_;
-      Eigen::VectorXd tmp3_;
-      Eigen::VectorXd tmp4_;
-    };
-
-    std::unique_ptr<ReferenceableData> data_;
   };
 
-}
+  /** Assignment constructor
+   * \param source The linear constraints whose matrix and vector(s) will be
+   * assigned.
+   * \param req Solving requirements attached to this constraint.
+   * \param target The target of the assignment.
+   * \param variables The vector of variables corresponding to the target.
+   * It must be such that its total dimension is equal to the column size of
+   * the target matrix.
+   * \param scalarizationWeight An additional scalar weight to apply on the
+   * constraint, used by the solver to emulate priority.
+   */
+  Assignment(LinearConstraintPtr source,
+             SolvingRequirementsPtr req,
+             const AssignmentTarget & target,
+             const VariableVector & variables,
+             const hint::internal::Substitutions * const subs = nullptr,
+             double scalarizationWeight = 1);
+
+  /** Version for bounds
+   * \param first wether this is the first assignement of bounds for this
+   * variable (first assignment just copy vectors while the following ones
+   * need to perform min/max operations).
+   */
+  Assignment(LinearConstraintPtr source, const AssignmentTarget & target, const VariablePtr & variables, bool first);
+
+  Assignment(const Assignment &) = delete;
+  Assignment(Assignment &&) = default;
+  Assignment & operator=(const Assignment &) = delete;
+  Assignment & operator=(Assignment &&) = default;
+
+  static Assignment reprocess(const Assignment &, const VariableVector &, const hint::internal::Substitutions * const);
+  static Assignment reprocess(const Assignment &, const VariablePtr &, bool);
+
+  AssignmentTarget & target(IWontForgetToCallUpdates = {});
+  /** Change the weight.*/
+  bool changeScalarWeightIsAllowed();
+  bool changeVectorWeightIsAllowed();
+
+  /** To be called when the source has been resized*/
+  void onUpdatedSource();
+  /** To be called when the target has been resized and/or range has changed*/
+  void onUpdatedTarget();
+  /** To be called when the variables change.*/
+  void onUpdatedMapping(const VariableVector & newVar, bool updateMatrixtarget = true);
+  /** To be called after changing the weights.*/
+  void onUpdateWeights(bool scalar = true, bool vector = true);
+
+  /** Perform the assignment.*/
+  void run();
+
+  static double big_;
+
+private:
+  /** Check that the convention and size of the target are compatible with the
+   * convention and size of the source.
+   */
+  void checkTarget();
+
+  void checkBounds();
+
+  /** Generates the assignments for the general case.
+   * \param variables the set of variables for the problem.
+   */
+  void build(const VariableVector & variables);
+
+  /** Generates the assignments for the bound case.
+   * \param variables the set of variables for the problem.
+   * \param first true if this is the first assignment for the bounds (first
+   * assignment makes copy, the following perform min/max
+   */
+  void build(const VariablePtr & variable, bool first);
+
+  /** Build internal data from the requirements*/
+  void processRequirements();
+
+  /** Creates a matrix assigment from the jacobian of \p source_ corresponding
+   * to variable \p x to the block of matrix described by \p M and \p range.
+   * \p flip indicates a sign change if \p true.
+   */
+  void addMatrixAssignment(Variable & x, MatrixFunction M, const Range & range, bool flip);
+
+  /** Creates the assignements due to susbtituing the variable \p x by the
+   * linear expression given by \p sub. The target is given by \p M.
+   * \p flip indicates a sign change if \p true.
+   */
+  void addMatrixSubstitutionAssignments(const VariableVector & variables,
+                                        Variable & x,
+                                        MatrixFunction M,
+                                        const function::BasicLinearFunction & sub,
+                                        bool flip);
+
+  /** Creates and assigment between the vector given by \p f and the one given
+   * by \p v, taking care of the RHS conventions for the source and the
+   * target. The assignement type is given by the template parameter \p A.
+   * \p flip indicates a sign change if \p true.
+   */
+  template<AssignType A = AssignType::COPY, typename From, typename To>
+  void addVectorAssignment(const From & f, To v, bool flip, bool useFRHS = true, bool useTRHS = true);
+
+  /** Creates and assigment between the vector given by \p f and the one given
+   * by \p v, taking care of the RHS conventions for the source and the
+   * target. The source is premultiplied by the inverse of the diagonal matrix
+   * \p D. The assignement type is given by the template parameter \p A.
+   * \p flip indicates a sign change if \p true.
+   */
+  template<AssignType A = AssignType::COPY, typename From, typename To>
+  void addVectorAssignment(const From & f,
+                           To v,
+                           const MatrixConstRef & D,
+                           bool flip,
+                           bool useFRHS = true,
+                           bool useTRHS = true);
+
+  /** Creates the assignements due to the substitution of variable \p x by the
+   * linear expression \p sub. The target is given by \p v.
+   */
+  void addVectorSubstitutionAssignments(const function::BasicLinearFunction & sub,
+                                        VectorFunction v,
+                                        Variable & x,
+                                        bool flip);
+
+  /** Create a vector assignement where the source is a constant. The target
+   * is given by \p v and the type of assignement by \p A.
+   */
+  template<AssignType A = AssignType::COPY, typename To>
+  void addVectorAssignment(double d, To v, bool flip = false, bool useFRHS = true, bool useTRHS = true);
+
+  /** Create a vector assignement where the source is a constant that is
+   * premultiplied by the inverse of a diagonal matrix \p D.
+   * The target is given by \p v and the type of assignement by \p A.
+   */
+  template<AssignType A = AssignType::COPY, typename To>
+  void addVectorAssignment(double d,
+                           To v,
+                           const MatrixConstRef & D,
+                           bool flip = false,
+                           bool useFRHS = true,
+                           bool useTRHS = true);
+
+  /** Creates an assignement setting to zero the matrix block given by \p M
+   * and \p range. The variable \p x is simply stored in the corresponding
+   * \p MatrixAssignment.
+   */
+  void addZeroAssignment(Variable & x, MatrixFunction M, const Range & range);
+
+  /** Calls addAssignments(const VariableVector& variables, MatrixFunction M,
+   * RHSFunction f1, VectorFunction v1, RHSFunction f2, VectorFunction v2,
+   * bool flip) for a single-sided case.
+   */
+  void addAssignments(const VariableVector & variables, MatrixFunction M, RHSFunction f, VectorFunction v, bool flip);
+
+  /** Calls addAssignments(const VariableVector& variables, MatrixFunction M,
+   * RHSFunction f1, VectorFunction v1, RHSFunction f2, VectorFunction v2,
+   * bool flip) for a double-sided case.
+   */
+  void addAssignments(const VariableVector & variables,
+                      MatrixFunction M,
+                      RHSFunction f1,
+                      VectorFunction v1,
+                      RHSFunction f2,
+                      VectorFunction v2);
+
+  /** Creates all the matrix assignements between the source and the target,
+   * as well as the vector assignements described by \p f1 and \p v1 and
+   * optionnally by \p f2 and \p v2 if those are not \p nullptr.
+   * This method is called after the constraint::Type conventions of the
+   * source and the target have been processed (resulting in the choice of
+   * \p M, \p f1, \p v1, \p f2, \p v2 and \p flip). It handles internally the
+   * substitutions.
+   */
+  void addAssignments(const VariableVector & variables,
+                      MatrixFunction M,
+                      RHSFunction f1,
+                      VectorFunction v1,
+                      RHSFunction f2,
+                      VectorFunction v2,
+                      bool flip);
+
+  void addBound(const VariablePtr & variable, RHSFunction f, bool first);
+
+  template<typename L, typename U>
+  void addBounds(const VariablePtr & variable, L l, U u, bool first);
+
+  template<typename L, typename U, typename TL, typename TU>
+  void addBounds(const VariablePtr & variable, L l, U u, TL tl, TU tu, bool first);
+
+  /** Create the compiled assignment between \p from and \p to, taking into
+   * account the requirements and the possible sign flip indicated by
+   * \p flip.
+   */
+  template<typename T, AssignType A, typename U>
+  CompiledAssignmentWrapper<T> createAssignment(const U & from, const Eigen::Ref<T> & to, bool flip = false);
+
+  /** Create the compiled substitution assignement to = Mult * from (vector
+   * case) or to = from * mult (matrix case) taking into account the
+   * requirements and \p flip
+   */
+  template<typename T, AssignType A, MatrixMult M = GENERAL, typename U, typename V>
+  CompiledAssignmentWrapper<T> createMultiplicationAssignment(const U & from,
+                                                              const Eigen::Ref<T> & to,
+                                                              const V & Mult,
+                                                              bool flip = false);
+
+  /** The source of the assignment.*/
+  LinearConstraintPtr source_;
+  /** The target of the assignment.*/
+  AssignmentTarget target_;
+  /** The weight used to emulate hierarchy in a weight scheme.*/
+  double scalarizationWeight_;
+  /** The requirements attached to the source.*/
+  SolvingRequirementsPtr requirements_;
+  /** Indicates if the requirements use a default weight AND the scalarizationWeight is 1.*/
+  bool useDefaultScalarWeight_;
+  /** Indicates if the requirements use a defautl anisotropic weight.*/
+  bool useDefaultAnisotropicWeight_;
+  /** All the assignements that are setting the initial values of the targeted blocks*/
+  std::vector<MatrixAssignment> matrixAssignments_;
+  /** All assignments due to substitutions. We separe them from matrixAssignments_
+   * because these assignements add to existing values, and we need to be sure
+   * that the assignements in matrixAssignments_ have been carried out before.
+   */
+  std::vector<MatrixAssignment> matrixSubstitutionAssignments_;
+  /** All the initial rhs assignments*/
+  std::vector<VectorAssignment> vectorAssignments_;
+  /** The additional rhs assignments due to substitutions. As for matrix
+   * assignments, they need to be carried out after those of vectorAssignments_.
+   */
+  std::vector<VectorSubstitutionAssignement> vectorSubstitutionAssignments_;
+
+  /** Data for substitutions */
+  VariableVector substitutedVariables_;
+  std::vector<std::shared_ptr<function::BasicLinearFunction>> variableSubstitutions_;
+
+  /** Helper structure grouping data whose adress should remain constant through
+   * a move
+   */
+  struct ReferenceableData
+  {
+    /** Processed requirements*/
+    double scalarWeight_ = 1;
+    double minusScalarWeight_ = -1;
+    Eigen::VectorXd anisotropicWeight_;
+    Eigen::VectorXd minusAnisotropicWeight_;
+
+    /** Temporary vectors for bound assignements*/
+    Eigen::VectorXd tmp1_;
+    Eigen::VectorXd tmp2_;
+    Eigen::VectorXd tmp3_;
+    Eigen::VectorXd tmp4_;
+  };
+
+  std::unique_ptr<ReferenceableData> data_;
+};
+
+} // namespace tvm::scheme::internal
 
 #include <tvm/scheme/internal/Assignment.hpp>

--- a/include/tvm/scheme/internal/Assignment.h
+++ b/include/tvm/scheme/internal/Assignment.h
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include <tvm/Variable.h> // Range
 #include <tvm/api.h>
-#include <tvm/constraint/abstract/LinearConstraint.h>
 #include <tvm/defs.h>
+
+#include <tvm/Variable.h> // Range
+#include <tvm/constraint/abstract/LinearConstraint.h>
 #include <tvm/hint/internal/Substitutions.h>
 #include <tvm/requirements/SolvingRequirements.h>
 #include <tvm/scheme/internal/AssignmentTarget.h>

--- a/include/tvm/scheme/internal/Assignment.h
+++ b/include/tvm/scheme/internal/Assignment.h
@@ -48,8 +48,7 @@ public:
 
   /** \private Dummy struct serving as reminder*/
   struct IWontForgetToCallUpdates
-  {
-  };
+  {};
 
   /** Assignment constructor
    * \param source The linear constraints whose matrix and vector(s) will be

--- a/include/tvm/scheme/internal/Assignment.hpp
+++ b/include/tvm/scheme/internal/Assignment.hpp
@@ -4,258 +4,259 @@
 
 namespace tvm::scheme::internal
 {
-  template<typename L, typename U>
-  inline void Assignment::addBounds(const VariablePtr& variable, L l, U u, bool first)
+template<typename L, typename U>
+inline void Assignment::addBounds(const VariablePtr & variable, L l, U u, bool first)
+{
+  const auto & J = source_->jacobian(*variable);
+  if(substitutedVariables_.contains(*variable))
   {
-    const auto& J = source_->jacobian(*variable);
-    if (substitutedVariables_.contains(*variable))
-    {
-      addBounds(variable, l, u, VectorRef(data_->tmp1_), VectorRef(data_->tmp2_), first);
-    }
-    else
-    {
-      addBounds(variable, l, u, &AssignmentTarget::l, &AssignmentTarget::u, first);
-    }
+    addBounds(variable, l, u, VectorRef(data_->tmp1_), VectorRef(data_->tmp2_), first);
   }
-
-  template<typename L, typename U, typename TL, typename TU>
-  inline void Assignment::addBounds(const VariablePtr& variable, L l, U u, TL tl, TU tu, bool first)
+  else
   {
-    const auto& J = source_->jacobian(*variable);
-    if (J.properties().isIdentity())
-    {
-      if (first)
-      {
-        addVectorAssignment(l, tl, false);
-        addVectorAssignment(u, tu, false);
-      }
-      else
-      {
-        addVectorAssignment<MAX>(l, tl, false);
-        addVectorAssignment<MIN>(u, tu, false);
-      }
-    }
-    else if (J.properties().isMinusIdentity())
-    {
-      if (first)
-      {
-        addVectorAssignment(l, tu, true);
-        addVectorAssignment(u, tl, true);
-      }
-      else
-      {
-        addVectorAssignment<MAX>(u, tl, true);
-        addVectorAssignment<MIN>(l, tu, true);
-      }
-    }
-    else
-    {
-      assert(J.properties().isDiagonal());
-      data_->tmp1_.resize(variable->size());
-      data_->tmp2_.resize(variable->size());
-      data_->tmp3_.resize(variable->size());
-      data_->tmp4_.resize(variable->size());
-      addVectorAssignment(l, VectorRef(data_->tmp1_), J, false, true, false);  // tmp1_ = inv(J)*l
-      addVectorAssignment(u, VectorRef(data_->tmp2_), J, false, true, false);  // tmp2_ = inv(J)*u
-      addVectorAssignment(VectorConstRef(data_->tmp1_), VectorRef(data_->tmp3_), false, false, false); // tmp3_ = inv(J)*l
-      addVectorAssignment(VectorConstRef(data_->tmp2_), VectorRef(data_->tmp4_), false, false, false); // tmp4_ = inv(J)*u
-      addVectorAssignment<MIN>(VectorConstRef(data_->tmp2_), VectorRef(data_->tmp3_), false, false, false); //tmp3_ = min(inv(J)*l, inv(J)*u)
-      addVectorAssignment<MAX>(VectorConstRef(data_->tmp1_), VectorRef(data_->tmp4_), false, false, false); //tmp4_ = max(inv(J)*l, inv(J)*u)
-      if (first)
-      {
-        addVectorAssignment(VectorConstRef(data_->tmp3_), tl, false, false, true);
-        addVectorAssignment(VectorConstRef(data_->tmp4_), tu, false, false, true);
-      }
-      else
-      {
-        addVectorAssignment<MAX>(VectorConstRef(data_->tmp3_), tl, false, false, true);
-        addVectorAssignment<MIN>(VectorConstRef(data_->tmp4_), tu, false, false, true);
-      }
-    }
-  }
-
-  template<typename T, AssignType A, typename U>
-  inline CompiledAssignmentWrapper<T> Assignment::createAssignment(const U& from, const Eigen::Ref<T>& to, bool flip)
-  {
-    using Wrapper = CompiledAssignmentWrapper<typename std::conditional<std::is_arithmetic<U>::value, Eigen::VectorXd, T>::type>;
-    const Source F = std::is_arithmetic<U>::value ? CONSTANT : EXTERNAL;
-
-    if (useDefaultAnisotropicWeight_)
-    {
-      if (useDefaultScalarWeight_)
-      {
-        if (flip)
-          return Wrapper::template make<A, MINUS, IDENTITY, F>(to, from);
-        else
-          return Wrapper::template make<A, NONE, IDENTITY, F>(to, from);
-      }
-      else
-      {
-        if (flip)
-          return Wrapper::template make<A, SCALAR, IDENTITY, F>(to, from, data_->minusScalarWeight_);
-        else
-          return Wrapper::template make<A, SCALAR, IDENTITY, F>(to, from, data_->scalarWeight_);
-      }
-    }
-    else
-    {
-      if (flip)
-        return Wrapper::template make<A, DIAGONAL, IDENTITY, F>(to, from, data_->minusAnisotropicWeight_);
-      else
-        return Wrapper::template make<A, DIAGONAL, IDENTITY, F>(to, from, data_->anisotropicWeight_);
-    }
-  }
-
-  template<typename T, AssignType A, MatrixMult M, typename U, typename V>
-  inline CompiledAssignmentWrapper<T> Assignment::createMultiplicationAssignment(const U& from, const Eigen::Ref<T>& to, const V& Mult, bool flip)
-  {
-    using Wrapper = CompiledAssignmentWrapper<typename std::conditional<std::is_arithmetic<U>::value, Eigen::VectorXd, T>::type>;
-    const Source F = std::is_arithmetic<U>::value ? CONSTANT : EXTERNAL;
-
-    if (useDefaultAnisotropicWeight_)
-    {
-      if (useDefaultScalarWeight_)
-      {
-        if (flip)
-          return Wrapper::template make<A, MINUS, M, F>(to, from, Mult);
-        else
-          return Wrapper::template make<A, NONE, M, F>(to, from, Mult);
-      }
-      else
-      {
-        if (flip)
-          return Wrapper::template make<A, SCALAR, M, F>(to, from, data_->minusScalarWeight_, Mult);
-        else
-          return Wrapper::template make<A, SCALAR, M, F>(to, from, data_->scalarWeight_, Mult);
-      }
-    }
-    else
-    {
-      if (flip)
-        return Wrapper::template make<A, DIAGONAL, M, F>(to, from, data_->minusAnisotropicWeight_, Mult);
-      else
-        return Wrapper::template make<A, DIAGONAL, M, F>(to, from, data_->anisotropicWeight_, Mult);
-    }
-  }
-
-  /** Helper function for addVectorAssignment returning the Eigen::Ref to the
-    * source vector, where the argument is the vector in question.
-    */
-  inline VectorConstRef retrieveSource(LinearConstraintPtr, const VectorConstRef& f)
-  {
-    return f;
-  }
-
-  /** Helper function for addVectorAssignment returning the Eigen::Ref to the
-    * source vector, where the argument is a method returning the vector.
-    */
-  inline VectorConstRef retrieveSource(LinearConstraintPtr s, const Assignment::RHSFunction& f)
-  {
-    return (s.get()->*f)();
-  }
-
-  /** Helper function for addVectorAssignment and addConstantAssignment
-    * returning the Eigen::Ref to the target vector, where the argument is the
-    * vector in question.
-    */
-  inline VectorRef retrieveTarget(AssignmentTarget&, VectorRef v)
-  {
-    return v;
-  }
-
-  /** Helper function for addVectorAssignment and addConstantAssignment
-    * returning the Eigen::Ref to the target vector, where the argument is a
-    * method returning the vector.
-    */
-  inline VectorRef retrieveTarget(AssignmentTarget& t, Assignment::VectorFunction v)
-  {
-    return (t.*v)();
-  }
-
-  /** Helper function for addVectorAssignment returning \p nullptr.*/
-  inline std::nullptr_t nullifyIfVecRef(const VectorConstRef&) { return nullptr; }
-  /** Helper function for addVectorAssignment returning \p nullptr.*/
-  inline std::nullptr_t nullifyIfVecRef(VectorRef) { return nullptr; }
-  /** Helper function for addVectorAssignment returning its argument.*/
-  inline Assignment::RHSFunction nullifyIfVecRef(Assignment::RHSFunction f) { return f; }
-  /** Helper function for addVectorAssignment returning its argument.*/
-  inline Assignment::VectorFunction nullifyIfVecRef(Assignment::VectorFunction v) { return v; }
-
-  template<AssignType A, typename From, typename To>
-  inline void Assignment::addVectorAssignment(const From& f, To v, bool flip, bool useFRHS, bool useTRHS)
-  {
-    bool useSource = source_->rhs() != constraint::RHS::ZERO
-      || std::is_same<From, VectorConstRef>::value;
-    if (useSource)
-    {
-      // So far, the sign flip has been deduced only from the ConstraintType of the source
-      // and the target. Now we need to take into account the constraint::RHS as well.
-      if (source_->rhs() == constraint::RHS::OPPOSITE && useFRHS)
-        flip = !flip;
-      if (target_.constraintRhs() == constraint::RHS::OPPOSITE && useTRHS)
-        flip = !flip;
-
-      const VectorRef& to = retrieveTarget(target_, v);
-      const auto& from = retrieveSource(source_, f);
-      auto w = createAssignment<Eigen::VectorXd, A>(from, to, flip);
-      bool b = nullifyIfVecRef(f);
-      vectorAssignments_.push_back({ w, b, nullifyIfVecRef(f), nullifyIfVecRef(v) });
-    }
-    else
-    {
-      if (target_.constraintRhs() != constraint::RHS::ZERO)
-      {
-        const VectorRef& to = retrieveTarget(target_, v);
-        auto w = CompiledAssignmentWrapper<Eigen::VectorXd>::make<A, NONE, IDENTITY, ZERO>(to);
-        vectorAssignments_.push_back({ w, false, nullptr, nullifyIfVecRef(v) });
-      }
-    }
-  }
-
-  template<AssignType A, typename From, typename To>
-  inline void Assignment::addVectorAssignment(const From& f, To v, const MatrixConstRef& D, bool flip, bool useFRHS, bool useTRHS)
-  {
-    bool useSource = source_->rhs() != constraint::RHS::ZERO
-      || std::is_same<From, VectorConstRef>::value;
-    if (useSource)
-    {
-      // So far, the sign flip has been deduced only from the ConstraintType of the source
-      // and the target. Now we need to take into account the constraint::RHS as well.
-      if (source_->rhs() == constraint::RHS::OPPOSITE && useFRHS)
-        flip = !flip;
-      if (target_.constraintRhs() == constraint::RHS::OPPOSITE && useTRHS)
-        flip = !flip;
-
-      const VectorRef& to = retrieveTarget(target_, v);
-      const auto& from = retrieveSource(source_, f);
-      auto w = createMultiplicationAssignment<Eigen::VectorXd, A, INVERSE_DIAGONAL>(from, to, D, flip);
-      bool b = nullifyIfVecRef(f);
-      vectorAssignments_.emplace_back(w, b, nullifyIfVecRef(f), nullifyIfVecRef(v));
-    }
-    else
-    {
-      if (target_.constraintRhs() != constraint::RHS::ZERO)
-      {
-        const VectorRef& to = retrieveTarget(target_, v);
-        auto w = CompiledAssignmentWrapper<Eigen::VectorXd>::make<A, NONE, IDENTITY, ZERO>(to);
-        vectorAssignments_.emplace_back(w, false, nullptr, nullifyIfVecRef(v));
-      }
-    }
-  }
-
-  template<AssignType A, typename To>
-  inline void Assignment::addVectorAssignment(double d, To v, bool flip, bool, bool)
-  {
-    const VectorRef& to = retrieveTarget(target_, v);
-    auto w = createAssignment<Eigen::VectorXd, A>(d, to, flip);
-    vectorAssignments_.emplace_back(w, false, nullptr, nullifyIfVecRef(v));
-  }
-
-  template<AssignType A, typename To>
-  inline void Assignment::addVectorAssignment(double d, To v, const MatrixConstRef& D, bool flip, bool, bool)
-  {
-    const VectorRef& to = retrieveTarget(target_, v);
-    auto w = createMultiplicationAssignment<Eigen::VectorXd, A>(d, to, D, flip);
-    vectorAssignments_.emplace_back(w, false, nullptr, nullifyIfVecRef(v));
+    addBounds(variable, l, u, &AssignmentTarget::l, &AssignmentTarget::u, first);
   }
 }
+
+template<typename L, typename U, typename TL, typename TU>
+inline void Assignment::addBounds(const VariablePtr & variable, L l, U u, TL tl, TU tu, bool first)
+{
+  const auto & J = source_->jacobian(*variable);
+  if(J.properties().isIdentity())
+  {
+    if(first)
+    {
+      addVectorAssignment(l, tl, false);
+      addVectorAssignment(u, tu, false);
+    }
+    else
+    {
+      addVectorAssignment<MAX>(l, tl, false);
+      addVectorAssignment<MIN>(u, tu, false);
+    }
+  }
+  else if(J.properties().isMinusIdentity())
+  {
+    if(first)
+    {
+      addVectorAssignment(l, tu, true);
+      addVectorAssignment(u, tl, true);
+    }
+    else
+    {
+      addVectorAssignment<MAX>(u, tl, true);
+      addVectorAssignment<MIN>(l, tu, true);
+    }
+  }
+  else
+  {
+    assert(J.properties().isDiagonal());
+    data_->tmp1_.resize(variable->size());
+    data_->tmp2_.resize(variable->size());
+    data_->tmp3_.resize(variable->size());
+    data_->tmp4_.resize(variable->size());
+    addVectorAssignment(l, VectorRef(data_->tmp1_), J, false, true, false); // tmp1_ = inv(J)*l
+    addVectorAssignment(u, VectorRef(data_->tmp2_), J, false, true, false); // tmp2_ = inv(J)*u
+    addVectorAssignment(VectorConstRef(data_->tmp1_), VectorRef(data_->tmp3_), false, false, false); // tmp3_ = inv(J)*l
+    addVectorAssignment(VectorConstRef(data_->tmp2_), VectorRef(data_->tmp4_), false, false, false); // tmp4_ = inv(J)*u
+    addVectorAssignment<MIN>(VectorConstRef(data_->tmp2_), VectorRef(data_->tmp3_), false, false,
+                             false); // tmp3_ = min(inv(J)*l, inv(J)*u)
+    addVectorAssignment<MAX>(VectorConstRef(data_->tmp1_), VectorRef(data_->tmp4_), false, false,
+                             false); // tmp4_ = max(inv(J)*l, inv(J)*u)
+    if(first)
+    {
+      addVectorAssignment(VectorConstRef(data_->tmp3_), tl, false, false, true);
+      addVectorAssignment(VectorConstRef(data_->tmp4_), tu, false, false, true);
+    }
+    else
+    {
+      addVectorAssignment<MAX>(VectorConstRef(data_->tmp3_), tl, false, false, true);
+      addVectorAssignment<MIN>(VectorConstRef(data_->tmp4_), tu, false, false, true);
+    }
+  }
+}
+
+template<typename T, AssignType A, typename U>
+inline CompiledAssignmentWrapper<T> Assignment::createAssignment(const U & from, const Eigen::Ref<T> & to, bool flip)
+{
+  using Wrapper =
+      CompiledAssignmentWrapper<typename std::conditional<std::is_arithmetic<U>::value, Eigen::VectorXd, T>::type>;
+  const Source F = std::is_arithmetic<U>::value ? CONSTANT : EXTERNAL;
+
+  if(useDefaultAnisotropicWeight_)
+  {
+    if(useDefaultScalarWeight_)
+    {
+      if(flip)
+        return Wrapper::template make<A, MINUS, IDENTITY, F>(to, from);
+      else
+        return Wrapper::template make<A, NONE, IDENTITY, F>(to, from);
+    }
+    else
+    {
+      if(flip)
+        return Wrapper::template make<A, SCALAR, IDENTITY, F>(to, from, data_->minusScalarWeight_);
+      else
+        return Wrapper::template make<A, SCALAR, IDENTITY, F>(to, from, data_->scalarWeight_);
+    }
+  }
+  else
+  {
+    if(flip)
+      return Wrapper::template make<A, DIAGONAL, IDENTITY, F>(to, from, data_->minusAnisotropicWeight_);
+    else
+      return Wrapper::template make<A, DIAGONAL, IDENTITY, F>(to, from, data_->anisotropicWeight_);
+  }
+}
+
+template<typename T, AssignType A, MatrixMult M, typename U, typename V>
+inline CompiledAssignmentWrapper<T> Assignment::createMultiplicationAssignment(const U & from,
+                                                                               const Eigen::Ref<T> & to,
+                                                                               const V & Mult,
+                                                                               bool flip)
+{
+  using Wrapper =
+      CompiledAssignmentWrapper<typename std::conditional<std::is_arithmetic<U>::value, Eigen::VectorXd, T>::type>;
+  const Source F = std::is_arithmetic<U>::value ? CONSTANT : EXTERNAL;
+
+  if(useDefaultAnisotropicWeight_)
+  {
+    if(useDefaultScalarWeight_)
+    {
+      if(flip)
+        return Wrapper::template make<A, MINUS, M, F>(to, from, Mult);
+      else
+        return Wrapper::template make<A, NONE, M, F>(to, from, Mult);
+    }
+    else
+    {
+      if(flip)
+        return Wrapper::template make<A, SCALAR, M, F>(to, from, data_->minusScalarWeight_, Mult);
+      else
+        return Wrapper::template make<A, SCALAR, M, F>(to, from, data_->scalarWeight_, Mult);
+    }
+  }
+  else
+  {
+    if(flip)
+      return Wrapper::template make<A, DIAGONAL, M, F>(to, from, data_->minusAnisotropicWeight_, Mult);
+    else
+      return Wrapper::template make<A, DIAGONAL, M, F>(to, from, data_->anisotropicWeight_, Mult);
+  }
+}
+
+/** Helper function for addVectorAssignment returning the Eigen::Ref to the
+ * source vector, where the argument is the vector in question.
+ */
+inline VectorConstRef retrieveSource(LinearConstraintPtr, const VectorConstRef & f) { return f; }
+
+/** Helper function for addVectorAssignment returning the Eigen::Ref to the
+ * source vector, where the argument is a method returning the vector.
+ */
+inline VectorConstRef retrieveSource(LinearConstraintPtr s, const Assignment::RHSFunction & f)
+{
+  return (s.get()->*f)();
+}
+
+/** Helper function for addVectorAssignment and addConstantAssignment
+ * returning the Eigen::Ref to the target vector, where the argument is the
+ * vector in question.
+ */
+inline VectorRef retrieveTarget(AssignmentTarget &, VectorRef v) { return v; }
+
+/** Helper function for addVectorAssignment and addConstantAssignment
+ * returning the Eigen::Ref to the target vector, where the argument is a
+ * method returning the vector.
+ */
+inline VectorRef retrieveTarget(AssignmentTarget & t, Assignment::VectorFunction v) { return (t.*v)(); }
+
+/** Helper function for addVectorAssignment returning \p nullptr.*/
+inline std::nullptr_t nullifyIfVecRef(const VectorConstRef &) { return nullptr; }
+/** Helper function for addVectorAssignment returning \p nullptr.*/
+inline std::nullptr_t nullifyIfVecRef(VectorRef) { return nullptr; }
+/** Helper function for addVectorAssignment returning its argument.*/
+inline Assignment::RHSFunction nullifyIfVecRef(Assignment::RHSFunction f) { return f; }
+/** Helper function for addVectorAssignment returning its argument.*/
+inline Assignment::VectorFunction nullifyIfVecRef(Assignment::VectorFunction v) { return v; }
+
+template<AssignType A, typename From, typename To>
+inline void Assignment::addVectorAssignment(const From & f, To v, bool flip, bool useFRHS, bool useTRHS)
+{
+  bool useSource = source_->rhs() != constraint::RHS::ZERO || std::is_same<From, VectorConstRef>::value;
+  if(useSource)
+  {
+    // So far, the sign flip has been deduced only from the ConstraintType of the source
+    // and the target. Now we need to take into account the constraint::RHS as well.
+    if(source_->rhs() == constraint::RHS::OPPOSITE && useFRHS)
+      flip = !flip;
+    if(target_.constraintRhs() == constraint::RHS::OPPOSITE && useTRHS)
+      flip = !flip;
+
+    const VectorRef & to = retrieveTarget(target_, v);
+    const auto & from = retrieveSource(source_, f);
+    auto w = createAssignment<Eigen::VectorXd, A>(from, to, flip);
+    bool b = nullifyIfVecRef(f);
+    vectorAssignments_.push_back({w, b, nullifyIfVecRef(f), nullifyIfVecRef(v)});
+  }
+  else
+  {
+    if(target_.constraintRhs() != constraint::RHS::ZERO)
+    {
+      const VectorRef & to = retrieveTarget(target_, v);
+      auto w = CompiledAssignmentWrapper<Eigen::VectorXd>::make<A, NONE, IDENTITY, ZERO>(to);
+      vectorAssignments_.push_back({w, false, nullptr, nullifyIfVecRef(v)});
+    }
+  }
+}
+
+template<AssignType A, typename From, typename To>
+inline void Assignment::addVectorAssignment(const From & f,
+                                            To v,
+                                            const MatrixConstRef & D,
+                                            bool flip,
+                                            bool useFRHS,
+                                            bool useTRHS)
+{
+  bool useSource = source_->rhs() != constraint::RHS::ZERO || std::is_same<From, VectorConstRef>::value;
+  if(useSource)
+  {
+    // So far, the sign flip has been deduced only from the ConstraintType of the source
+    // and the target. Now we need to take into account the constraint::RHS as well.
+    if(source_->rhs() == constraint::RHS::OPPOSITE && useFRHS)
+      flip = !flip;
+    if(target_.constraintRhs() == constraint::RHS::OPPOSITE && useTRHS)
+      flip = !flip;
+
+    const VectorRef & to = retrieveTarget(target_, v);
+    const auto & from = retrieveSource(source_, f);
+    auto w = createMultiplicationAssignment<Eigen::VectorXd, A, INVERSE_DIAGONAL>(from, to, D, flip);
+    bool b = nullifyIfVecRef(f);
+    vectorAssignments_.emplace_back(w, b, nullifyIfVecRef(f), nullifyIfVecRef(v));
+  }
+  else
+  {
+    if(target_.constraintRhs() != constraint::RHS::ZERO)
+    {
+      const VectorRef & to = retrieveTarget(target_, v);
+      auto w = CompiledAssignmentWrapper<Eigen::VectorXd>::make<A, NONE, IDENTITY, ZERO>(to);
+      vectorAssignments_.emplace_back(w, false, nullptr, nullifyIfVecRef(v));
+    }
+  }
+}
+
+template<AssignType A, typename To>
+inline void Assignment::addVectorAssignment(double d, To v, bool flip, bool, bool)
+{
+  const VectorRef & to = retrieveTarget(target_, v);
+  auto w = createAssignment<Eigen::VectorXd, A>(d, to, flip);
+  vectorAssignments_.emplace_back(w, false, nullptr, nullifyIfVecRef(v));
+}
+
+template<AssignType A, typename To>
+inline void Assignment::addVectorAssignment(double d, To v, const MatrixConstRef & D, bool flip, bool, bool)
+{
+  const VectorRef & to = retrieveTarget(target_, v);
+  auto w = createMultiplicationAssignment<Eigen::VectorXd, A>(d, to, D, flip);
+  vectorAssignments_.emplace_back(w, false, nullptr, nullifyIfVecRef(v));
+}
+} // namespace tvm::scheme::internal

--- a/include/tvm/scheme/internal/Assignment.hpp
+++ b/include/tvm/scheme/internal/Assignment.hpp
@@ -55,8 +55,8 @@ inline void Assignment::addBounds(const VariablePtr & variable, L l, U u, TL tl,
     data_->tmp2_.resize(variable->size());
     data_->tmp3_.resize(variable->size());
     data_->tmp4_.resize(variable->size());
-    addVectorAssignment(l, VectorRef(data_->tmp1_), J, false, true, false); // tmp1_ = inv(J)*l
-    addVectorAssignment(u, VectorRef(data_->tmp2_), J, false, true, false); // tmp2_ = inv(J)*u
+    addVectorAssignment(l, VectorRef(data_->tmp1_), J, false, true, false);                          // tmp1_ = inv(J)*l
+    addVectorAssignment(u, VectorRef(data_->tmp2_), J, false, true, false);                          // tmp2_ = inv(J)*u
     addVectorAssignment(VectorConstRef(data_->tmp1_), VectorRef(data_->tmp3_), false, false, false); // tmp3_ = inv(J)*l
     addVectorAssignment(VectorConstRef(data_->tmp2_), VectorRef(data_->tmp4_), false, false, false); // tmp4_ = inv(J)*u
     addVectorAssignment<MIN>(VectorConstRef(data_->tmp2_), VectorRef(data_->tmp3_), false, false,

--- a/include/tvm/scheme/internal/AssignmentTarget.h
+++ b/include/tvm/scheme/internal/AssignmentTarget.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/constraint/enums.h>
 #include <tvm/defs.h>
+
+#include <tvm/constraint/enums.h>
 
 #include <Eigen/Core>
 

--- a/include/tvm/scheme/internal/AssignmentTarget.h
+++ b/include/tvm/scheme/internal/AssignmentTarget.h
@@ -1,37 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/defs.h>
 #include <tvm/constraint/enums.h>
+#include <tvm/defs.h>
 
 #include <Eigen/Core>
 
@@ -46,109 +46,108 @@ namespace scheme
 namespace internal
 {
 
-  enum class TargetType
-  {
-    Linear,
-    Quadratic
-  };
+enum class TargetType
+{
+  Linear,
+  Quadratic
+};
 
-  /** This class describes the matrix and vector(s) rows in which a given
-   * constraint needs to be copied, and the convention to be used for those
-   * matrix and vectors.
-   *
-   * If the target is quadratic form, the whole matrix and vector are
-   * returned.
+/** This class describes the matrix and vector(s) rows in which a given
+ * constraint needs to be copied, and the convention to be used for those
+ * matrix and vectors.
+ *
+ * If the target is quadratic form, the whole matrix and vector are
+ * returned.
+ */
+class TVM_DLLAPI AssignmentTarget
+{
+public:
+  /** Ax = 0, Ax <= 0 or Ax >= 0. */
+  AssignmentTarget(RangePtr range, MatrixRef A, constraint::Type ct);
+  /** Ax = +/-b, Ax <= +/-b or Ax >= +/-b */
+  AssignmentTarget(RangePtr range, MatrixRef A, VectorRef b, constraint::Type ct, constraint::RHS cr);
+
+  /** l <= Ax <= u */
+  AssignmentTarget(RangePtr range, MatrixRef A, VectorRef l, VectorRef u, constraint::RHS cr);
+
+  /** l <= x <= u */
+  AssignmentTarget(RangePtr range, VectorRef l, VectorRef u);
+
+  /** x >= b or x <= b*/
+  AssignmentTarget(RangePtr range, VectorRef lu, constraint::Type ct);
+
+  /** Quadratic function 1/2 x^T Q x +\epsilon q, where \epsilon = 0, 1 or -1 depending on cr.*/
+  AssignmentTarget(MatrixRef Q, VectorRef q, constraint::RHS cr);
+
+  TargetType targetType() const;
+  constraint::Type constraintType() const;
+  constraint::RHS constraintRhs() const;
+  /** Row size of the target.*/
+  int size() const;
+  Range & range();
+  const Range & range() const;
+
+  /** Return the (range.dim x colDim) block of A starting at
+   *(range.start,colStart) */
+  MatrixRef A(int colStart, int colDim) const;
+  /** Return the whole quadratic matrix*/
+  MatrixRef Q() const;
+  /** Return the segment of l defined by range. */
+  VectorRef l() const;
+  /** Return the segment of u defined by range. */
+  VectorRef u() const;
+  /** Return the segment of b defined by range. */
+  VectorRef b() const;
+  /** Return the whole vector q.*/
+  VectorRef q() const;
+
+  /** Same as A(...), and b(), but return only the first or second half of
+   * the row range. This is necessary when double-sided constraints are
+   * assigned to matrix/vector with single-sided convention
    */
-  class TVM_DLLAPI AssignmentTarget
-  {
-  public:
-    /** Ax = 0, Ax <= 0 or Ax >= 0. */
-    AssignmentTarget(RangePtr range, MatrixRef A, constraint::Type ct);
-    /** Ax = +/-b, Ax <= +/-b or Ax >= +/-b */
-    AssignmentTarget(RangePtr range, MatrixRef A, VectorRef b, constraint::Type ct, constraint::RHS cr);
+  /**@{*/
+  MatrixRef AFirstHalf(int colStart, int colDim) const;
+  MatrixRef ASecondHalf(int colStart, int colDim) const;
+  VectorRef bFirstHalf() const;
+  VectorRef bSecondHalf() const;
+  /**@}*/
 
-    /** l <= Ax <= u */
-    AssignmentTarget(RangePtr range, MatrixRef A, VectorRef l, VectorRef u, constraint::RHS cr);
+  AssignmentTarget & setA(MatrixRef A);
+  AssignmentTarget & setQ(MatrixRef Q);
+  AssignmentTarget & setl(VectorRef l);
+  AssignmentTarget & setu(VectorRef u);
+  AssignmentTarget & setb(VectorRef b);
+  AssignmentTarget & setq(VectorRef q);
 
-    /** l <= x <= u */
-    AssignmentTarget(RangePtr range, VectorRef l, VectorRef u);
+  /** Ax = +/-b, Ax <= +/-b, Ax >= +/-b or 1/2 x^T Q x +\epsilon q*/
+  void changeData(MatrixRef AQ, VectorRef bq);
 
-    /** x >= b or x <= b*/
-    AssignmentTarget(RangePtr range, VectorRef lu, constraint::Type ct);
+  /** l <= Ax <= u */
+  void changeData(MatrixRef A, VectorRef l, VectorRef u);
 
-    /** Quadratic function 1/2 x^T Q x +\epsilon q, where \epsilon = 0, 1 or -1 depending on cr.*/
-    AssignmentTarget(MatrixRef Q, VectorRef q, constraint::RHS cr);
+  /** l <= x <= u */
+  void changeData(VectorRef l, VectorRef u);
 
+private:
+  /** Type of target*/
+  TargetType targetType_;
+  /** Constraint type convention*/
+  constraint::Type cstrType_;
+  /** RHS type convention*/
+  constraint::RHS constraintRhs_;
+  /** Pointer to the row range*/
+  RangePtr range_;
+  /** Pointers to the target matrix and vectors (when applicable) */
+  MatrixRef A_ = Eigen::Map<Eigen::MatrixXd>(nullptr, 0, 0);
+  MatrixRef Q_ = Eigen::Map<Eigen::MatrixXd>(nullptr, 0, 0);
+  VectorRef l_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
+  VectorRef u_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
+  VectorRef b_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
+  VectorRef q_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
+};
 
-    TargetType targetType() const;
-    constraint::Type constraintType() const;
-    constraint::RHS constraintRhs() const;
-    /** Row size of the target.*/
-    int size() const;
-    Range& range();
-    const Range& range() const;
+} // namespace internal
 
-    /** Return the (range.dim x colDim) block of A starting at
-    *(range.start,colStart) */
-    MatrixRef A(int colStart, int colDim) const;
-    /** Return the whole quadratic matrix*/
-    MatrixRef Q() const;
-    /** Return the segment of l defined by range. */
-    VectorRef l() const;
-    /** Return the segment of u defined by range. */
-    VectorRef u() const;
-    /** Return the segment of b defined by range. */
-    VectorRef b() const;
-    /** Return the whole vector q.*/
-    VectorRef q() const;
+} // namespace scheme
 
-    /** Same as A(...), and b(), but return only the first or second half of
-      * the row range. This is necessary when double-sided constraints are
-      * assigned to matrix/vector with single-sided convention
-      */
-    /**@{*/
-    MatrixRef AFirstHalf(int colStart, int colDim) const;
-    MatrixRef ASecondHalf(int colStart, int colDim) const;
-    VectorRef bFirstHalf() const;
-    VectorRef bSecondHalf() const;
-    /**@}*/
-
-    AssignmentTarget& setA(MatrixRef A);
-    AssignmentTarget& setQ(MatrixRef Q);
-    AssignmentTarget& setl(VectorRef l);
-    AssignmentTarget& setu(VectorRef u);
-    AssignmentTarget& setb(VectorRef b);
-    AssignmentTarget& setq(VectorRef q);
-
-    /** Ax = +/-b, Ax <= +/-b, Ax >= +/-b or 1/2 x^T Q x +\epsilon q*/
-    void changeData(MatrixRef AQ, VectorRef bq);
-
-    /** l <= Ax <= u */
-    void changeData(MatrixRef A, VectorRef l, VectorRef u);
-
-    /** l <= x <= u */
-    void changeData(VectorRef l, VectorRef u);
-
-  private:
-    /** Type of target*/
-    TargetType targetType_;
-    /** Constraint type convention*/
-    constraint::Type cstrType_;
-    /** RHS type convention*/
-    constraint::RHS constraintRhs_;
-    /** Pointer to the row range*/
-    RangePtr range_;
-    /** Pointers to the target matrix and vectors (when applicable) */
-    MatrixRef A_ = Eigen::Map<Eigen::MatrixXd>(nullptr, 0, 0);
-    MatrixRef Q_ = Eigen::Map<Eigen::MatrixXd>(nullptr, 0, 0);
-    VectorRef l_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
-    VectorRef u_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
-    VectorRef b_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
-    VectorRef q_ = Eigen::Map<Eigen::VectorXd>(nullptr, 0);
-  };
-
-}  // namespace internal
-
-}  // namespace scheme
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/scheme/internal/AssignmentTarget.h
+++ b/include/tvm/scheme/internal/AssignmentTarget.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/internal/CompiledAssignment.h
+++ b/include/tvm/scheme/internal/CompiledAssignment.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/internal/CompiledAssignment.h
+++ b/include/tvm/scheme/internal/CompiledAssignment.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -43,763 +43,840 @@ namespace scheme
 namespace internal
 {
 
-  /** Specify in which way \a from is assigned to \a to.*/
-  enum AssignType
+/** Specify in which way \a from is assigned to \a to.*/
+enum AssignType
+{
+  /** to =  from */ COPY,
+  /** to += from */ ADD,
+  /** to -= from */ SUB,
+  /** to = min(to, from) */ MIN,
+  /** to = max(to, from) */ MAX
+};
+
+/** Specify whether \a from is to be multiplied by 1, -1 or a user
+ * specified scalar.
+ */
+enum WeightMult
+{
+  /** from */ NONE,
+  /** -from */ MINUS,
+  /** s*from */ SCALAR,
+  /** diag(d) * from */ DIAGONAL
+};
+
+/** Specify if from is to be multiplied a matrix, and if so, what is the
+ * type of the matrix.
+ */
+enum MatrixMult
+{
+  /** from */
+  IDENTITY,
+  /** M*from (vector case) or from*M (matrix case) where M is a matrix.*/
+  GENERAL,
+  /** inv(M) * from or from*inv(M) where M is diagonal*/
+  INVERSE_DIAGONAL,
+  /** use a custom multiplier */
+  CUSTOM
+};
+
+/** The type of the source.
+ * Note there are two considerations for explicitly introducing the
+ * CONSTANT case (versus requiring the user to give a Ref to a constant
+ * vector):
+ *  - we can deal with it more efficiently
+ *  - we take care automatically of any change of size of to or of the
+ *    multiplier matrix.
+ */
+enum Source
+{
+  /** source is an external vector or matrix (main use-case) */
+  EXTERNAL,
+  /** source is zero */
+  ZERO,
+  /** source is a (non-zero) constant */
+  CONSTANT
+};
+
+/** trait-like definition to detect if an Eigen expression \p MatrixType is describing
+ * a vector.
+ */
+template<typename MatrixType>
+using isVector = typename std::conditional<MatrixType::ColsAtCompileTime == 1, std::true_type, std::false_type>::type;
+
+/* trait-like definition to detect if an Eigen expression \p MatrixType is describing
+ * a matrix.
+ */
+template<typename MatrixType>
+using isMatrix = typename std::conditional<MatrixType::ColsAtCompileTime != 1, std::true_type, std::false_type>::type;
+
+/** Dummy type for constructors with no arguments*/
+class NoArg
+{
+};
+
+/** Helper structure to get the N-th argument in a function call.
+ * \sa ParseArg
+ */
+template<int N>
+class ParseArg_
+{
+public:
+  template<typename... Args>
+  static typename std::tuple_element<N, std::tuple<Args...>>::type get(Args &&... args)
   {
-    /** to =  from */         COPY,
-    /** to += from */         ADD,
-    /** to -= from */         SUB,
-    /** to = min(to, from) */ MIN,
-    /** to = max(to, from) */ MAX
-  };
+    return std::get<N>(std::forward_as_tuple(args...));
+  }
+};
 
-  /** Specify whether \a from is to be multiplied by 1, -1 or a user
-    * specified scalar.
-    */
-  enum WeightMult
+/** Helper structure to get no argument in a function call.
+ * \sa ParseArg
+ */
+class ParseNoArg_
+{
+public:
+  template<typename... Args>
+  static NoArg get(Args &&...)
   {
-    /** from */                 NONE,
-    /** -from */                MINUS,
-    /** s*from */               SCALAR,
-    /** diag(d) * from */       DIAGONAL
-  };
+    return {};
+  }
+};
 
-  /** Specify if from is to be multiplied a matrix, and if so, what is the
-    * type of the matrix.
-    */
-  enum MatrixMult
-  {
-    /** from */
-    IDENTITY,
-    /** M*from (vector case) or from*M (matrix case) where M is a matrix.*/
-    GENERAL,
-    /** inv(M) * from or from*inv(M) where M is diagonal*/ 
-    INVERSE_DIAGONAL,
-    /** use a custom multiplier */
-    CUSTOM
-  };
+/** A helper structure with a static \p get method to retrieve the N-th
+ * argument in a function call. We use it to dispatch arguments to base
+ * classes in the constructor of an aggregated derived class.
+ * If N>=0, returns the corresponding argument, otherwise returns an instance
+ * of NoArg.
+ */
+template<int N>
+class ParseArg : public std::conditional<(N >= 0), ParseArg_<N>, ParseNoArg_>::type
+{
+};
 
-  /** The type of the source.
-    * Note there are two considerations for explicitly introducing the
-    * CONSTANT case (versus requiring the user to give a Ref to a constant
-    * vector):
-    *  - we can deal with it more efficiently
-    *  - we take care automatically of any change of size of to or of the
-    *    multiplier matrix.
-    */
-  enum Source
-  {
-    /** source is an external vector or matrix (main use-case) */
-    EXTERNAL,
-    /** source is zero */
-    ZERO,
-    /** source is a (non-zero) constant */
-    CONSTANT
-  };
+/** A dummy helper function to build hasNoArgCtor*/
+template<typename T>
+std::true_type hasNoArgCtorDummy(const T &);
+/** Helper function that exists only if \p T has a constructor accepting NoArg.
+ * We use hasNoArgCtorDummy as a mean to enable SFINAE.
+ */
+template<typename T>
+decltype(hasNoArgCtorDummy(T(NoArg()))) hasNoArgCtor_(int);
+/** Overload that always exists. It will only be chosen if the other overload
+ * does not exist.
+ */
+template<typename>
+std::false_type hasNoArgCtor_(...);
 
-  /** trait-like definition to detect if an Eigen expression \p MatrixType is describing
-    * a vector.
-    */
-  template<typename MatrixType>
-  using isVector = typename std::conditional<MatrixType::ColsAtCompileTime == 1, std::true_type, std::false_type>::type;
-  
-   /* trait-like definition to detect if an Eigen expression \p MatrixType is describing
-    * a matrix.
-    */
-  template<typename MatrixType>
-  using isMatrix = typename std::conditional<MatrixType::ColsAtCompileTime != 1, std::true_type, std::false_type>::type;
-  
-  /** Dummy type for constructors with no arguments*/
-  class NoArg {};
+/** Traits-like class to detect if class \p T has a constructor accepting an
+ * instance of \p NoArg as argument.
+ * The class derives from std::true_type if this is the case and
+ * std::false_type otherwise.
+ */
+template<typename T>
+class hasNoArgCtor : public decltype(hasNoArgCtor_<T>(0))
+{
+};
 
-  /** Helper structure to get the N-th argument in a function call.
-    * \sa ParseArg
-    */
-  template<int N>
-  class ParseArg_
-  {
-  public:
-    template<typename... Args>
-    static typename std::tuple_element<N, std::tuple<Args...>>::type get(Args&& ... args)
-    {
-      return std::get<N>(std::forward_as_tuple(args...));
-    }
-  };
+/** Given a list of types, count how many of then havec a constructor
+ * accepting NoArg
+ */
+template<typename T, typename... Args>
+class ArgCount
+{
+public:
+  static constexpr int count = ArgCount<Args...>::count + (hasNoArgCtor<T>::value ? 0 : 1);
+};
 
-  /** Helper structure to get no argument in a function call.
-    * \sa ParseArg
-    */
-  class ParseNoArg_
-  {
-  public:
-    template<typename... Args>
-    static NoArg get(Args&&...) { return {}; }
-  };
+/** End of reccursion for ArgCount*/
+template<typename T>
+class ArgCount<T>
+{
+public:
+  static constexpr int count = hasNoArgCtor<T>::value ? 0 : 1;
+};
 
-  /** A helper structure with a static \p get method to retrieve the N-th
-    * argument in a function call. We use it to dispatch arguments to base
-    * classes in the constructor of an aggregated derived class.
-    * If N>=0, returns the corresponding argument, otherwise returns an instance
-    * of NoArg.
-    */
-  template<int N>
-  class ParseArg : public std::conditional< (N >= 0), ParseArg_<N>, ParseNoArg_>::type {};
-
-
-  /** A dummy helper function to build hasNoArgCtor*/
+/** A cache for holding temporary value in the evaluation of an assignment.
+ * By default, it does not do anything but forward an expression.
+ */
+template<typename MatrixType, bool Cache>
+class CachedResult
+{
+public:
   template<typename T>
-  std::true_type hasNoArgCtorDummy(const T&);
-  /** Helper function that exists only if \p T has a constructor accepting NoArg.
-    * We use hasNoArgCtorDummy as a mean to enable SFINAE.
-    */
+  const T & cache(const T & M)
+  {
+    return M;
+  }
+};
+
+/** Specialization for when a cache is needed.*/
+template<typename MatrixType>
+class CachedResult<MatrixType, true>
+{
+public:
   template<typename T>
-  decltype(hasNoArgCtorDummy(T(NoArg()))) hasNoArgCtor_(int);
-  /** Overload that always exists. It will only be chosen if the other overload
-    * does not exist.
-    */
-  template<typename>
-  std::false_type hasNoArgCtor_(...);
-
-  /** Traits-like class to detect if class \p T has a constructor accepting an
-    * instance of \p NoArg as argument.
-    * The class derives from std::true_type if this is the case and
-    * std::false_type otherwise.
-    */
-  template<typename T>
-  class hasNoArgCtor : public decltype(hasNoArgCtor_<T>(0)){};
-
-  /** Given a list of types, count how many of then havec a constructor
-    * accepting NoArg
-    */
-  template<typename T, typename... Args>
-  class ArgCount
+  const MatrixType & cache(const T & M)
   {
-  public:
-    static constexpr int count = ArgCount<Args...>::count + (hasNoArgCtor<T>::value ? 0 : 1);
-  };
-
-  /** End of reccursion for ArgCount*/
-  template<typename T>
-  class ArgCount<T>
-  {
-  public:
-    static constexpr int count = hasNoArgCtor<T>::value ? 0 : 1;
-  };
-
-
-  /** A cache for holding temporary value in the evaluation of an assignment.
-    * By default, it does not do anything but forward an expression.
-    */
-  template<typename MatrixType, bool Cache>
-  class CachedResult
-  {
-  public:
-    template<typename T>
-    const T& cache(const T& M) { return M; }
-  };
-
-  /** Specialization for when a cache is needed.*/
-  template<typename MatrixType>
-  class CachedResult<MatrixType, true>
-  {
-  public:
-    template<typename T>
-    const MatrixType& cache(const T& M)
-    {
 #ifdef AUTHORIZE_MALLOC_FOR_CACHE
-      if (!Eigen::internal::is_malloc_allowed())
-      {
-        Eigen::internal::set_is_malloc_allowed(true);
-        cache_ = M; return cache_;
-        Eigen::internal::set_is_malloc_allowed(false);
-      }
-      else
-#endif
-        cache_ = M;
+    if(!Eigen::internal::is_malloc_allowed())
+    {
+      Eigen::internal::set_is_malloc_allowed(true);
+      cache_ = M;
       return cache_;
+      Eigen::internal::set_is_malloc_allowed(false);
     }
+    else
+#endif
+      cache_ = M;
+    return cache_;
+  }
 
-    MatrixType& cache() { return cache_; }
-    const MatrixType& cache() const { return cache_; }
+  MatrixType & cache() { return cache_; }
+  const MatrixType & cache() const { return cache_; }
 
-  private:
-    MatrixType cache_;
-  };
+private:
+  MatrixType cache_;
+};
 
+/** Traits for deciding whether or not to use a cache before the assign step.
+ * By default, no cache is used.
+ */
+template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F>
+class use_assign_cache : public std::false_type
+{
+};
 
-  /** Traits for deciding whether or not to use a cache before the assign step.
-    * By default, no cache is used.
-    */
-  template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F>
-  class use_assign_cache : public std::false_type {};
+/** Specialization for min/max with general matrix product. In this case, we
+ * use the cache
+ */
+template<typename MatrixType, WeightMult W>
+class use_assign_cache<MatrixType, MIN, W, GENERAL, EXTERNAL> : public std::true_type
+{
+};
+template<typename MatrixType, WeightMult W>
+class use_assign_cache<MatrixType, MAX, W, GENERAL, EXTERNAL> : public std::true_type
+{
+};
 
-  /** Specialization for min/max with general matrix product. In this case, we
-    * use the cache
-    */
-  template<typename MatrixType, WeightMult W>
-  class use_assign_cache<MatrixType, MIN, W, GENERAL, EXTERNAL> : public std::true_type {};
-  template<typename MatrixType, WeightMult W>
-  class use_assign_cache<MatrixType, MAX, W, GENERAL, EXTERNAL> : public std::true_type {};
+/** Specialization for GENERAL*CONSTANT. This should not be necessary, but
+ * the product needs a temporary. Maybe it's not the case anymore with Eigen 3.3.
+ */
+template<typename MatrixType, AssignType A, WeightMult W>
+class use_assign_cache<MatrixType, A, W, GENERAL, CONSTANT> : public std::true_type
+{
+};
 
-  /** Specialization for GENERAL*CONSTANT. This should not be necessary, but
-    * the product needs a temporary. Maybe it's not the case anymore with Eigen 3.3.
-    */
-  template<typename MatrixType, AssignType A, WeightMult W>
-  class use_assign_cache<MatrixType, A, W, GENERAL, CONSTANT> : public std::true_type {};
+/** Traits for deciding whether or not to use a cache for the product.
+ * By default, no cache is used.
+ */
+template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F>
+class use_product_cache : public std::false_type
+{
+};
 
-  /** Traits for deciding whether or not to use a cache for the product.
-    * By default, no cache is used.
-    */
-  template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F>
-  class use_product_cache : public std::false_type {};
+/** Specialization for GENERAL product with diagonal weight
+ *
+ * FIXME : this should not be needed for MatrixType = VectorXd
+ */
+template<typename MatrixType, AssignType A>
+class use_product_cache<MatrixType, A, DIAGONAL, GENERAL, EXTERNAL> : public std::true_type
+{
+};
+template<typename MatrixType, AssignType A>
+class use_product_cache<MatrixType, A, DIAGONAL, GENERAL, CONSTANT> : public std::true_type
+{
+};
 
-  /** Specialization for GENERAL product with diagonal weight
-    *
-    * FIXME : this should not be needed for MatrixType = VectorXd
-    */
-  template<typename MatrixType, AssignType A>
-  class use_product_cache<MatrixType, A, DIAGONAL, GENERAL, EXTERNAL> : public std::true_type {};
-  template<typename MatrixType, AssignType A>
-  class use_product_cache<MatrixType, A, DIAGONAL, GENERAL, CONSTANT> : public std::true_type {};
-  
+/** Base class for the assignation */
+template<AssignType A>
+class AssignBase
+{
+};
 
-  /** Base class for the assignation */
-  template<AssignType A>  class AssignBase {};
-
-  template<>
-  class AssignBase<COPY>
+template<>
+class AssignBase<COPY>
+{
+public:
+  template<typename T, typename U>
+  void assign(U & out, const T & in)
   {
-  public:
-    template <typename T, typename U>
-    void assign(U& out, const T& in) { out.noalias() = in; }
+    out.noalias() = in;
+  }
 
-    template <typename U>
-    void assign(U& out, double in) { out.setConstant(in); }
-  };
-
-  template<>
-  class AssignBase<ADD>
+  template<typename U>
+  void assign(U & out, double in)
   {
-  public:
-    template <typename T, typename U>
-    void assign(U& out, const T& in) { out.noalias() += in; }
+    out.setConstant(in);
+  }
+};
 
-    template <typename U>
-    void assign(U& out, double in) { out.array() += in; }
-  };
-
-  template<>
-  class AssignBase<SUB>
+template<>
+class AssignBase<ADD>
+{
+public:
+  template<typename T, typename U>
+  void assign(U & out, const T & in)
   {
-  public:
-    template <typename T, typename U>
-    void assign(U& out, const T& in) { out.noalias() -= in; }
+    out.noalias() += in;
+  }
 
-    template <typename U>
-    void assign(U& out, double in) { out.array() -= in; }
-  };
-
-  template<>
-  class AssignBase<MIN>
+  template<typename U>
+  void assign(U & out, double in)
   {
-  public:
-    template <typename T, typename U>
-    void assign(U& out, const T& in) { out.array() = out.array().min(in.array()); }
+    out.array() += in;
+  }
+};
 
-    template <typename U>
-    void assign(U& out, double in) { out.array() = out.array().min(in); }
-  };
-
-  template<>
-  class AssignBase<MAX>
+template<>
+class AssignBase<SUB>
+{
+public:
+  template<typename T, typename U>
+  void assign(U & out, const T & in)
   {
-  public:
-    template <typename T, typename U>
-    void assign(U& out, const T& in) { out.array() = out.array().max(in.array()); }
+    out.noalias() -= in;
+  }
 
-    template <typename U>
-    void assign(U& out, double in) { out.array() = out.array().max(in); }
-  };
-
-
-  /** Base class for the multiplication by a scalar*/
-  template<WeightMult W> class WeightMultBase {};
-
-  /** Specialization for NONE */
-  template<>
-  class WeightMultBase<NONE>
+  template<typename U>
+  void assign(U & out, double in)
   {
-  public:
-    static const bool useArg = false;
+    out.array() -= in;
+  }
+};
 
-    WeightMultBase(NoArg) {};
-
-    template<typename T>
-    const T& applyWeightMult(const T& M) { return M; }
-  };
-
-  /** Specialization for MINUS */
-  template<>
-  class WeightMultBase<MINUS>
+template<>
+class AssignBase<MIN>
+{
+public:
+  template<typename T, typename U>
+  void assign(U & out, const T & in)
   {
-  public:
-    static const bool useArg = false;
+    out.array() = out.array().min(in.array());
+  }
 
-    WeightMultBase(NoArg) {};
+  template<typename U>
+  void assign(U & out, double in)
+  {
+    out.array() = out.array().min(in);
+  }
+};
 
-    double applyWeightMult(const double& M) { return -M; }
+template<>
+class AssignBase<MAX>
+{
+public:
+  template<typename T, typename U>
+  void assign(U & out, const T & in)
+  {
+    out.array() = out.array().max(in.array());
+  }
 
-    template<typename Derived>
-    decltype(-std::declval<Eigen::MatrixBase<Derived> >()) applyWeightMult(const Eigen::MatrixBase<Derived>& M) { return -M; }
+  template<typename U>
+  void assign(U & out, double in)
+  {
+    out.array() = out.array().max(in);
+  }
+};
 
-    /** We need this specialization because, odly, -(A*B) relies on a temporary evaluation while (-A)*B does not*/
+/** Base class for the multiplication by a scalar*/
+template<WeightMult W>
+class WeightMultBase
+{
+};
+
+/** Specialization for NONE */
+template<>
+class WeightMultBase<NONE>
+{
+public:
+  static const bool useArg = false;
+
+  WeightMultBase(NoArg){};
+
+  template<typename T>
+  const T & applyWeightMult(const T & M)
+  {
+    return M;
+  }
+};
+
+/** Specialization for MINUS */
+template<>
+class WeightMultBase<MINUS>
+{
+public:
+  static const bool useArg = false;
+
+  WeightMultBase(NoArg){};
+
+  double applyWeightMult(const double & M) { return -M; }
+
+  template<typename Derived>
+  decltype(-std::declval<Eigen::MatrixBase<Derived>>()) applyWeightMult(const Eigen::MatrixBase<Derived> & M)
+  {
+    return -M;
+  }
+
+  /** We need this specialization because, odly, -(A*B) relies on a temporary evaluation while (-A)*B does not*/
 #if EIGEN_VERSION_AT_LEAST(3, 2, 90)
-    template<typename Lhs, typename Rhs, int Option>
-    decltype(-(std::declval<Lhs>().lazyProduct(std::declval<Rhs>()))) applyWeightMult(const Eigen::Product<Lhs, Rhs, Option>& P)
-    {
-      return -(P.lhs().lazyProduct(P.rhs()));
-    }
+  template<typename Lhs, typename Rhs, int Option>
+  decltype(-(std::declval<Lhs>().lazyProduct(std::declval<Rhs>()))) applyWeightMult(
+      const Eigen::Product<Lhs, Rhs, Option> & P)
+  {
+    return -(P.lhs().lazyProduct(P.rhs()));
+  }
 #else
-    template<typename Derived, typename Lhs, typename Rhs>
-    decltype((-std::declval<Lhs>())*std::declval<Rhs>()) applyWeightMult(const Eigen::ProductBase<Derived, Lhs, Rhs>& P)
-    {
-      return (-P.lhs())*P.rhs();
-    }
-#endif
-  };
-
-  /** Specialization for SCALAR */
-  template<>
-  class WeightMultBase<SCALAR>
+  template<typename Derived, typename Lhs, typename Rhs>
+  decltype((-std::declval<Lhs>()) * std::declval<Rhs>()) applyWeightMult(const Eigen::ProductBase<Derived, Lhs, Rhs> & P)
   {
-  public:
-    WeightMultBase(const double& s) : s_(s) {};
+    return (-P.lhs()) * P.rhs();
+  }
+#endif
+};
 
-    template<typename T>
-    decltype(double()*std::declval<T>()) applyWeightMult(const T& M) { return s_ * M; }
+/** Specialization for SCALAR */
+template<>
+class WeightMultBase<SCALAR>
+{
+public:
+  WeightMultBase(const double & s) : s_(s){};
+
+  template<typename T>
+  decltype(double() * std::declval<T>()) applyWeightMult(const T & M)
+  {
+    return s_ * M;
+  }
 
 #if EIGEN_VERSION_AT_LEAST(3, 2, 90)
-    template<typename Lhs, typename Rhs, int Option>
-    decltype(double()*(std::declval<Lhs>().lazyProduct(std::declval<Rhs>()))) applyWeightMult(const Eigen::Product<Lhs, Rhs, Option>& P)
-    {
-      return s_ * (P.lhs().lazyProduct(P.rhs()));
-    }
+  template<typename Lhs, typename Rhs, int Option>
+  decltype(double() * (std::declval<Lhs>().lazyProduct(std::declval<Rhs>()))) applyWeightMult(
+      const Eigen::Product<Lhs, Rhs, Option> & P)
+  {
+    return s_ * (P.lhs().lazyProduct(P.rhs()));
+  }
 #endif
 
-  private:
-    const double& s_;
-  };
+private:
+  const double & s_;
+};
 
-  /** Specialization for DIAGONAL */
-  template<>
-  class WeightMultBase<DIAGONAL>
+/** Specialization for DIAGONAL */
+template<>
+class WeightMultBase<DIAGONAL>
+{
+public:
+  WeightMultBase(const Eigen::Ref<const Eigen::VectorXd> & d) : d_(d) {}
+
+  template<typename T>
+  using ReturnType = decltype(std::declval<Eigen::Ref<const Eigen::VectorXd>>().asDiagonal() * std::declval<T>());
+  template<typename T>
+  ReturnType<T> applyWeightMult(const T & M)
   {
-  public: 
-    WeightMultBase(const Eigen::Ref<const Eigen::VectorXd>& d) : d_(d) {}
+    return d_.asDiagonal() * M;
+  }
 
-    template<typename T>
-    using ReturnType = decltype(std::declval<Eigen::Ref<const Eigen::VectorXd>>().asDiagonal() * std::declval<T>());
-    template<typename T> 
-    ReturnType<T> applyWeightMult(const T& M) { return d_.asDiagonal() * M; }
-
-    /** Diagonal * constant vector case*/
-    decltype(double()*std::declval<Eigen::Ref<const Eigen::VectorXd>>())
-      applyWeightMult(const double& d)
-    {
-      return d * d_;
-    }
-
-  private:
-    Eigen::Ref<const Eigen::VectorXd> d_;
-  };
-
-  /** Base class for the multiplication by a matrix*/
-  template<typename MatrixType, MatrixMult M> class MatrixMultBase {};
-
-  /** Partial specialization for IDENTITY*/
-  template<typename MatrixType>
-  class MatrixMultBase<MatrixType, IDENTITY>
+  /** Diagonal * constant vector case*/
+  decltype(double() * std::declval<Eigen::Ref<const Eigen::VectorXd>>()) applyWeightMult(const double & d)
   {
-  public:
-    MatrixMultBase(NoArg) {}
+    return d * d_;
+  }
 
-    template<typename T>
-    const T& applyMatrixMult(const T& M) { return M; }
-  };
+private:
+  Eigen::Ref<const Eigen::VectorXd> d_;
+};
 
-  /** Partial specialization for GENERAL*/
-  template<typename MatrixType>
-  class MatrixMultBase<MatrixType, GENERAL>
+/** Base class for the multiplication by a matrix*/
+template<typename MatrixType, MatrixMult M>
+class MatrixMultBase
+{
+};
+
+/** Partial specialization for IDENTITY*/
+template<typename MatrixType>
+class MatrixMultBase<MatrixType, IDENTITY>
+{
+public:
+  MatrixMultBase(NoArg) {}
+
+  template<typename T>
+  const T & applyMatrixMult(const T & M)
   {
-  public:
-    MatrixMultBase(const Eigen::Ref<const Eigen::MatrixXd>& M) : M_(M) {}
+    return M;
+  }
+};
 
-    /** Return type of Matrix*T */
-    template<typename T>
-    using PreType = decltype(std::declval<Eigen::Ref<const Eigen::MatrixXd>>()*std::declval<T>());
-    /** Return type of T*Matrix */
-    template<typename T>
-    using PostType = decltype(std::declval<T>()*std::declval<Eigen::Ref<const Eigen::MatrixXd>>());
-    /** Return type of Matrix * ConstantVector */
-    using ConstType = decltype(std::declval<Eigen::Ref<const Eigen::MatrixXd>>()*Eigen::VectorXd::Constant(1, 1));
+/** Partial specialization for GENERAL*/
+template<typename MatrixType>
+class MatrixMultBase<MatrixType, GENERAL>
+{
+public:
+  MatrixMultBase(const Eigen::Ref<const Eigen::MatrixXd> & M) : M_(M) {}
 
-    template<typename T>
-    typename std::enable_if<isVector<MatrixType>::value, PreType<T>>::type applyMatrixMult(const T& M)
-    {
-      return M_ * M;
-    }
+  /** Return type of Matrix*T */
+  template<typename T>
+  using PreType = decltype(std::declval<Eigen::Ref<const Eigen::MatrixXd>>() * std::declval<T>());
+  /** Return type of T*Matrix */
+  template<typename T>
+  using PostType = decltype(std::declval<T>() * std::declval<Eigen::Ref<const Eigen::MatrixXd>>());
+  /** Return type of Matrix * ConstantVector */
+  using ConstType = decltype(std::declval<Eigen::Ref<const Eigen::MatrixXd>>() * Eigen::VectorXd::Constant(1, 1));
 
-    template<typename T>
-    typename std::enable_if<!isVector<MatrixType>::value, PostType<T>>::type applyMatrixMult(const T& M)
-    {
-      return M * M_;
-    }
-
-    template<typename U = MatrixType>
-    typename std::enable_if<isVector<U>::value, ConstType>::type applyMatrixMult(const double& d)
-    {
-      return M_ * Eigen::VectorXd::Constant(M_.cols(), d);
-    }
-
-    /** Cached version of applyMatrixMult*/
-    template<typename T>
-    void applyMatrixMultCached(MatrixType& cache, const T& M)
-    {
-      cache.noalias() =  applyMatrixMult(M);
-    }
-
-  private:
-    Eigen::Ref<const Eigen::MatrixXd> M_;
-  };
-
-  /** Partial specialization for INVERSE_DIAGONAL*/
-  template<typename MatrixType>
-  class MatrixMultBase<MatrixType, INVERSE_DIAGONAL>
+  template<typename T>
+  typename std::enable_if<isVector<MatrixType>::value, PreType<T>>::type applyMatrixMult(const T & M)
   {
-  public:
-    MatrixMultBase(const Eigen::Ref<const Eigen::MatrixXd>& M) : M_(M) {}
+    return M_ * M;
+  }
 
-    /** Type of the diagonal inverse*/
-    using InvDiagType = decltype(std::declval<Eigen::Ref<const Eigen::MatrixXd>>().diagonal().cwiseInverse().asDiagonal());
-    /** Return type of Matrix*T */
-    template<typename T>
-    using PreType = decltype(std::declval<InvDiagType>()*std::declval<T>());
-    /** Return type of T*Matrix */
-    template<typename T>
-    using PostType = decltype(std::declval<T>()*std::declval<InvDiagType>());
-    /** Return type of Matrix * ConstantVector */
-    using ConstType = decltype(std::declval<InvDiagType>()*Eigen::VectorXd::Constant(1, 1));
-
-    template<typename T>
-    typename std::enable_if<isVector<MatrixType>::value, PreType<T>>::type applyMatrixMult(const T& M)
-    {
-      return M_.diagonal().cwiseInverse().asDiagonal() * M;
-    }
-
-    template<typename T>
-    typename std::enable_if<!isVector<MatrixType>::value, PostType<T>>::type applyMatrixMult(const T& M)
-    {
-      return M * M_.diagonal().cwiseInverse().asDiagonal();
-    }
-
-    template<typename U = MatrixType>
-    typename std::enable_if<isVector<U>::value, ConstType>::type applyMatrixMult(const double& d)
-    {
-      return M_.diagonal().cwiseInverse().asDiagonal() * Eigen::VectorXd::Constant(M_.cols(), d);
-    }
-
-    /** Cached version of applyMatrixMult*/
-    template<typename T>
-    void applyMatrixMultCached(MatrixType& cache, const T& M)
-    {
-      cache.noalias() = applyMatrixMult(M);
-    }
-
-  private:
-    Eigen::Ref<const Eigen::MatrixXd> M_;
-  };
-
-  /** Partial specialization for CUSTOM*/
-  template<typename MatrixType>
-  class MatrixMultBase<MatrixType, CUSTOM>
+  template<typename T>
+  typename std::enable_if<!isVector<MatrixType>::value, PostType<T>>::type applyMatrixMult(const T & M)
   {
-  public:
-    MatrixMultBase(void(*mult)(Eigen::Ref<MatrixType> out, const Eigen::Ref<const MatrixType>& in)) : mult_(mult) {}
+    return M * M_;
+  }
 
-    template<typename T>
-    void applyMatrixMultCached(MatrixType& cache, const T& M)
-    {
-      mult_(cache, M);
-    }
-
-  private:
-    void(*mult_)(Eigen::Ref<MatrixType> out, const Eigen::Ref<const MatrixType>& in);
-  };
-
-
-  /** Base class for managing the source*/
-  template<typename MatrixType, Source F>
-  class SourceBase
+  template<typename U = MatrixType>
+  typename std::enable_if<isVector<U>::value, ConstType>::type applyMatrixMult(const double & d)
   {
-  public:
-    using SourceType = typename std::conditional<F == CONSTANT, double, Eigen::Ref<const MatrixType>>::type;
+    return M_ * Eigen::VectorXd::Constant(M_.cols(), d);
+  }
 
-    SourceBase(const SourceType& from) : from_(from) {}
-
-    const SourceType& from() const
-    {
-      return from_;
-    }
-
-    void from(const SourceType& from)
-    {
-      // We want to do from_ = from but there is no operator= for Eigen::Ref,
-      // so we need to use a placement new.
-      new (&from_) SourceType(from);
-    }
-
-  private:
-    SourceType from_;
-  };
-
-  /** Partial specialization for ZERO*/
-  template<typename MatrixType>
-  class SourceBase<MatrixType, ZERO> {};
-
-
-  /** The main class. Its run method perfoms the assignment t = op(t, w*M*f)
-    * (if f is a vector) or t = op(t, w*f*M) (if f is a matrix)
-    * where
-    *  - t is the target matrix/vector
-    *  - f is the source matrix/vector
-    *  - op is described by A
-    *  - w is a scalar, user supplied if W is SCALAR, +/-1 if W is NONE or
-    *    MINUS, and a vector if W is DIAGONAL or INVERSE_DIAGONAL
-    *  - M is a matrix, either the identity or user-supplied, depending on
-    *    the template parameter M (see MatrixMult)
-    * If F=EXTERNAl f is a user supplied Eigen::Ref<MatrixType>, if F=ZERO,
-    * f=0 and if F=CONSTANT, f is a constant vector (vector only).
-    *
-    * This class is meant to be a helper class and should not live on its own,
-    * but be create by a higher-level class ensuring its data are valid.
-    *
-    * \internal TODO:
-    * - use an object for custom multiplications
-    * - resize of cache at initialization
-    * - reference on all inputs? (not the case now for inputs that are double)
-    */
-  template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F = EXTERNAL>
-  class CompiledAssignment
-    : public CachedResult<MatrixType, 
-        use_assign_cache<MatrixType, A, W, M, F>::value || use_product_cache<MatrixType, A, W, M, F>::value>
-    , public AssignBase<A>
-    , public WeightMultBase<W>
-    , public MatrixMultBase<MatrixType, M>
-    , public SourceBase<MatrixType, F>
+  /** Cached version of applyMatrixMult*/
+  template<typename T>
+  void applyMatrixMultCached(MatrixType & cache, const T & M)
   {
-  private:
-    using WBase = WeightMultBase<W>;
-    using MBase = MatrixMultBase<MatrixType, M>;
-    using SBase = SourceBase<MatrixType, F>;
-    using SParse = typename std::conditional<hasNoArgCtor<SBase>::value, ParseArg<-1>, ParseArg<ArgCount<SBase>::count-1>>::type;
-    using WParse = typename std::conditional<hasNoArgCtor<WBase>::value, ParseArg<-1>, ParseArg<ArgCount<SBase, WBase>::count-1>>::type;
-    using MParse = typename std::conditional<hasNoArgCtor<MBase>::value, ParseArg<-1>, ParseArg<ArgCount<SBase, WBase, MBase>::count-1>>::type;
+    cache.noalias() = applyMatrixMult(M);
+  }
 
-    /** Constructor. Arguments are given as follows:
-      * \param to output matrix/vector.
-      * \param from input matrix/vector (only for F = EXTERNAL or F = CONSTANT).
-      * \param w weight. (only for W = SCALAR, DIAGONAL or INVERSE_DIAGONAL. It
-      * is a scalar for W = SCALAR, and a vector for W = DIAGONAL or
-      * W = INVERSE_DIAGONAL.
-      * \param M matrix used in the multiplication (only for M = GENERAL or
-      * M = CUSTOM)
-      */
-    template<typename... Args>
-    CompiledAssignment(const Eigen::Ref<MatrixType>& to, Args&&... args)
-      : WBase(WParse::get(std::forward<Args>(args)...))
-      , MBase(MParse::get(std::forward<Args>(args)...))
-      , SBase(SParse::get(std::forward<Args>(args)...)) 
-      , to_(to)
-    {
-      static_assert(!(isMatrix<MatrixType>::value && F == CONSTANT), "Constant source is only for vectors.");
-    }
+private:
+  Eigen::Ref<const Eigen::MatrixXd> M_;
+};
 
-  public:
-    template<typename U = MatrixType>
-    typename std::enable_if<!use_product_cache<U, A, W, M, F>::value>::type run()
-    {
-      // There is room for speed improvement by switching at runtime in function of the 
-      // matrices sizes, in particular for M = GENERAL, it seems that lazy product is
-      // faster for small matrices (but slower for bigger ones)
-      this->assign(to_, this->cache(this->applyWeightMult(this->applyMatrixMult(this->from()))));
-    }
+/** Partial specialization for INVERSE_DIAGONAL*/
+template<typename MatrixType>
+class MatrixMultBase<MatrixType, INVERSE_DIAGONAL>
+{
+public:
+  MatrixMultBase(const Eigen::Ref<const Eigen::MatrixXd> & M) : M_(M) {}
 
-    template<typename U = MatrixType>
-    typename std::enable_if<use_product_cache<U, A, W, M, F>::value
-                && !use_assign_cache<U, A, W, M, F>::value>::type run()
-    {
-      //FIXME have rather a resize method called in the constructor (and whenever
-      //one of the argument in the product is changed). This would require
-      //a CustomProduct class to be used instead of a function pointer for
-      //MatrixMultBase<Custom>, to get the column size of the product
+  /** Type of the diagonal inverse*/
+  using InvDiagType =
+      decltype(std::declval<Eigen::Ref<const Eigen::MatrixXd>>().diagonal().cwiseInverse().asDiagonal());
+  /** Return type of Matrix*T */
+  template<typename T>
+  using PreType = decltype(std::declval<InvDiagType>() * std::declval<T>());
+  /** Return type of T*Matrix */
+  template<typename T>
+  using PostType = decltype(std::declval<T>() * std::declval<InvDiagType>());
+  /** Return type of Matrix * ConstantVector */
+  using ConstType = decltype(std::declval<InvDiagType>() * Eigen::VectorXd::Constant(1, 1));
+
+  template<typename T>
+  typename std::enable_if<isVector<MatrixType>::value, PreType<T>>::type applyMatrixMult(const T & M)
+  {
+    return M_.diagonal().cwiseInverse().asDiagonal() * M;
+  }
+
+  template<typename T>
+  typename std::enable_if<!isVector<MatrixType>::value, PostType<T>>::type applyMatrixMult(const T & M)
+  {
+    return M * M_.diagonal().cwiseInverse().asDiagonal();
+  }
+
+  template<typename U = MatrixType>
+  typename std::enable_if<isVector<U>::value, ConstType>::type applyMatrixMult(const double & d)
+  {
+    return M_.diagonal().cwiseInverse().asDiagonal() * Eigen::VectorXd::Constant(M_.cols(), d);
+  }
+
+  /** Cached version of applyMatrixMult*/
+  template<typename T>
+  void applyMatrixMultCached(MatrixType & cache, const T & M)
+  {
+    cache.noalias() = applyMatrixMult(M);
+  }
+
+private:
+  Eigen::Ref<const Eigen::MatrixXd> M_;
+};
+
+/** Partial specialization for CUSTOM*/
+template<typename MatrixType>
+class MatrixMultBase<MatrixType, CUSTOM>
+{
+public:
+  MatrixMultBase(void (*mult)(Eigen::Ref<MatrixType> out, const Eigen::Ref<const MatrixType> & in)) : mult_(mult) {}
+
+  template<typename T>
+  void applyMatrixMultCached(MatrixType & cache, const T & M)
+  {
+    mult_(cache, M);
+  }
+
+private:
+  void (*mult_)(Eigen::Ref<MatrixType> out, const Eigen::Ref<const MatrixType> & in);
+};
+
+/** Base class for managing the source*/
+template<typename MatrixType, Source F>
+class SourceBase
+{
+public:
+  using SourceType = typename std::conditional<F == CONSTANT, double, Eigen::Ref<const MatrixType>>::type;
+
+  SourceBase(const SourceType & from) : from_(from) {}
+
+  const SourceType & from() const { return from_; }
+
+  void from(const SourceType & from)
+  {
+    // We want to do from_ = from but there is no operator= for Eigen::Ref,
+    // so we need to use a placement new.
+    new(&from_) SourceType(from);
+  }
+
+private:
+  SourceType from_;
+};
+
+/** Partial specialization for ZERO*/
+template<typename MatrixType>
+class SourceBase<MatrixType, ZERO>
+{
+};
+
+/** The main class. Its run method perfoms the assignment t = op(t, w*M*f)
+ * (if f is a vector) or t = op(t, w*f*M) (if f is a matrix)
+ * where
+ *  - t is the target matrix/vector
+ *  - f is the source matrix/vector
+ *  - op is described by A
+ *  - w is a scalar, user supplied if W is SCALAR, +/-1 if W is NONE or
+ *    MINUS, and a vector if W is DIAGONAL or INVERSE_DIAGONAL
+ *  - M is a matrix, either the identity or user-supplied, depending on
+ *    the template parameter M (see MatrixMult)
+ * If F=EXTERNAl f is a user supplied Eigen::Ref<MatrixType>, if F=ZERO,
+ * f=0 and if F=CONSTANT, f is a constant vector (vector only).
+ *
+ * This class is meant to be a helper class and should not live on its own,
+ * but be create by a higher-level class ensuring its data are valid.
+ *
+ * \internal TODO:
+ * - use an object for custom multiplications
+ * - resize of cache at initialization
+ * - reference on all inputs? (not the case now for inputs that are double)
+ */
+template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F = EXTERNAL>
+class CompiledAssignment : public CachedResult<MatrixType,
+                                               use_assign_cache<MatrixType, A, W, M, F>::value
+                                                   || use_product_cache<MatrixType, A, W, M, F>::value>,
+                           public AssignBase<A>,
+                           public WeightMultBase<W>,
+                           public MatrixMultBase<MatrixType, M>,
+                           public SourceBase<MatrixType, F>
+{
+private:
+  using WBase = WeightMultBase<W>;
+  using MBase = MatrixMultBase<MatrixType, M>;
+  using SBase = SourceBase<MatrixType, F>;
+  using SParse =
+      typename std::conditional<hasNoArgCtor<SBase>::value, ParseArg<-1>, ParseArg<ArgCount<SBase>::count - 1>>::type;
+  using WParse = typename std::
+      conditional<hasNoArgCtor<WBase>::value, ParseArg<-1>, ParseArg<ArgCount<SBase, WBase>::count - 1>>::type;
+  using MParse = typename std::
+      conditional<hasNoArgCtor<MBase>::value, ParseArg<-1>, ParseArg<ArgCount<SBase, WBase, MBase>::count - 1>>::type;
+
+  /** Constructor. Arguments are given as follows:
+   * \param to output matrix/vector.
+   * \param from input matrix/vector (only for F = EXTERNAL or F = CONSTANT).
+   * \param w weight. (only for W = SCALAR, DIAGONAL or INVERSE_DIAGONAL. It
+   * is a scalar for W = SCALAR, and a vector for W = DIAGONAL or
+   * W = INVERSE_DIAGONAL.
+   * \param M matrix used in the multiplication (only for M = GENERAL or
+   * M = CUSTOM)
+   */
+  template<typename... Args>
+  CompiledAssignment(const Eigen::Ref<MatrixType> & to, Args &&... args)
+  : WBase(WParse::get(std::forward<Args>(args)...)), MBase(MParse::get(std::forward<Args>(args)...)),
+    SBase(SParse::get(std::forward<Args>(args)...)), to_(to)
+  {
+    static_assert(!(isMatrix<MatrixType>::value && F == CONSTANT), "Constant source is only for vectors.");
+  }
+
+public:
+  template<typename U = MatrixType>
+  typename std::enable_if<!use_product_cache<U, A, W, M, F>::value>::type run()
+  {
+    // There is room for speed improvement by switching at runtime in function of the
+    // matrices sizes, in particular for M = GENERAL, it seems that lazy product is
+    // faster for small matrices (but slower for bigger ones)
+    this->assign(to_, this->cache(this->applyWeightMult(this->applyMatrixMult(this->from()))));
+  }
+
+  template<typename U = MatrixType>
+  typename std::enable_if<use_product_cache<U, A, W, M, F>::value && !use_assign_cache<U, A, W, M, F>::value>::type run()
+  {
+    // FIXME have rather a resize method called in the constructor (and whenever
+    // one of the argument in the product is changed). This would require
+    // a CustomProduct class to be used instead of a function pointer for
+    // MatrixMultBase<Custom>, to get the column size of the product
 #ifdef AUTHORIZE_MALLOC_FOR_CACHE
-      if (!Eigen::internal::is_malloc_allowed())
-      {
-        Eigen::internal::set_is_malloc_allowed(true);
-        this->applyMatrixMultCached(this->cache(), this->from());
-        Eigen::internal::set_is_malloc_allowed(false);
-      }
-      else
-#endif
-      {
-        this->applyMatrixMultCached(this->cache(), this->from());
-      }
-      this->assign(to_, this->applyWeightMult(this->cache()));
-    }
-
-    template<typename U = MatrixType>
-    typename std::enable_if<use_product_cache<U, A, W, M, F>::value
-                &&  use_assign_cache<U, A, W, M, F>::value>::type run()
+    if(!Eigen::internal::is_malloc_allowed())
     {
+      Eigen::internal::set_is_malloc_allowed(true);
+      this->applyMatrixMultCached(this->cache(), this->from());
+      Eigen::internal::set_is_malloc_allowed(false);
+    }
+    else
+#endif
+    {
+      this->applyMatrixMultCached(this->cache(), this->from());
+    }
+    this->assign(to_, this->applyWeightMult(this->cache()));
+  }
+
+  template<typename U = MatrixType>
+  typename std::enable_if<use_product_cache<U, A, W, M, F>::value && use_assign_cache<U, A, W, M, F>::value>::type run()
+  {
 #ifdef AUTHORIZE_MALLOC_FOR_CACHE
-      if (!Eigen::internal::is_malloc_allowed())
-      {
-        Eigen::internal::set_is_malloc_allowed(true);
-        this->applyMatrixMultCached(this->cache(), this->from());
-        Eigen::internal::set_is_malloc_allowed(false);
-      }
-      else
+    if(!Eigen::internal::is_malloc_allowed())
+    {
+      Eigen::internal::set_is_malloc_allowed(true);
+      this->applyMatrixMultCached(this->cache(), this->from());
+      Eigen::internal::set_is_malloc_allowed(false);
+    }
+    else
 #endif
-      {
-        this->applyMatrixMultCached(this->cache(), this->from());
-      }
-      this->cache() = this->applyWeightMult(this->cache());
-      this->assign(to_, this->cache());
-    }
-
-    void to(const Eigen::Ref<MatrixType>& to)
     {
-      // We want to do to_ = to but there is no operator= for Eigen::Ref,
-      // so we need to use a placement new.
-      new (&to_) Eigen::Ref<MatrixType>(to);
+      this->applyMatrixMultCached(this->cache(), this->from());
     }
+    this->cache() = this->applyWeightMult(this->cache());
+    this->assign(to_, this->cache());
+  }
 
-  private:
-    /** Warning: it is the user responsability to ensure that the matrix/vector
-    * pointed to by from_, to_ and, if applicable, M_ stay alive.*/
-    Eigen::Ref<MatrixType> to_;
-
-    template<typename MatrixType_>
-    friend class CompiledAssignmentWrapper;
-  };
-
-  /** Specialization for F=0. The class does nothing in the general case.*/
-  template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M>
-  class CompiledAssignment<MatrixType, A, W, M, ZERO>
+  void to(const Eigen::Ref<MatrixType> & to)
   {
-  public:
-    using SourceType = Eigen::Ref<const MatrixType>;
-  
-  private:
-    CompiledAssignment(const Eigen::Ref<MatrixType>& to) : to_(to) {}
+    // We want to do to_ = to but there is no operator= for Eigen::Ref,
+    // so we need to use a placement new.
+    new(&to_) Eigen::Ref<MatrixType>(to);
+  }
 
-  public:
-    void run() {/* Do nothing */ }
-    void from(const Eigen::Ref<const MatrixType>&) {/* Do nothing */ }
-    void to(const Eigen::Ref<MatrixType>& to)
-    {
-      // We want to do to_ = to but there is no operator= for Eigen::Ref,
-      // so we need to use a placement new.
-      new (&to_) Eigen::Ref<MatrixType>(to);
-    }
+private:
+  /** Warning: it is the user responsability to ensure that the matrix/vector
+   * pointed to by from_, to_ and, if applicable, M_ stay alive.*/
+  Eigen::Ref<MatrixType> to_;
 
-  private:
-    Eigen::Ref<MatrixType> to_;
+  template<typename MatrixType_>
+  friend class CompiledAssignmentWrapper;
+};
 
-    template<typename MatrixType_>
-    friend class CompiledAssignmentWrapper;
-  };
+/** Specialization for F=0. The class does nothing in the general case.*/
+template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M>
+class CompiledAssignment<MatrixType, A, W, M, ZERO>
+{
+public:
+  using SourceType = Eigen::Ref<const MatrixType>;
 
+private:
+  CompiledAssignment(const Eigen::Ref<MatrixType> & to) : to_(to) {}
 
-  /** Specialization for F=0 and A=COPY.*/
-  template<typename MatrixType, WeightMult W, MatrixMult M>
-  class CompiledAssignment<MatrixType, COPY, W, M, ZERO>
+public:
+  void run()
+  { /* Do nothing */
+  }
+  void from(const Eigen::Ref<const MatrixType> &)
+  { /* Do nothing */
+  }
+  void to(const Eigen::Ref<MatrixType> & to)
   {
-  public:
-    using SourceType = Eigen::Ref<const MatrixType>;
+    // We want to do to_ = to but there is no operator= for Eigen::Ref,
+    // so we need to use a placement new.
+    new(&to_) Eigen::Ref<MatrixType>(to);
+  }
 
-  private:
-    CompiledAssignment(const Eigen::Ref<MatrixType>& to) : to_(to) {}
+private:
+  Eigen::Ref<MatrixType> to_;
 
-  public:
-    void run() { to_.setZero(); }
-    void from(const Eigen::Ref<const MatrixType>&) {/* Do nothing */ }
-    void to(const Eigen::Ref<MatrixType>& to)
-    {
-      // We want to do to_ = to but there is no operator= for Eigen::Ref,
-      // so we need to use a placement new.
-      new (&to_) Eigen::Ref<MatrixType>(to);
-    }
+  template<typename MatrixType_>
+  friend class CompiledAssignmentWrapper;
+};
 
-  private:
-    Eigen::Ref<MatrixType> to_;
+/** Specialization for F=0 and A=COPY.*/
+template<typename MatrixType, WeightMult W, MatrixMult M>
+class CompiledAssignment<MatrixType, COPY, W, M, ZERO>
+{
+public:
+  using SourceType = Eigen::Ref<const MatrixType>;
 
-    template<typename MatrixType_>
-    friend class CompiledAssignmentWrapper;
-  };
+private:
+  CompiledAssignment(const Eigen::Ref<MatrixType> & to) : to_(to) {}
 
-  /** Specialization for F=0 and A=MIN.*/
-  template<typename MatrixType, WeightMult W, MatrixMult M>
-  class CompiledAssignment<MatrixType, MIN, W, M, ZERO>
+public:
+  void run() { to_.setZero(); }
+  void from(const Eigen::Ref<const MatrixType> &)
+  { /* Do nothing */
+  }
+  void to(const Eigen::Ref<MatrixType> & to)
   {
-  public:
-    using SourceType = Eigen::Ref<const MatrixType>;
+    // We want to do to_ = to but there is no operator= for Eigen::Ref,
+    // so we need to use a placement new.
+    new(&to_) Eigen::Ref<MatrixType>(to);
+  }
 
-  private:
-    CompiledAssignment(const Eigen::Ref<MatrixType>& to) : to_(to) {}
+private:
+  Eigen::Ref<MatrixType> to_;
 
-  public:
-    void run() { to_.array() = to_.array().min(0); }
-    void from(const Eigen::Ref<const MatrixType>&) {/* Do nothing */ }
-    void to(const Eigen::Ref<MatrixType>& to)
-    {
-      new (&to_) Eigen::Ref<MatrixType>(to);
-    }
+  template<typename MatrixType_>
+  friend class CompiledAssignmentWrapper;
+};
 
-  private:
-    Eigen::Ref<MatrixType> to_;
+/** Specialization for F=0 and A=MIN.*/
+template<typename MatrixType, WeightMult W, MatrixMult M>
+class CompiledAssignment<MatrixType, MIN, W, M, ZERO>
+{
+public:
+  using SourceType = Eigen::Ref<const MatrixType>;
 
-    template<typename MatrixType_>
-    friend class CompiledAssignmentWrapper;
-  };
+private:
+  CompiledAssignment(const Eigen::Ref<MatrixType> & to) : to_(to) {}
 
-  /** Specialization for F=0 and A=MAX.*/
-  template<typename MatrixType, WeightMult W, MatrixMult M>
-  class CompiledAssignment<MatrixType, MAX, W, M, ZERO>
-  {
-  public:
-    using SourceType = Eigen::Ref<const MatrixType>;
+public:
+  void run() { to_.array() = to_.array().min(0); }
+  void from(const Eigen::Ref<const MatrixType> &)
+  { /* Do nothing */
+  }
+  void to(const Eigen::Ref<MatrixType> & to) { new(&to_) Eigen::Ref<MatrixType>(to); }
 
-  private:
-    CompiledAssignment(const Eigen::Ref<MatrixType>& to) : to_(to) {}
+private:
+  Eigen::Ref<MatrixType> to_;
 
-  public:
-    void run() { to_.array() = to_.array().max(0); }
-    void from(const Eigen::Ref<const MatrixType>&) {/* Do nothing */ }
-    void to(const Eigen::Ref<MatrixType>& to)
-    {
-      new (&to_) Eigen::Ref<MatrixType>(to);
-    }
+  template<typename MatrixType_>
+  friend class CompiledAssignmentWrapper;
+};
 
-  private:
-    Eigen::Ref<MatrixType> to_;
+/** Specialization for F=0 and A=MAX.*/
+template<typename MatrixType, WeightMult W, MatrixMult M>
+class CompiledAssignment<MatrixType, MAX, W, M, ZERO>
+{
+public:
+  using SourceType = Eigen::Ref<const MatrixType>;
 
-    template<typename MatrixType_>
-    friend class CompiledAssignmentWrapper;
-  };
+private:
+  CompiledAssignment(const Eigen::Ref<MatrixType> & to) : to_(to) {}
 
-}  // namespace internal
+public:
+  void run() { to_.array() = to_.array().max(0); }
+  void from(const Eigen::Ref<const MatrixType> &)
+  { /* Do nothing */
+  }
+  void to(const Eigen::Ref<MatrixType> & to) { new(&to_) Eigen::Ref<MatrixType>(to); }
 
-}  // namespace scheme
+private:
+  Eigen::Ref<MatrixType> to_;
 
-}  // namespace tvm
+  template<typename MatrixType_>
+  friend class CompiledAssignmentWrapper;
+};
+
+} // namespace internal
+
+} // namespace scheme
+
+} // namespace tvm

--- a/include/tvm/scheme/internal/CompiledAssignment.h
+++ b/include/tvm/scheme/internal/CompiledAssignment.h
@@ -84,8 +84,7 @@ using isMatrix = typename std::conditional<MatrixType::ColsAtCompileTime != 1, s
 
 /** Dummy type for constructors with no arguments*/
 class NoArg
-{
-};
+{};
 
 /** Helper structure to get the N-th argument in a function call.
  * \sa ParseArg
@@ -122,8 +121,7 @@ public:
  */
 template<int N>
 class ParseArg : public std::conditional<(N >= 0), ParseArg_<N>, ParseNoArg_>::type
-{
-};
+{};
 
 /** A dummy helper function to build hasNoArgCtor*/
 template<typename T>
@@ -146,8 +144,7 @@ std::false_type hasNoArgCtor_(...);
  */
 template<typename T>
 class hasNoArgCtor : public decltype(hasNoArgCtor_<T>(0))
-{
-};
+{};
 
 /** Given a list of types, count how many of then havec a constructor
  * accepting NoArg
@@ -215,36 +212,31 @@ private:
  */
 template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F>
 class use_assign_cache : public std::false_type
-{
-};
+{};
 
 /** Specialization for min/max with general matrix product. In this case, we
  * use the cache
  */
 template<typename MatrixType, WeightMult W>
 class use_assign_cache<MatrixType, MIN, W, GENERAL, EXTERNAL> : public std::true_type
-{
-};
+{};
 template<typename MatrixType, WeightMult W>
 class use_assign_cache<MatrixType, MAX, W, GENERAL, EXTERNAL> : public std::true_type
-{
-};
+{};
 
 /** Specialization for GENERAL*CONSTANT. This should not be necessary, but
  * the product needs a temporary. Maybe it's not the case anymore with Eigen 3.3.
  */
 template<typename MatrixType, AssignType A, WeightMult W>
 class use_assign_cache<MatrixType, A, W, GENERAL, CONSTANT> : public std::true_type
-{
-};
+{};
 
 /** Traits for deciding whether or not to use a cache for the product.
  * By default, no cache is used.
  */
 template<typename MatrixType, AssignType A, WeightMult W, MatrixMult M, Source F>
 class use_product_cache : public std::false_type
-{
-};
+{};
 
 /** Specialization for GENERAL product with diagonal weight
  *
@@ -252,18 +244,15 @@ class use_product_cache : public std::false_type
  */
 template<typename MatrixType, AssignType A>
 class use_product_cache<MatrixType, A, DIAGONAL, GENERAL, EXTERNAL> : public std::true_type
-{
-};
+{};
 template<typename MatrixType, AssignType A>
 class use_product_cache<MatrixType, A, DIAGONAL, GENERAL, CONSTANT> : public std::true_type
-{
-};
+{};
 
 /** Base class for the assignation */
 template<AssignType A>
 class AssignBase
-{
-};
+{};
 
 template<>
 class AssignBase<COPY>
@@ -353,8 +342,7 @@ public:
 /** Base class for the multiplication by a scalar*/
 template<WeightMult W>
 class WeightMultBase
-{
-};
+{};
 
 /** Specialization for NONE */
 template<>
@@ -460,8 +448,7 @@ private:
 /** Base class for the multiplication by a matrix*/
 template<typename MatrixType, MatrixMult M>
 class MatrixMultBase
-{
-};
+{};
 
 /** Partial specialization for IDENTITY*/
 template<typename MatrixType>
@@ -612,8 +599,7 @@ private:
 /** Partial specialization for ZERO*/
 template<typename MatrixType>
 class SourceBase<MatrixType, ZERO>
-{
-};
+{};
 
 /** The main class. Its run method perfoms the assignment t = op(t, w*M*f)
  * (if f is a vector) or t = op(t, w*f*M) (if f is a matrix)

--- a/include/tvm/scheme/internal/CompiledAssignmentWrapper.h
+++ b/include/tvm/scheme/internal/CompiledAssignmentWrapper.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -43,224 +43,218 @@ namespace scheme
 
 namespace internal
 {
-  /** This class wraps a CompiledAssignment so as to hide the template
-    * machinery. The three member functions of CompiledAssignment are
-    * exposed: run, from, to.
-    *
-    * \internal Internally we hold a void* pointer to the CompiledAssignment.
-    * We also hold pointer to functions that are templated by the actual type of
-    * the assignment. Those functions allow casting back the void* to the true
-    * type of the assignment.
-    */
-  template<typename MatrixType>
-  class CompiledAssignmentWrapper
-  {
-  public:
-    CompiledAssignmentWrapper();
-    CompiledAssignmentWrapper(const CompiledAssignmentWrapper&);
-    CompiledAssignmentWrapper(CompiledAssignmentWrapper&&) = default;
-    ~CompiledAssignmentWrapper() = default;
+/** This class wraps a CompiledAssignment so as to hide the template
+ * machinery. The three member functions of CompiledAssignment are
+ * exposed: run, from, to.
+ *
+ * \internal Internally we hold a void* pointer to the CompiledAssignment.
+ * We also hold pointer to functions that are templated by the actual type of
+ * the assignment. Those functions allow casting back the void* to the true
+ * type of the assignment.
+ */
+template<typename MatrixType>
+class CompiledAssignmentWrapper
+{
+public:
+  CompiledAssignmentWrapper();
+  CompiledAssignmentWrapper(const CompiledAssignmentWrapper &);
+  CompiledAssignmentWrapper(CompiledAssignmentWrapper &&) = default;
+  ~CompiledAssignmentWrapper() = default;
 
-    CompiledAssignmentWrapper& operator=(const CompiledAssignmentWrapper&);
-    CompiledAssignmentWrapper& operator=(CompiledAssignmentWrapper&&) = default;
+  CompiledAssignmentWrapper & operator=(const CompiledAssignmentWrapper &);
+  CompiledAssignmentWrapper & operator=(CompiledAssignmentWrapper &&) = default;
 
-    /** Run the assignment*/
-    void run();
-    /** Change the source (for assignement built with Source == CONSTANT)
-      * \throw std::runtime_error if used for Source != CONSTANT
-      */
-    void from(double);
-    /** Change the source (for assignement built with Source != CONSTANT)
-      * \throw std::runtime_error if used for Source == CONSTANT
-      */
-    void from(const Eigen::Ref<const MatrixType>& from);
-    /** Change the destination of the assignment*/
-    void to(const Eigen::Ref<MatrixType>&);
+  /** Run the assignment*/
+  void run();
+  /** Change the source (for assignement built with Source == CONSTANT)
+   * \throw std::runtime_error if used for Source != CONSTANT
+   */
+  void from(double);
+  /** Change the source (for assignement built with Source != CONSTANT)
+   * \throw std::runtime_error if used for Source == CONSTANT
+   */
+  void from(const Eigen::Ref<const MatrixType> & from);
+  /** Change the destination of the assignment*/
+  void to(const Eigen::Ref<MatrixType> &);
 
-    /** Create an assignement and its wrapper.
-      * \param args to [, from] [, weight] [, multiplier] where
-      * - \p to is the destination matrix or vector
-      * - \p from is the source (nothing for F = ZERO, a double for F = CONSTANT,
-      *   and a matrix or vector for F = EXTERNAL)
-      * - \p weight is the weight to apply (nothing for W = NONE and W = MINUS, a
-      *   double for W = SCALAR, and a vector for W = DIAGONAL or 
-      *   W = INVERSE_DIAGONAL)
-      * - \p multiplier is the matrix multiplier (nothing for M = IDENTITY, a
-      *   matrix for M = GENERAL, and a custom object for M = CUSTOM)
-      */
-    template<AssignType A, WeightMult W, MatrixMult M, Source F = EXTERNAL, typename... Args>
-    static CompiledAssignmentWrapper make(Args&&... args);
+  /** Create an assignement and its wrapper.
+   * \param args to [, from] [, weight] [, multiplier] where
+   * - \p to is the destination matrix or vector
+   * - \p from is the source (nothing for F = ZERO, a double for F = CONSTANT,
+   *   and a matrix or vector for F = EXTERNAL)
+   * - \p weight is the weight to apply (nothing for W = NONE and W = MINUS, a
+   *   double for W = SCALAR, and a vector for W = DIAGONAL or
+   *   W = INVERSE_DIAGONAL)
+   * - \p multiplier is the matrix multiplier (nothing for M = IDENTITY, a
+   *   matrix for M = GENERAL, and a custom object for M = CUSTOM)
+   */
+  template<AssignType A, WeightMult W, MatrixMult M, Source F = EXTERNAL, typename... Args>
+  static CompiledAssignmentWrapper make(Args &&... args);
 
-  private:
-    CompiledAssignmentWrapper(void(*deleter)(void*));
+private:
+  CompiledAssignmentWrapper(void (*deleter)(void *));
 
-    /** call ca->run*/
-    template<typename T> static void srun(void* ca);
-    /** call the destructor of ca*/
-    template<typename T> static void sdelete(void* ca);
-    /** call ca->from*/
-    template<typename T> static void sfrom(void* ca, const typename T::SourceType& f);
-    /** call ca->to*/
-    template<typename T> static void sto(void* ca, const Eigen::Ref<MatrixType>& from);
-    /** return a copy of ca*/
-    template<typename T> static void* sclone(void* ca);
-
-    /** A pointer to CompiledAssignment whose type has been erased.*/
-    std::unique_ptr<void, void(*)(void*)> ca_;
-    /** Pointer to srun<T> where T is the actual type of the CompiledAssignment.*/
-    void(*run_)(void*);
-    /** Pointer to sfrom<T> if the assignment has a CONSTANT Source, a null
-      * pointer otherwise. T is the actual type of the CompileAssignment.
-      */
-    void(*fromd_)(void*, const double&);
-    /** Pointer to sfrom<T> if the assignment has not a CONSTANT Source, a null
-      * pointer otherwise. T is the actual type of the CompileAssignment.
-      */
-    void(*fromm_)(void*, const Eigen::Ref<const MatrixType>&);
-    /** Pointer to srun<T> where T is the actual type of the CompiledAssignment.*/
-    void(*to_)(void*, const Eigen::Ref<MatrixType>&);
-    /** Pointer to sclone<T> where T is the actual type of the CompiledAssignment.*/
-    void*(*clone_)(void*);
-  };
-
-
-  template<typename MatrixType>
+  /** call ca->run*/
   template<typename T>
-  inline void CompiledAssignmentWrapper<MatrixType>::srun(void* ca)
-  {
-    static_cast<T*>(ca)->run();
-  }
-
-  template<typename MatrixType>
+  static void srun(void * ca);
+  /** call the destructor of ca*/
   template<typename T>
-  inline void CompiledAssignmentWrapper<MatrixType>::sdelete(void* ca)
-  {
-    delete static_cast<T*>(ca);
-  }
-
-  template<typename MatrixType>
+  static void sdelete(void * ca);
+  /** call ca->from*/
   template<typename T>
-  inline void CompiledAssignmentWrapper<MatrixType>::sfrom(void* ca, const typename T::SourceType& f)
-  {
-    static_cast<T*>(ca)->from(f);
-  }
-
-  template<typename MatrixType>
+  static void sfrom(void * ca, const typename T::SourceType & f);
+  /** call ca->to*/
   template<typename T>
-  inline void CompiledAssignmentWrapper<MatrixType>::sto(void* ca, const Eigen::Ref<MatrixType>& t)
-  {
-    static_cast<T*>(ca)->to(t);
-  }
-
-  template<typename MatrixType>
+  static void sto(void * ca, const Eigen::Ref<MatrixType> & from);
+  /** return a copy of ca*/
   template<typename T>
-  inline void* CompiledAssignmentWrapper<MatrixType>::sclone(void* ca)
+  static void * sclone(void * ca);
+
+  /** A pointer to CompiledAssignment whose type has been erased.*/
+  std::unique_ptr<void, void (*)(void *)> ca_;
+  /** Pointer to srun<T> where T is the actual type of the CompiledAssignment.*/
+  void (*run_)(void *);
+  /** Pointer to sfrom<T> if the assignment has a CONSTANT Source, a null
+   * pointer otherwise. T is the actual type of the CompileAssignment.
+   */
+  void (*fromd_)(void *, const double &);
+  /** Pointer to sfrom<T> if the assignment has not a CONSTANT Source, a null
+   * pointer otherwise. T is the actual type of the CompileAssignment.
+   */
+  void (*fromm_)(void *, const Eigen::Ref<const MatrixType> &);
+  /** Pointer to srun<T> where T is the actual type of the CompiledAssignment.*/
+  void (*to_)(void *, const Eigen::Ref<MatrixType> &);
+  /** Pointer to sclone<T> where T is the actual type of the CompiledAssignment.*/
+  void * (*clone_)(void *);
+};
+
+template<typename MatrixType>
+template<typename T>
+inline void CompiledAssignmentWrapper<MatrixType>::srun(void * ca)
+{
+  static_cast<T *>(ca)->run();
+}
+
+template<typename MatrixType>
+template<typename T>
+inline void CompiledAssignmentWrapper<MatrixType>::sdelete(void * ca)
+{
+  delete static_cast<T *>(ca);
+}
+
+template<typename MatrixType>
+template<typename T>
+inline void CompiledAssignmentWrapper<MatrixType>::sfrom(void * ca, const typename T::SourceType & f)
+{
+  static_cast<T *>(ca)->from(f);
+}
+
+template<typename MatrixType>
+template<typename T>
+inline void CompiledAssignmentWrapper<MatrixType>::sto(void * ca, const Eigen::Ref<MatrixType> & t)
+{
+  static_cast<T *>(ca)->to(t);
+}
+
+template<typename MatrixType>
+template<typename T>
+inline void * CompiledAssignmentWrapper<MatrixType>::sclone(void * ca)
+{
+  return new T(*static_cast<T *>(ca));
+}
+
+template<typename MatrixType>
+template<AssignType A, WeightMult W, MatrixMult M, Source F, typename... Args>
+inline CompiledAssignmentWrapper<MatrixType> CompiledAssignmentWrapper<MatrixType>::make(Args &&... args)
+{
+  using CA = CompiledAssignment<MatrixType, A, W, M, F>;
+  CompiledAssignmentWrapper<MatrixType> w(sdelete<CA>);
+  w.run_ = srun<CA>;
+  w.fromd_ = F == CONSTANT ? reinterpret_cast<void (*)(void *, const double &)>(&sfrom<CA>) : nullptr;
+  w.fromm_ =
+      F != CONSTANT ? reinterpret_cast<void (*)(void *, const Eigen::Ref<const MatrixType> &)>(&sfrom<CA>) : nullptr;
+  w.to_ = sto<CA>;
+  w.clone_ = sclone<CA>;
+  w.ca_.reset(new CA(std::forward<Args>(args)...));
+  return w;
+}
+
+template<typename MatrixType>
+inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper()
+: ca_(nullptr, nullptr), run_(nullptr), fromd_(nullptr), fromm_(nullptr), to_(nullptr), clone_(nullptr)
+{
+}
+
+template<typename MatrixType>
+inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper(void (*deleter)(void *))
+: ca_(nullptr, deleter), run_(nullptr), fromd_(nullptr), fromm_(nullptr), to_(nullptr), clone_(nullptr)
+{
+}
+
+template<typename MatrixType>
+inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper(const CompiledAssignmentWrapper & other)
+: ca_(other.clone_(other.ca_.get()), other.ca_.get_deleter()), run_(other.run_), fromd_(other.fromd_),
+  fromm_(other.fromm_), to_(other.to_), clone_(other.clone_)
+{
+}
+
+template<typename MatrixType>
+inline CompiledAssignmentWrapper<MatrixType> & CompiledAssignmentWrapper<MatrixType>::operator=(
+    const CompiledAssignmentWrapper & other)
+{
+  ca_.reset(other.clone_(other.ca_.get()));
+  ca_.get_deleter() = other.ca_.get_deleter();
+  run_ = other.run_;
+  fromd_ = other.fromd_;
+  fromm_ = other.fromm_;
+  to_ = other.to_;
+  clone_ = other.clone_;
+
+  return *this;
+}
+
+template<typename MatrixType>
+inline void CompiledAssignmentWrapper<MatrixType>::run()
+{
+  run_(ca_.get());
+}
+
+template<typename MatrixType>
+inline void CompiledAssignmentWrapper<MatrixType>::from(double d)
+{
+  if(fromd_)
   {
-    return new T(*static_cast<T*>(ca));
+    fromd_(ca_.get(), d);
   }
-
-  template<typename MatrixType>
-  template<AssignType A, WeightMult W, MatrixMult M, Source F, typename ...Args>
-  inline CompiledAssignmentWrapper<MatrixType> CompiledAssignmentWrapper<MatrixType>::make(Args &&... args)
+  else
   {
-    using CA = CompiledAssignment<MatrixType, A, W, M, F>;
-    CompiledAssignmentWrapper<MatrixType> w(sdelete<CA>);
-    w.run_ = srun<CA>;
-    w.fromd_ = F==CONSTANT?reinterpret_cast<void(*)(void*, const double&)>(&sfrom<CA>):nullptr;
-    w.fromm_ = F!=CONSTANT?reinterpret_cast<void(*)(void*, const Eigen::Ref<const MatrixType>&)>(&sfrom<CA>) :nullptr;
-    w.to_ = sto<CA>;
-    w.clone_ = sclone<CA>;
-    w.ca_.reset(new CA(std::forward<Args>(args)...));
-    return w;
+    throw std::runtime_error(
+        "Method from(double) is invalid for this assignment, try from(const Eigen::Ref<const MatrixType>&) instead");
   }
+}
 
-  template<typename MatrixType>
-  inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper()
-    : ca_(nullptr, nullptr)
-    , run_(nullptr)
-    , fromd_(nullptr)
-    , fromm_(nullptr)
-    , to_(nullptr)
-    , clone_(nullptr)
+template<typename MatrixType>
+inline void CompiledAssignmentWrapper<MatrixType>::from(const Eigen::Ref<const MatrixType> & f)
+{
+  if(fromm_)
   {
+    fromm_(ca_.get(), f);
   }
-
-  template<typename MatrixType>
-  inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper(void(*deleter)(void*))
-    : ca_(nullptr, deleter)
-    , run_(nullptr)
-    , fromd_(nullptr)
-    , fromm_(nullptr)
-    , to_(nullptr)
-    , clone_(nullptr)
+  else
   {
+    throw std::runtime_error(
+        "Method from(const Eigen::Ref<const MatrixType>&) is invalid for this assignment, try from(double) instead");
   }
+}
 
-  template<typename MatrixType>
-  inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper(const CompiledAssignmentWrapper& other)
-    : ca_(other.clone_(other.ca_.get()), other.ca_.get_deleter())
-    , run_(other.run_)
-    , fromd_(other.fromd_)
-    , fromm_(other.fromm_)
-    , to_(other.to_)
-    , clone_(other.clone_)
-  {
-  }
+template<typename MatrixType>
+inline void CompiledAssignmentWrapper<MatrixType>::to(const Eigen::Ref<MatrixType> & t)
+{
+  to_(ca_.get(), t);
+}
 
-  template<typename MatrixType>
-  inline CompiledAssignmentWrapper<MatrixType>& CompiledAssignmentWrapper<MatrixType>::operator=(const CompiledAssignmentWrapper& other)
-  {
-    ca_.reset(other.clone_(other.ca_.get()));
-    ca_.get_deleter() = other.ca_.get_deleter();
-    run_ = other.run_;
-    fromd_ = other.fromd_;
-    fromm_ = other.fromm_;
-    to_ = other.to_;
-    clone_ = other.clone_;
+} // namespace internal
 
-    return *this;
-  }
+} // namespace scheme
 
-  template<typename MatrixType>
-  inline void CompiledAssignmentWrapper<MatrixType>::run()
-  {
-    run_(ca_.get());
-  }
-
-  template<typename MatrixType>
-  inline void CompiledAssignmentWrapper<MatrixType>::from(double d)
-  {
-    if (fromd_)
-    {
-      fromd_(ca_.get(), d);
-    }
-    else
-    {
-      throw std::runtime_error("Method from(double) is invalid for this assignment, try from(const Eigen::Ref<const MatrixType>&) instead");
-    }
-  }
-
-  template<typename MatrixType>
-  inline void CompiledAssignmentWrapper<MatrixType>::from(const Eigen::Ref<const MatrixType>& f)
-  {
-    if (fromm_)
-    {
-      fromm_(ca_.get(), f);
-    }
-    else
-    {
-      throw std::runtime_error("Method from(const Eigen::Ref<const MatrixType>&) is invalid for this assignment, try from(double) instead");
-    }
-  }
-
-  template<typename MatrixType>
-  inline void CompiledAssignmentWrapper<MatrixType>::to(const Eigen::Ref<MatrixType>& t)
-  {
-    to_(ca_.get(), t);
-  }
-
-}  // namespace internal
-
-}  // namespace scheme
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/scheme/internal/CompiledAssignmentWrapper.h
+++ b/include/tvm/scheme/internal/CompiledAssignmentWrapper.h
@@ -155,21 +155,18 @@ inline CompiledAssignmentWrapper<MatrixType> CompiledAssignmentWrapper<MatrixTyp
 template<typename MatrixType>
 inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper()
 : ca_(nullptr, nullptr), run_(nullptr), fromd_(nullptr), fromm_(nullptr), to_(nullptr), clone_(nullptr)
-{
-}
+{}
 
 template<typename MatrixType>
 inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper(void (*deleter)(void *))
 : ca_(nullptr, deleter), run_(nullptr), fromd_(nullptr), fromm_(nullptr), to_(nullptr), clone_(nullptr)
-{
-}
+{}
 
 template<typename MatrixType>
 inline CompiledAssignmentWrapper<MatrixType>::CompiledAssignmentWrapper(const CompiledAssignmentWrapper & other)
 : ca_(other.clone_(other.ca_.get()), other.ca_.get_deleter()), run_(other.run_), fromd_(other.fromd_),
   fromm_(other.fromm_), to_(other.to_), clone_(other.clone_)
-{
-}
+{}
 
 template<typename MatrixType>
 inline CompiledAssignmentWrapper<MatrixType> & CompiledAssignmentWrapper<MatrixType>::operator=(

--- a/include/tvm/scheme/internal/CompiledAssignmentWrapper.h
+++ b/include/tvm/scheme/internal/CompiledAssignmentWrapper.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/internal/LinearizedProblemComputationData.h
+++ b/include/tvm/scheme/internal/LinearizedProblemComputationData.h
@@ -8,59 +8,57 @@
 
 namespace tvm::scheme::internal
 {
-  /** An extension of ProblemComputationData containing data specific to
-    * linearized problems, in particular a mapping from task to constraint.
-    *
-    * \internal Keeping a local mapping is necessary, because addition and
-    * removal of tasks on the problem may change the association between a
-    * task and a constraint (LinearizedControlProblem recreates a constraint
-    * if a task is removed and added again).
-    */
-  class LinearizedProblemComputationData : public ProblemComputationData
+/** An extension of ProblemComputationData containing data specific to
+ * linearized problems, in particular a mapping from task to constraint.
+ *
+ * \internal Keeping a local mapping is necessary, because addition and
+ * removal of tasks on the problem may change the association between a
+ * task and a constraint (LinearizedControlProblem recreates a constraint
+ * if a task is removed and added again).
+ */
+class LinearizedProblemComputationData : public ProblemComputationData
+{
+public:
+  /** Add a constraint \c c and the task \c tr it is derived from so as to keep
+   * the mapping \c tr -> \c c
+   */
+  void addConstraint(TaskWithRequirements * tr, const LinearConstraintWithRequirements & c)
   {
-  public:
-    /** Add a constraint \c c and the task \c tr it is derived from so as to keep
-      * the mapping \c tr -> \c c
-      */
-    void addConstraint(TaskWithRequirements* tr, const LinearConstraintWithRequirements& c)
-    {
-      assert(task2Constraint_.find(tr) == task2Constraint_.end());
-      task2Constraint_[tr] = c;
-    }
+    assert(task2Constraint_.find(tr) == task2Constraint_.end());
+    task2Constraint_[tr] = c;
+  }
 
-    /** Remove constraint corresponding to task \p tr.*/
-    void removeConstraint(TaskWithRequirements* tr)
-    {
-      task2Constraint_.erase(tr);
-    }
+  /** Remove constraint corresponding to task \p tr.*/
+  void removeConstraint(TaskWithRequirements * tr) { task2Constraint_.erase(tr); }
 
-    /** Add a mapping task -> constraint.*/
-    void addConstraints(const tvm::utils::internal::map<TaskWithRequirements*, LinearConstraintWithRequirements>& map)
-    {
-      task2Constraint_.insert(map.begin(), map.end());
-    }
+  /** Add a mapping task -> constraint.*/
+  void addConstraints(const tvm::utils::internal::map<TaskWithRequirements *, LinearConstraintWithRequirements> & map)
+  {
+    task2Constraint_.insert(map.begin(), map.end());
+  }
 
-    /** Access the constraint corresponding to \p tr.*/
-    const LinearConstraintWithRequirements& constraint(TaskWithRequirements* tr) const
-    {
-      return task2Constraint_.at(tr);
-    }
+  /** Access the constraint corresponding to \p tr.*/
+  const LinearConstraintWithRequirements & constraint(TaskWithRequirements * tr) const
+  {
+    return task2Constraint_.at(tr);
+  }
 
-    /** Access the constraint corresponding to \p tr, and return it as a std::optional.*/
-    std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>> constraintNoThrow(TaskWithRequirements* tr) const
-    {
-      auto it = task2Constraint_.find(tr);
-      if (it != task2Constraint_.end())
-        return it->second;
-      else
-        return {};
-    }
+  /** Access the constraint corresponding to \p tr, and return it as a std::optional.*/
+  std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>> constraintNoThrow(
+      TaskWithRequirements * tr) const
+  {
+    auto it = task2Constraint_.find(tr);
+    if(it != task2Constraint_.end())
+      return it->second;
+    else
+      return {};
+  }
 
-  protected:
-    /** Constructor, using the id of the solver.*/
-    LinearizedProblemComputationData(int solverId) : ProblemComputationData(solverId) {}
+protected:
+  /** Constructor, using the id of the solver.*/
+  LinearizedProblemComputationData(int solverId) : ProblemComputationData(solverId) {}
 
-  private:
-    tvm::utils::internal::map<TaskWithRequirements*, LinearConstraintWithRequirements> task2Constraint_;
-  };
-}
+private:
+  tvm::utils::internal::map<TaskWithRequirements *, LinearConstraintWithRequirements> task2Constraint_;
+};
+} // namespace tvm::scheme::internal

--- a/include/tvm/scheme/internal/MatrixAssignment.h
+++ b/include/tvm/scheme/internal/MatrixAssignment.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include <tvm/Variable.h> // Range
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
+#include <tvm/Variable.h> // Range
 #include <tvm/scheme/internal/AssignmentTarget.h>
 #include <tvm/scheme/internal/CompiledAssignmentWrapper.h>
 

--- a/include/tvm/scheme/internal/MatrixAssignment.h
+++ b/include/tvm/scheme/internal/MatrixAssignment.h
@@ -53,8 +53,7 @@ public:
 
   VectorSubstitutionAssignement(const CompiledAssignmentWrapper<Eigen::VectorXd> & a, VectorFunction getTarget)
   : assignment(a), getTargetVector(getTarget)
-  {
-  }
+  {}
 
   CompiledAssignmentWrapper<Eigen::VectorXd> assignment; // The underlying assignment
   VectorFunction getTargetVector;                        // The way to retrieve the target vector part
@@ -77,8 +76,7 @@ public:
                    RHSFunction getSource,
                    VectorFunction getTarget)
   : VectorSubstitutionAssignement(a, getTarget), useSource(useSource), getSourceVector(getSource)
-  {
-  }
+  {}
 
   bool useSource;              // Whether or not this assignment uses a source
   RHSFunction getSourceVector; // The way to retrieve the source vector.

--- a/include/tvm/scheme/internal/MatrixAssignment.h
+++ b/include/tvm/scheme/internal/MatrixAssignment.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
+#include <tvm/Variable.h> // Range
 #include <tvm/api.h>
 #include <tvm/defs.h>
-#include <tvm/Variable.h> // Range
 #include <tvm/scheme/internal/AssignmentTarget.h>
 #include <tvm/scheme/internal/CompiledAssignmentWrapper.h>
 
@@ -12,72 +12,75 @@
 
 namespace tvm::scheme::internal
 {
-  /** A structure grouping a matrix assignment and some of the elements that
-    * defined it.
-    */
-  class TVM_DLLAPI MatrixAssignment
+/** A structure grouping a matrix assignment and some of the elements that
+ * defined it.
+ */
+class TVM_DLLAPI MatrixAssignment
+{
+public:
+  /** Pointer type to a method of AssignmentTarget returning a matrix block.
+   * It is used to make a selection between A(), AFirstHalf() and ASecondHalf().
+   */
+  using MatrixFunction = MatrixRef (AssignmentTarget::*)(int, int) const;
+
+  CompiledAssignmentWrapper<Eigen::MatrixXd> assignment;
+  Variable * x;
+  Range colRange;
+  MatrixFunction getTargetMatrix;
+
+  /** Effectively update the output matrix of the underlying compiled assignment. */
+  void updateTarget(const AssignmentTarget & target);
+  /** Update the the column mapping of this assignment, based on the new variable
+   * layout specified by \p newVar.
+   * If \c updateMatrixTarget is \c true, the output matrix is effectively
+   * updated (if not, only \c colRange is changed, but the change is not
+   * reflected in the actual compiled assignment).
+   */
+  void updateMapping(const VariableVector & newVar, const AssignmentTarget & target, bool updateMatrixTarget);
+};
+
+/** A structure grouping a vector assignment and its target, for the case of
+ * substitutions.
+ */
+class TVM_DLLAPI VectorSubstitutionAssignement
+{
+public:
+  /** Pointer type to a method of AssignementTarget returning a vector segment.
+   * It is used to make a selection between b(), bFirstHalf(), bSecondHalf(),
+   * l() and u().
+   */
+  using VectorFunction = VectorRef (AssignmentTarget::*)() const;
+
+  VectorSubstitutionAssignement(const CompiledAssignmentWrapper<Eigen::VectorXd> & a, VectorFunction getTarget)
+  : assignment(a), getTargetVector(getTarget)
   {
-  public:
-    /** Pointer type to a method of AssignmentTarget returning a matrix block.
-      * It is used to make a selection between A(), AFirstHalf() and ASecondHalf().
-      */
-    using MatrixFunction = MatrixRef(AssignmentTarget::*)(int, int) const;
+  }
 
-    CompiledAssignmentWrapper<Eigen::MatrixXd> assignment;
-    Variable* x;
-    Range colRange;
-    MatrixFunction getTargetMatrix;
+  CompiledAssignmentWrapper<Eigen::VectorXd> assignment; // The underlying assignment
+  VectorFunction getTargetVector; // The way to retrieve the target vector part
+};
 
-    /** Effectively update the output matrix of the underlying compiled assignment. */
-    void updateTarget(const AssignmentTarget& target);
-    /** Update the the column mapping of this assignment, based on the new variable
-      * layout specified by \p newVar.
-      * If \c updateMatrixTarget is \c true, the output matrix is effectively
-      * updated (if not, only \c colRange is changed, but the change is not
-      * reflected in the actual compiled assignment).
-      */
-    void updateMapping(const VariableVector& newVar, const AssignmentTarget& target, bool updateMatrixTarget);
-  };
+/** A structure grouping a vector assignment and some of the elements that
+ * defined it.
+ */
+class TVM_DLLAPI VectorAssignment : public VectorSubstitutionAssignement
+{
+public:
+  /** Pointer type to a method of LinearConstraint returning a vector.
+   * It is used to make a selection between e(), l() and u().
+   */
+  using RHSFunction = const Eigen::VectorXd & (constraint::abstract::LinearConstraint::*)() const;
+  using VectorSubstitutionAssignement::VectorFunction;
 
-
-  /** A structure grouping a vector assignment and its target, for the case of
-    * substitutions.
-    */
-  class TVM_DLLAPI VectorSubstitutionAssignement
+  VectorAssignment(const CompiledAssignmentWrapper<Eigen::VectorXd> & a,
+                   bool useSource,
+                   RHSFunction getSource,
+                   VectorFunction getTarget)
+  : VectorSubstitutionAssignement(a, getTarget), useSource(useSource), getSourceVector(getSource)
   {
-  public:
-    /** Pointer type to a method of AssignementTarget returning a vector segment.
-      * It is used to make a selection between b(), bFirstHalf(), bSecondHalf(),
-      * l() and u().
-      */
-    using VectorFunction = VectorRef(AssignmentTarget::*)() const;
+  }
 
-    VectorSubstitutionAssignement(const CompiledAssignmentWrapper<Eigen::VectorXd>& a, VectorFunction getTarget)
-      : assignment(a), getTargetVector(getTarget)
-    {}
-
-    CompiledAssignmentWrapper<Eigen::VectorXd> assignment; // The underlying assignment
-    VectorFunction getTargetVector;                        // The way to retrieve the target vector part
-  };
-
-  /** A structure grouping a vector assignment and some of the elements that
-    * defined it.
-    */
-  class TVM_DLLAPI VectorAssignment : public VectorSubstitutionAssignement
-  {
-  public:
-    /** Pointer type to a method of LinearConstraint returning a vector.
-      * It is used to make a selection between e(), l() and u().
-      */
-    using RHSFunction = const Eigen::VectorXd& (constraint::abstract::LinearConstraint::*)() const;
-    using VectorSubstitutionAssignement::VectorFunction;
-
-    VectorAssignment(const CompiledAssignmentWrapper<Eigen::VectorXd>& a, bool useSource, RHSFunction getSource, VectorFunction getTarget)
-      : VectorSubstitutionAssignement(a, getTarget), useSource(useSource), getSourceVector(getSource)
-    {}
-
-    bool useSource;               // Whether or not this assignment uses a source
-    RHSFunction getSourceVector;  // The way to retrieve the source vector.
-  };
-}
-
+  bool useSource; // Whether or not this assignment uses a source
+  RHSFunction getSourceVector; // The way to retrieve the source vector.
+};
+} // namespace tvm::scheme::internal

--- a/include/tvm/scheme/internal/MatrixAssignment.h
+++ b/include/tvm/scheme/internal/MatrixAssignment.h
@@ -57,7 +57,7 @@ public:
   }
 
   CompiledAssignmentWrapper<Eigen::VectorXd> assignment; // The underlying assignment
-  VectorFunction getTargetVector; // The way to retrieve the target vector part
+  VectorFunction getTargetVector;                        // The way to retrieve the target vector part
 };
 
 /** A structure grouping a vector assignment and some of the elements that
@@ -80,7 +80,7 @@ public:
   {
   }
 
-  bool useSource; // Whether or not this assignment uses a source
+  bool useSource;              // Whether or not this assignment uses a source
   RHSFunction getSourceVector; // The way to retrieve the source vector.
 };
 } // namespace tvm::scheme::internal

--- a/include/tvm/scheme/internal/ProblemComputationData.h
+++ b/include/tvm/scheme/internal/ProblemComputationData.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include <tvm/VariableVector.h>
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
+#include <tvm/VariableVector.h>
 #include <tvm/scheme/internal/ProblemDefinitionEvent.h>
 
 #include <queue>

--- a/include/tvm/scheme/internal/ProblemComputationData.h
+++ b/include/tvm/scheme/internal/ProblemComputationData.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
+#include <tvm/VariableVector.h>
 #include <tvm/api.h>
 #include <tvm/defs.h>
-#include <tvm/VariableVector.h>
 #include <tvm/scheme/internal/ProblemDefinitionEvent.h>
 
 #include <queue>
@@ -13,153 +13,135 @@
 namespace tvm::scheme::internal
 {
 
-  /** Base class to be derived by each resolution scheme to hold all of the
-    * temporary memories and states related to the resolution of a problem.
-    * The rationale is that a resolution scheme is stateless, and when given
-    * for the first time a problem to solve, creates a ProblemComputationData
-    * that it gives to the problem and retrieves at each further resolution.
-    * A problem computation data further act as a queue of events changing the
-    * problem definition.
-    */
-  class TVM_DLLAPI ProblemComputationData
+/** Base class to be derived by each resolution scheme to hold all of the
+ * temporary memories and states related to the resolution of a problem.
+ * The rationale is that a resolution scheme is stateless, and when given
+ * for the first time a problem to solve, creates a ProblemComputationData
+ * that it gives to the problem and retrieves at each further resolution.
+ * A problem computation data further act as a queue of events changing the
+ * problem definition.
+ */
+class TVM_DLLAPI ProblemComputationData
+{
+public:
+  virtual ~ProblemComputationData() = default;
+
+  int solverId() const;
+
+  /** Add a variable if not already present. Return true if the variable was
+   * effectively added. The class counts how many time a variable was added.
+   */
+  bool addVariable(VariablePtr var);
+  /** Add a set of variables, calling addVariable(VariablePtr var) on each
+   * variable.
+   */
+  void addVariable(const VariableVector & vars);
+  /** Effectively remove a variable if as many calls were made to this method
+   * as to addVariable, for the given variable. Return true if the variable
+   * was really removed.
+   */
+  bool removeVariable(Variable * v);
+  /** Remove a set of variables, calling removeVariable(Variable* v) on each
+   * variable.
+   */
+  void removeVariable(const VariableVector & vars);
+  /** Get the variables of the problem.*/
+  const VariableVector & variables() const;
+
+  /** Set the value of the variables to that of the solution. */
+  void setVariablesToSolution();
+
+  /** Adding an event changing the problem definition, that needs to be handled
+   * by the resolution scheme. Events are stored in a queue (FIFO).
+   */
+  void addEvent(const ProblemDefinitionEvent & e);
+  /** Read and remove the first event in the queue. Need the queue to be non-empty.*/
+  ProblemDefinitionEvent popEvent();
+  /** Is the queue not empty?*/
+  bool hasEvents() const;
+
+protected:
+  ProblemComputationData(int solverId);
+  ProblemComputationData() = delete;
+
+  /** Need to put in x the solution of the computation. */
+  virtual void setVariablesToSolution_(VariableVector & x) = 0;
+
+  /** The problem variable*/
+  VariableVector x_;
+  /** Count on the number of time a variable was added to x_.*/
+  std::vector<int> varCount_;
+
+  /** Problem definition events*/
+  std::queue<ProblemDefinitionEvent> events_;
+
+private:
+  int solverId_;
+};
+
+inline int ProblemComputationData::solverId() const { return solverId_; }
+
+inline bool ProblemComputationData::addVariable(VariablePtr var)
+{
+  assert(x_.numberOfVariables() == varCount_.size());
+  int i = x_.addAndGetIndex(var);
+  if(i >= varCount_.size())
   {
-  public:
-    virtual ~ProblemComputationData() = default;
-
-    int solverId() const;
-
-    /** Add a variable if not already present. Return true if the variable was
-      * effectively added. The class counts how many time a variable was added.
-      */
-    bool addVariable(VariablePtr var);
-    /** Add a set of variables, calling addVariable(VariablePtr var) on each
-      * variable.
-      */
-    void addVariable(const VariableVector& vars);
-    /** Effectively remove a variable if as many calls were made to this method
-      * as to addVariable, for the given variable. Return true if the variable
-      * was really removed.
-      */
-    bool removeVariable(Variable* v);
-    /** Remove a set of variables, calling removeVariable(Variable* v) on each
-      * variable.
-      */
-    void removeVariable(const VariableVector& vars);
-    /** Get the variables of the problem.*/
-    const VariableVector& variables() const;
-
-    /** Set the value of the variables to that of the solution. */
-    void setVariablesToSolution();
-
-    /** Adding an event changing the problem definition, that needs to be handled
-      * by the resolution scheme. Events are stored in a queue (FIFO).
-      */
-    void addEvent(const ProblemDefinitionEvent& e);
-    /** Read and remove the first event in the queue. Need the queue to be non-empty.*/
-    ProblemDefinitionEvent popEvent();
-    /** Is the queue not empty?*/
-    bool hasEvents() const;
-
-  protected:
-    ProblemComputationData(int solverId);
-    ProblemComputationData() = delete;
-
-    /** Need to put in x the solution of the computation. */
-    virtual void setVariablesToSolution_(VariableVector& x) = 0;
-
-    /** The problem variable*/
-    VariableVector x_;
-    /** Count on the number of time a variable was added to x_.*/
-    std::vector<int> varCount_;
-
-    /** Problem definition events*/
-    std::queue<ProblemDefinitionEvent> events_;
-
-  private:
-    int solverId_;
-  };
-
-  inline int ProblemComputationData::solverId() const
-  {
-    return solverId_;
+    varCount_.push_back(1);
+    return true;
   }
-
-  inline bool ProblemComputationData::addVariable(VariablePtr var)
+  else
   {
-    assert(x_.numberOfVariables() == varCount_.size());
-    int i = x_.addAndGetIndex(var);
-    if (i >= varCount_.size())
-    {
-      varCount_.push_back(1);
-      return true;
-    }
-    else
-    {
-      ++varCount_[i];
-      return false;
-    }
-  }
-
-  inline void ProblemComputationData::addVariable(const VariableVector& vars)
-  {
-    for (const auto& v : vars.variables())
-      addVariable(v);
-  }
-
-  inline bool ProblemComputationData::removeVariable(Variable* v)
-  {
-    int i = x_.indexOf(*v);
-    assert(i >= 0 && i < static_cast<int>(varCount_.size()));
-
-    --varCount_[i];
-    if (varCount_[i] == 0)
-    {
-      x_.remove(i);
-      varCount_.erase(varCount_.begin() + i);
-      return true;
-    }
-    else
-    {
-      return false;
-    }
-  }
-
-  inline void ProblemComputationData::removeVariable(const VariableVector& vars)
-  {
-    for (const auto& v : vars.variables())
-      removeVariable(v.get());
-  }
-
-  inline const VariableVector& ProblemComputationData::variables() const
-  {
-    return x_;
-  }
-
-  inline void ProblemComputationData::setVariablesToSolution()
-  {
-    setVariablesToSolution_(x_);
-  }
-
-  inline void ProblemComputationData::addEvent(const ProblemDefinitionEvent& e)
-  {
-    events_.push(e);
-  }
-
-  [[nodiscard]] inline ProblemDefinitionEvent ProblemComputationData::popEvent()
-  {
-    assert(hasEvents());
-    auto e = events_.front();
-    events_.pop();
-    return e;
-  }
-
-  inline bool ProblemComputationData::hasEvents() const
-  {
-    return !events_.empty();
-  }
-
-  inline ProblemComputationData::ProblemComputationData(int solverId)
-    : solverId_(solverId)
-  {
+    ++varCount_[i];
+    return false;
   }
 }
+
+inline void ProblemComputationData::addVariable(const VariableVector & vars)
+{
+  for(const auto & v : vars.variables())
+    addVariable(v);
+}
+
+inline bool ProblemComputationData::removeVariable(Variable * v)
+{
+  int i = x_.indexOf(*v);
+  assert(i >= 0 && i < static_cast<int>(varCount_.size()));
+
+  --varCount_[i];
+  if(varCount_[i] == 0)
+  {
+    x_.remove(i);
+    varCount_.erase(varCount_.begin() + i);
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+inline void ProblemComputationData::removeVariable(const VariableVector & vars)
+{
+  for(const auto & v : vars.variables())
+    removeVariable(v.get());
+}
+
+inline const VariableVector & ProblemComputationData::variables() const { return x_; }
+
+inline void ProblemComputationData::setVariablesToSolution() { setVariablesToSolution_(x_); }
+
+inline void ProblemComputationData::addEvent(const ProblemDefinitionEvent & e) { events_.push(e); }
+
+[[nodiscard]] inline ProblemDefinitionEvent ProblemComputationData::popEvent()
+{
+  assert(hasEvents());
+  auto e = events_.front();
+  events_.pop();
+  return e;
+}
+
+inline bool ProblemComputationData::hasEvents() const { return !events_.empty(); }
+
+inline ProblemComputationData::ProblemComputationData(int solverId) : solverId_(solverId) {}
+} // namespace tvm::scheme::internal

--- a/include/tvm/scheme/internal/ProblemDefinitionEvent.h
+++ b/include/tvm/scheme/internal/ProblemDefinitionEvent.h
@@ -2,36 +2,34 @@
 
 #pragma once
 
-#include<memory>
+#include <memory>
 
 namespace tvm
 {
-  class TaskWithRequirements;
+class TaskWithRequirements;
 
 namespace scheme::internal
 {
-  /** A class describing a change in a problem definition.*/
-  class ProblemDefinitionEvent
+/** A class describing a change in a problem definition.*/
+class ProblemDefinitionEvent
+{
+public:
+  enum class Type
   {
-  public:
-    enum class Type
-    {
-      WeightChange,
-      AnisotropicWeightChange,
-      TaskAddition,
-      TaskRemoval
-    };
-
-    ProblemDefinitionEvent(Type type, TaskWithRequirements* emitter)
-      : type_(type), emitter_(emitter)
-    {}
-
-    Type type() const { return type_; }
-    TaskWithRequirements* emitter() const { return emitter_; }
-
-  private:
-    Type type_;
-    TaskWithRequirements* emitter_;
+    WeightChange,
+    AnisotropicWeightChange,
+    TaskAddition,
+    TaskRemoval
   };
-}
-}
+
+  ProblemDefinitionEvent(Type type, TaskWithRequirements * emitter) : type_(type), emitter_(emitter) {}
+
+  Type type() const { return type_; }
+  TaskWithRequirements * emitter() const { return emitter_; }
+
+private:
+  Type type_;
+  TaskWithRequirements * emitter_;
+};
+} // namespace scheme::internal
+} // namespace tvm

--- a/include/tvm/scheme/internal/ResolutionSchemeBase.h
+++ b/include/tvm/scheme/internal/ResolutionSchemeBase.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -37,35 +37,35 @@
 namespace tvm
 {
 
-  namespace scheme
-  {
-    using identifier = int;
+namespace scheme
+{
+using identifier = int;
 
-    namespace internal
-    {
-      /** Base class for solving a ControlProblem*/
-      class TVM_DLLAPI ResolutionSchemeBase: public tvm::internal::ObjWithId
-      {
-      public:
-        double big_number() const;
-        void big_number(double big);
+namespace internal
+{
+/** Base class for solving a ControlProblem*/
+class TVM_DLLAPI ResolutionSchemeBase : public tvm::internal::ObjWithId
+{
+public:
+  double big_number() const;
+  void big_number(double big);
 
-      protected:
-        /** Constructor, meant only for derived classes
-        *
-        * \param abilities The set of abilities for this scheme.
-        * \param big A big number use to represent infinity, in particular when
-        * specifying non-existing bounds (e.g. x <= Inf is given as x <= big).
-        */
-        ResolutionSchemeBase(SchemeAbilities abilities, double big = constant::big_number);
+protected:
+  /** Constructor, meant only for derived classes
+   *
+   * \param abilities The set of abilities for this scheme.
+   * \param big A big number use to represent infinity, in particular when
+   * specifying non-existing bounds (e.g. x <= Inf is given as x <= big).
+   */
+  ResolutionSchemeBase(SchemeAbilities abilities, double big = constant::big_number);
 
-        SchemeAbilities abilities_;
+  SchemeAbilities abilities_;
 
-        /** A number to use for infinite bounds*/
-        double big_number_;
-      };
-    }  // namespace internal
+  /** A number to use for infinite bounds*/
+  double big_number_;
+};
+} // namespace internal
 
-  }  // namespace scheme
+} // namespace scheme
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/scheme/internal/ResolutionSchemeBase.h
+++ b/include/tvm/scheme/internal/ResolutionSchemeBase.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/internal/ResolutionSchemeBase.h
+++ b/include/tvm/scheme/internal/ResolutionSchemeBase.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/internal/ObjWithId.h>
 #include <tvm/scheme/internal/SchemeAbilities.h>
 

--- a/include/tvm/scheme/internal/SchemeAbilities.h
+++ b/include/tvm/scheme/internal/SchemeAbilities.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/constraint/abstract/Constraint.h>
 #include <tvm/defs.h>
+
+#include <tvm/constraint/abstract/Constraint.h>
 #include <tvm/requirements/ViolationEvaluation.h>
 
 #include <iostream>

--- a/include/tvm/scheme/internal/SchemeAbilities.h
+++ b/include/tvm/scheme/internal/SchemeAbilities.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/defs.h>
 #include <tvm/constraint/abstract/Constraint.h>
+#include <tvm/defs.h>
 #include <tvm/requirements/ViolationEvaluation.h>
 
 #include <iostream>
@@ -20,123 +20,120 @@ namespace scheme
 namespace internal
 {
 
-  /** Used to describe any level that is not explicitly specified.*/
-  inline constexpr int GeneralLevel = -1;
-  /** Used to specify that a scheme can handle an unlimited number of levels.*/
-  inline constexpr int NoLimit = GeneralLevel;
+/** Used to describe any level that is not explicitly specified.*/
+inline constexpr int GeneralLevel = -1;
+/** Used to specify that a scheme can handle an unlimited number of levels.*/
+inline constexpr int NoLimit = GeneralLevel;
 
-  /** A class to describe what type of constraint and solving requirements a
-    * level of a resolution scheme can handle.
-    */
-  class TVM_DLLAPI LevelAbilities
-  {
-  public:
-    /** \param inequality True if the level is able to handle inequality
-      * constraints.
-      * \param types The types of violation evaluation that can be handled at
-      * this level.
-      */
-    LevelAbilities(bool inequality, const std::vector<requirements::ViolationEvaluationType>& types);
+/** A class to describe what type of constraint and solving requirements a
+ * level of a resolution scheme can handle.
+ */
+class TVM_DLLAPI LevelAbilities
+{
+public:
+  /** \param inequality True if the level is able to handle inequality
+   * constraints.
+   * \param types The types of violation evaluation that can be handled at
+   * this level.
+   */
+  LevelAbilities(bool inequality, const std::vector<requirements::ViolationEvaluationType> & types);
 
-    /** Check that the given constraint \c and requirements \req can be handled
-      * by this level.
-      *
-      * \throws std::runtime_error if the level cannot handled them.
-      */
-    template<class RequirementsPtr>
-    void check(const ConstraintPtr& c, const RequirementsPtr& req, bool emitWarnings = true) const;
-
-  private:
-    bool inequalities_;
-    std::vector<requirements::ViolationEvaluationType> evaluationTypes_;
-  };
-
-
-  /** A class to describe what type of constraint and solving requirements a
-    * resolution scheme can handle
-    */
-  class TVM_DLLAPI SchemeAbilities
-  {
-  public:
-    /** \param numberOfLevels The number of levels that the scheme can handle. 
-      * Use \c NoLimit to indicate an unlimited number of levels.
-      * \param abilies The association of a level number and the LevelAbilities
-      * of that level. Use \c GeneralLevel to specify all levels that do not
-      * appear explicitly in the map.
-      * \param scalarization Specify is this scheme can use weights to approximate
-      * priority.
-      *
-      * \note \p numberOfLevels should be the number of levels the scheme can
-      * handle without scalarization. Scalarization is an artificial way to add
-      * levels. For example, a QP-based scheme should declare 2 levels, even if
-      * scalarization will make it possible to emulate a few more.
-      */
-    SchemeAbilities(int numberOfLevels, const std::map<int, LevelAbilities>& abilities, bool scalarization=false);
-
-    /** Check that the given constraint \c and requirements \req can be handled
-      * by this scheme.
-      *
-      * \throws std::runtime_error if the scheme cannot handled them.
-      */
-    template<class RequirementsPtr>
-    void check(const ConstraintPtr& c, const RequirementsPtr& req, bool emitWarnings = true) const;
-
-  private:
-    int numberOfLevels_;
-    bool scalarization_;
-    std::map<int, LevelAbilities> abilities_;
-  };
-
-
+  /** Check that the given constraint \c and requirements \req can be handled
+   * by this level.
+   *
+   * \throws std::runtime_error if the level cannot handled them.
+   */
   template<class RequirementsPtr>
-  inline void LevelAbilities::check(const ConstraintPtr& c, const RequirementsPtr& req, bool /*emitWarnings*/) const
-  {
-    //checking the constraint type
-    if (c->type() != constraint::Type::EQUAL && !inequalities_)
-      throw std::runtime_error("This level does not handle inequality constraints.");
+  void check(const ConstraintPtr & c, const RequirementsPtr & req, bool emitWarnings = true) const;
 
-    //checking the evaluation type
-    auto it = std::find(evaluationTypes_.begin(), evaluationTypes_.end(), req->violationEvaluation().value());
-    if (it == evaluationTypes_.end())
-      throw std::runtime_error("This level does not handle the required violation evaluation value.");
-  }
+private:
+  bool inequalities_;
+  std::vector<requirements::ViolationEvaluationType> evaluationTypes_;
+};
 
+/** A class to describe what type of constraint and solving requirements a
+ * resolution scheme can handle
+ */
+class TVM_DLLAPI SchemeAbilities
+{
+public:
+  /** \param numberOfLevels The number of levels that the scheme can handle.
+   * Use \c NoLimit to indicate an unlimited number of levels.
+   * \param abilies The association of a level number and the LevelAbilities
+   * of that level. Use \c GeneralLevel to specify all levels that do not
+   * appear explicitly in the map.
+   * \param scalarization Specify is this scheme can use weights to approximate
+   * priority.
+   *
+   * \note \p numberOfLevels should be the number of levels the scheme can
+   * handle without scalarization. Scalarization is an artificial way to add
+   * levels. For example, a QP-based scheme should declare 2 levels, even if
+   * scalarization will make it possible to emulate a few more.
+   */
+  SchemeAbilities(int numberOfLevels, const std::map<int, LevelAbilities> & abilities, bool scalarization = false);
 
+  /** Check that the given constraint \c and requirements \req can be handled
+   * by this scheme.
+   *
+   * \throws std::runtime_error if the scheme cannot handled them.
+   */
   template<class RequirementsPtr>
-  inline void SchemeAbilities::check(const ConstraintPtr& c, const RequirementsPtr& req, bool emitWarnings) const
+  void check(const ConstraintPtr & c, const RequirementsPtr & req, bool emitWarnings = true) const;
+
+private:
+  int numberOfLevels_;
+  bool scalarization_;
+  std::map<int, LevelAbilities> abilities_;
+};
+
+template<class RequirementsPtr>
+inline void LevelAbilities::check(const ConstraintPtr & c, const RequirementsPtr & req, bool /*emitWarnings*/) const
+{
+  // checking the constraint type
+  if(c->type() != constraint::Type::EQUAL && !inequalities_)
+    throw std::runtime_error("This level does not handle inequality constraints.");
+
+  // checking the evaluation type
+  auto it = std::find(evaluationTypes_.begin(), evaluationTypes_.end(), req->violationEvaluation().value());
+  if(it == evaluationTypes_.end())
+    throw std::runtime_error("This level does not handle the required violation evaluation value.");
+}
+
+template<class RequirementsPtr>
+inline void SchemeAbilities::check(const ConstraintPtr & c, const RequirementsPtr & req, bool emitWarnings) const
+{
+  // check priority level value
+  int p = req->priorityLevel().value();
+  if(numberOfLevels_ > 0 && p >= numberOfLevels_)
   {
-    //check priority level value
-    int p = req->priorityLevel().value();
-    if (numberOfLevels_ > 0 && p >= numberOfLevels_)
+    if(scalarization_)
     {
-      if (scalarization_)
+      if(emitWarnings)
       {
-        if (emitWarnings)
-        {
-          std::cout << "Warning: required priority level (" << p
-            << ") cannot be handled as a strict hierarchy level by the resolution scheme. "
-            << "Using scalarization to revert to weighted approach.";
-        }
-      }
-      else
-      {
-        std::stringstream s;
-        s << "This resolution scheme can handle priorities level up to" << numberOfLevels_ - 1
-          << ". It cannot process required level (" << p << ")." << std::endl;
-        throw std::runtime_error(s.str());
+        std::cout << "Warning: required priority level (" << p
+                  << ") cannot be handled as a strict hierarchy level by the resolution scheme. "
+                  << "Using scalarization to revert to weighted approach.";
       }
     }
-
-    //check abilities of the required priority level
-    auto it = abilities_.find(p);
-    if (it != abilities_.end())
-      it->second.check(c, req, emitWarnings);
     else
-      abilities_.at(GeneralLevel).check(c, req, emitWarnings);
+    {
+      std::stringstream s;
+      s << "This resolution scheme can handle priorities level up to" << numberOfLevels_ - 1
+        << ". It cannot process required level (" << p << ")." << std::endl;
+      throw std::runtime_error(s.str());
+    }
   }
 
-}  // namespace internal
+  // check abilities of the required priority level
+  auto it = abilities_.find(p);
+  if(it != abilities_.end())
+    it->second.check(c, req, emitWarnings);
+  else
+    abilities_.at(GeneralLevel).check(c, req, emitWarnings);
+}
 
-}  // namespace scheme
+} // namespace internal
 
-}  // namespace tvm
+} // namespace scheme
+
+} // namespace tvm

--- a/include/tvm/scheme/internal/helpers.h
+++ b/include/tvm/scheme/internal/helpers.h
@@ -1,37 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/defs.h>
 #include <tvm/constraint/enums.h>
+#include <tvm/defs.h>
 
 #include <vector>
 
@@ -41,69 +41,72 @@ namespace hint
 {
 namespace internal
 {
-  class Substitutions;
+class Substitutions;
 }
-}
+} // namespace hint
 namespace function
 {
-  class BasicLinearFunction;
+class BasicLinearFunction;
 }
 
 namespace scheme
 {
 namespace internal
 {
-  class ProblemComputationData;
+class ProblemComputationData;
 
-  /** Get the computation data linked to a particular resolution scheme.
-    * If this data does not exist, create it, using the resolution scheme as
-    * a factory
-    * \param The resolution scheme for which we want to get back the
-    * computation data. It needs to have a method \a createComputationData.
-    */
-  template<typename Problem, typename Scheme>
-  inline ProblemComputationData* getComputationData(Problem& problem, const Scheme& resolutionScheme);
+/** Get the computation data linked to a particular resolution scheme.
+ * If this data does not exist, create it, using the resolution scheme as
+ * a factory
+ * \param The resolution scheme for which we want to get back the
+ * computation data. It needs to have a method \a createComputationData.
+ */
+template<typename Problem, typename Scheme>
+inline ProblemComputationData * getComputationData(Problem & problem, const Scheme & resolutionScheme);
 
-  /** We consider as bound a constraint with a single variable and a diagonal,
-    * invertible jacobian.
-    * It would be possible to accept non-invertible sparse diagonal jacobians
-    * as well, in which case the zero elements of the diagonal would 
-    * correspond to non-existing bounds, but this requires quite a lot of
-    * work for something that is unlikely to happen and could be expressed
-    * by changing the bound itself to +/- infinity.
-    */
-  bool TVM_DLLAPI isBound(const ConstraintPtr& c);
+/** We consider as bound a constraint with a single variable and a diagonal,
+ * invertible jacobian.
+ * It would be possible to accept non-invertible sparse diagonal jacobians
+ * as well, in which case the zero elements of the diagonal would
+ * correspond to non-existing bounds, but this requires quite a lot of
+ * work for something that is unlikely to happen and could be expressed
+ * by changing the bound itself to +/- infinity.
+ */
+bool TVM_DLLAPI isBound(const ConstraintPtr & c);
 
-  /** Assert if a constraint is a bound in the presence of substitutions
-    * \param c the constraint
-    * \param subs the set of substitutions
-    * We have a bound if c is a bound and the variable is not substituted or it
-    * is by an expression with a single varaible and an invertible, diagonal
-    * jacobian.
-    */
-  bool TVM_DLLAPI isBound(const ConstraintPtr& c, const hint::internal::Substitutions& subs);
+/** Assert if a constraint is a bound in the presence of substitutions
+ * \param c the constraint
+ * \param subs the set of substitutions
+ * We have a bound if c is a bound and the variable is not substituted or it
+ * is by an expression with a single varaible and an invertible, diagonal
+ * jacobian.
+ */
+bool TVM_DLLAPI isBound(const ConstraintPtr & c, const hint::internal::Substitutions & subs);
 
-  /** Assert if a constraint is a bound in the presence of substitutions
-    * \param c the constraint
-    * \param x the set of variables being substituted
-    * \param xsub the set of substitution functions corresponding to those variables.
-    * We have a bound if c is a bound and the variable is not substituted or it
-    * is by an expression with a single varaible and an invertible, diagonal
-    * jacobian.
-    */
-  bool TVM_DLLAPI isBound(const ConstraintPtr& c, const std::vector<VariablePtr>& x,
-                          const std::vector<std::shared_ptr<function::BasicLinearFunction>>& xsub);
+/** Assert if a constraint is a bound in the presence of substitutions
+ * \param c the constraint
+ * \param x the set of variables being substituted
+ * \param xsub the set of substitution functions corresponding to those variables.
+ * We have a bound if c is a bound and the variable is not substituted or it
+ * is by an expression with a single varaible and an invertible, diagonal
+ * jacobian.
+ */
+bool TVM_DLLAPI isBound(const ConstraintPtr & c,
+                        const std::vector<VariablePtr> & x,
+                        const std::vector<std::shared_ptr<function::BasicLinearFunction>> & xsub);
 
-  /** Check if the constraint can be used as a bound for a given target convention.
-    * For example l <= x <= u is a bound, but it cannot be transformed into x >= lb.
-    */
-  bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr& c, const hint::internal::Substitutions& subs,
-                                   constraint::Type targetConvention);
+/** Check if the constraint can be used as a bound for a given target convention.
+ * For example l <= x <= u is a bound, but it cannot be transformed into x >= lb.
+ */
+bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr & c,
+                                 const hint::internal::Substitutions & subs,
+                                 constraint::Type targetConvention);
 
-  /** Version with separated susbtituted variables and substitution functions.*/
-  bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr& c, const std::vector<VariablePtr>& x,
-                                   const std::vector<std::shared_ptr<function::BasicLinearFunction>>& xsub,
-                                   constraint::Type targetConvention);
-}
-}
-}
+/** Version with separated susbtituted variables and substitution functions.*/
+bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr & c,
+                                 const std::vector<VariablePtr> & x,
+                                 const std::vector<std::shared_ptr<function::BasicLinearFunction>> & xsub,
+                                 constraint::Type targetConvention);
+} // namespace internal
+} // namespace scheme
+} // namespace tvm

--- a/include/tvm/scheme/internal/helpers.h
+++ b/include/tvm/scheme/internal/helpers.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/scheme/internal/helpers.h
+++ b/include/tvm/scheme/internal/helpers.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/constraint/enums.h>
 #include <tvm/defs.h>
+
+#include <tvm/constraint/enums.h>
 
 #include <vector>
 

--- a/include/tvm/scheme/internal/helpers.hpp
+++ b/include/tvm/scheme/internal/helpers.hpp
@@ -1,22 +1,6 @@
 #pragma once
 
-/* Copyright 2017 CNRS-UM LIRMM, CNRS-AIST JRL
- *
- * This file is part of TVM.
- *
- * TVM is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * TVM is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with TVM.  If not, see <http://www.gnu.org/licenses/>.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 namespace tvm
 {

--- a/include/tvm/scheme/internal/helpers.hpp
+++ b/include/tvm/scheme/internal/helpers.hpp
@@ -24,25 +24,26 @@ namespace scheme
 {
 namespace internal
 {
-  class ProblemComputationData;
+class ProblemComputationData;
 
-  template<typename Problem, typename Scheme>
-  inline ProblemComputationData* getComputationData(Problem& problem, const Scheme& resolutionScheme)
+template<typename Problem, typename Scheme>
+inline ProblemComputationData * getComputationData(Problem & problem, const Scheme & resolutionScheme)
+{
+  auto id = resolutionScheme.id();
+  auto it = problem.computationData_.find(id);
+  if(it != problem.computationData_.end())
   {
-    auto id = resolutionScheme.id();
-    auto it = problem.computationData_.find(id);
-    if (it != problem.computationData_.end())
-    {
-      return it->second.get();
-    }
-    else
-    {
-      problem.finalize();
-      auto p = problem.computationData_.insert(std::move(std::make_pair(id, resolutionScheme.createComputationData(problem))));
-      return p.first->second.get();
-    }
+    return it->second.get();
   }
+  else
+  {
+    problem.finalize();
+    auto p =
+        problem.computationData_.insert(std::move(std::make_pair(id, resolutionScheme.createComputationData(problem))));
+    return p.first->second.get();
+  }
+}
 
-}
-}
-}
+} // namespace internal
+} // namespace scheme
+} // namespace tvm

--- a/include/tvm/solver/LSSOLLeastSquareSolver.h
+++ b/include/tvm/solver/LSSOLLeastSquareSolver.h
@@ -4,107 +4,105 @@
 
 #include <tvm/solver/abstract/LeastSquareSolver.h>
 
+#include <eigen-lssol //LSSOL_FP.h>
 #include <eigen-lssol/LSSOL_LS.h>
-#include <eigen-lssol//LSSOL_FP.h>
 
 namespace tvm
 {
 
 namespace solver
 {
-  class LSSOLLSSolverFactory;
+class LSSOLLSSolverFactory;
 
-  /** A set of options for LSSOLLeastSquareSolver */
-  class TVM_DLLAPI LSSOLLSSolverOptions
-  {
-    TVM_ADD_NON_DEFAULT_OPTION  (big_number,          constant::big_number)
-    TVM_ADD_DEFAULT_OPTION      (crashTol,            double)
-    TVM_ADD_DEFAULT_OPTION      (feasibilityMaxIter,  int)
-    TVM_ADD_NON_DEFAULT_OPTION  (feasibilityTol,      1e-6)
-    TVM_ADD_DEFAULT_OPTION      (infiniteBnd,         double)
-    TVM_ADD_DEFAULT_OPTION      (infiniteStep,        double)
-    TVM_ADD_DEFAULT_OPTION      (optimalityMaxIter,   int)
-    TVM_ADD_DEFAULT_OPTION      (persistence,         bool)
-    TVM_ADD_DEFAULT_OPTION      (printLevel,          int)
-    TVM_ADD_DEFAULT_OPTION      (rankTol,             double)
-    TVM_ADD_NON_DEFAULT_OPTION  (verbose,             false)
-    TVM_ADD_NON_DEFAULT_OPTION  (warm,                true)
+/** A set of options for LSSOLLeastSquareSolver */
+class TVM_DLLAPI LSSOLLSSolverOptions
+{
+  TVM_ADD_NON_DEFAULT_OPTION(big_number, constant::big_number)
+  TVM_ADD_DEFAULT_OPTION(crashTol, double)
+  TVM_ADD_DEFAULT_OPTION(feasibilityMaxIter, int)
+  TVM_ADD_NON_DEFAULT_OPTION(feasibilityTol, 1e-6)
+  TVM_ADD_DEFAULT_OPTION(infiniteBnd, double)
+  TVM_ADD_DEFAULT_OPTION(infiniteStep, double)
+  TVM_ADD_DEFAULT_OPTION(optimalityMaxIter, int)
+  TVM_ADD_DEFAULT_OPTION(persistence, bool)
+  TVM_ADD_DEFAULT_OPTION(printLevel, int)
+  TVM_ADD_DEFAULT_OPTION(rankTol, double)
+  TVM_ADD_NON_DEFAULT_OPTION(verbose, false)
+  TVM_ADD_NON_DEFAULT_OPTION(warm, true)
 
-  public:
-    using Factory = LSSOLLSSolverFactory;
-  };
+public:
+  using Factory = LSSOLLSSolverFactory;
+};
 
+/** An encapsulation of the LSSOL solver, to solve linear least-squares problems. */
+class TVM_DLLAPI LSSOLLeastSquareSolver : public abstract::LeastSquareSolver
+{
+public:
+  LSSOLLeastSquareSolver(const LSSOLLSSolverOptions & options = {});
 
-  /** An encapsulation of the LSSOL solver, to solve linear least-squares problems. */
-  class TVM_DLLAPI LSSOLLeastSquareSolver : public abstract::LeastSquareSolver
-  {
-  public:
-    LSSOLLeastSquareSolver(const LSSOLLSSolverOptions& options = {});
+protected:
+  void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) override;
+  ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) override;
+  void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) override;
+  void addEqualityConstraint_(LinearConstraintPtr cstr) override;
+  void addIneqalityConstraint_(LinearConstraintPtr cstr) override;
+  void addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight) override;
+  void setMinimumNorm_() override;
+  void preAssignmentProcess_() override;
+  void postAssignmentProcess_() override;
+  bool solve_() override;
+  const Eigen::VectorXd & result_() const override;
+  bool handleDoubleSidedConstraint_() const override { return true; }
+  Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  Range nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const override;
 
-  protected:
-    void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) override;
-    ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) override;
-    void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) override;
-    void addEqualityConstraint_(LinearConstraintPtr cstr) override;
-    void addIneqalityConstraint_(LinearConstraintPtr cstr) override;
-    void addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight) override;
-    void setMinimumNorm_() override;
-    void preAssignmentProcess_() override;
-    void postAssignmentProcess_() override;
-    bool solve_() override;
-    const Eigen::VectorXd& result_() const override;
-    bool handleDoubleSidedConstraint_() const override { return true; }
-    Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    Range nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const override;
+  void removeBounds_(const Range & range) override;
+  void updateEqualityTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateInequalityTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateBoundTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateObjectiveTargetData(scheme::internal::AssignmentTarget & target) override;
 
-    void removeBounds_(const Range& range) override;
-    void updateEqualityTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateInequalityTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateBoundTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateObjectiveTargetData(scheme::internal::AssignmentTarget& target) override;
+  void applyImpactLogic(ImpactFromChanges & impact);
 
-    void applyImpactLogic(ImpactFromChanges& impact);
+  void printProblemData_() const override;
+  void printDiagnostic_() const override;
 
-    void printProblemData_() const override;
-    void printDiagnostic_() const override;
+private:
+  using VectorXdTail = decltype(Eigen::VectorXd().tail(1));
 
-  private:
-    using VectorXdTail = decltype(Eigen::VectorXd().tail(1));
+  Eigen::MatrixXd A_;
+  Eigen::MatrixXd C_;
+  Eigen::VectorXd b_;
+  Eigen::VectorXd l_;
+  Eigen::VectorXd u_;
 
-    Eigen::MatrixXd A_;
-    Eigen::MatrixXd C_;
-    Eigen::VectorXd b_;
-    Eigen::VectorXd l_;
-    Eigen::VectorXd u_;
+  VectorXdTail cl_; // part of l_ corresponding to general constraints
+  VectorXdTail cu_; // part of u_ corresponding to general constraints
 
-    VectorXdTail    cl_;   // part of l_ corresponding to general constraints
-    VectorXdTail    cu_;   // part of u_ corresponding to general constraints
+  Eigen::LSSOL_LS ls_;
+  Eigen::LSSOL_FP fp_;
 
-    Eigen::LSSOL_LS ls_;
-    Eigen::LSSOL_FP fp_;
+  bool autoMinNorm_;
+  double big_number_;
+};
 
-    bool autoMinNorm_;
-    double big_number_;
-  };
+/** A factory class to create LSSOLLeastSquareSolver instances with a given
+ * set of options.
+ */
+class TVM_DLLAPI LSSOLLSSolverFactory : public abstract::LSSolverFactory
+{
+public:
+  /** Creation of a configuration from a set of options*/
+  LSSOLLSSolverFactory(const LSSOLLSSolverOptions & options = {});
 
-  
-  /** A factory class to create LSSOLLeastSquareSolver instances with a given
-    * set of options.
-    */
-  class TVM_DLLAPI LSSOLLSSolverFactory : public abstract::LSSolverFactory
-  {
-  public:
-    /** Creation of a configuration from a set of options*/
-    LSSOLLSSolverFactory(const LSSOLLSSolverOptions& options = {});
+  std::unique_ptr<abstract::LSSolverFactory> clone() const override;
+  std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
 
-    std::unique_ptr<abstract::LSSolverFactory> clone() const override;
-    std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
+private:
+  LSSOLLSSolverOptions options_;
+};
 
-  private:
-    LSSOLLSSolverOptions options_;
-  };
+} // namespace solver
 
-}
-
-}
+} // namespace tvm

--- a/include/tvm/solver/LSSOLLeastSquareSolver.h
+++ b/include/tvm/solver/LSSOLLeastSquareSolver.h
@@ -4,7 +4,7 @@
 
 #include <tvm/solver/abstract/LeastSquareSolver.h>
 
-#include <eigen-lssol //LSSOL_FP.h>
+#include <eigen-lssol/LSSOL_FP.h>
 #include <eigen-lssol/LSSOL_LS.h>
 
 namespace tvm

--- a/include/tvm/solver/QLDLeastSquareSolver.h
+++ b/include/tvm/solver/QLDLeastSquareSolver.h
@@ -13,101 +13,100 @@ namespace tvm
 
 namespace solver
 {
-  class QLDLSSolverFactory;
+class QLDLSSolverFactory;
 
-  /** A set of options for QLDLeastSquareSolver */
-  class TVM_DLLAPI QLDLSSolverOptions
-  {
-    TVM_ADD_NON_DEFAULT_OPTION  (big_number,          constant::big_number)
-    TVM_ADD_NON_DEFAULT_OPTION  (cholesky,            false)
-    TVM_ADD_NON_DEFAULT_OPTION  (choleskyDamping,     1e-8)
-    TVM_ADD_NON_DEFAULT_OPTION  (eps,                 1e-6)
-    TVM_ADD_NON_DEFAULT_OPTION  (verbose,             false)
-  public:
-    using Factory = QLDLSSolverFactory;
-  };
+/** A set of options for QLDLeastSquareSolver */
+class TVM_DLLAPI QLDLSSolverOptions
+{
+  TVM_ADD_NON_DEFAULT_OPTION(big_number, constant::big_number)
+  TVM_ADD_NON_DEFAULT_OPTION(cholesky, false)
+  TVM_ADD_NON_DEFAULT_OPTION(choleskyDamping, 1e-8)
+  TVM_ADD_NON_DEFAULT_OPTION(eps, 1e-6)
+  TVM_ADD_NON_DEFAULT_OPTION(verbose, false)
+public:
+  using Factory = QLDLSSolverFactory;
+};
 
-  /** An encapsulation of the QLD solver, to solve linear least-squares problems. */
-  class TVM_DLLAPI QLDLeastSquareSolver : public abstract::LeastSquareSolver
-  {
-  public:
-    QLDLeastSquareSolver(const QLDLSSolverOptions & options = {});
+/** An encapsulation of the QLD solver, to solve linear least-squares problems. */
+class TVM_DLLAPI QLDLeastSquareSolver : public abstract::LeastSquareSolver
+{
+public:
+  QLDLeastSquareSolver(const QLDLSSolverOptions & options = {});
 
-  protected:
-    void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) override;
-    ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) override;
-    void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) override;
-    void addEqualityConstraint_(LinearConstraintPtr cstr) override;
-    void addIneqalityConstraint_(LinearConstraintPtr cstr) override;
-    void addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight) override;
-    void setMinimumNorm_() override;
-    void preAssignmentProcess_() override;
-    void postAssignmentProcess_() override;
-    bool solve_() override;
-    virtual const Eigen::VectorXd& result_() const override;
-    bool handleDoubleSidedConstraint_() const override { return false; }
-    Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    Range nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    void removeBounds_(const Range& r) override;
-    void updateEqualityTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateInequalityTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateBoundTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateObjectiveTargetData(scheme::internal::AssignmentTarget& target) override;
+protected:
+  void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) override;
+  ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) override;
+  void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) override;
+  void addEqualityConstraint_(LinearConstraintPtr cstr) override;
+  void addIneqalityConstraint_(LinearConstraintPtr cstr) override;
+  void addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight) override;
+  void setMinimumNorm_() override;
+  void preAssignmentProcess_() override;
+  void postAssignmentProcess_() override;
+  bool solve_() override;
+  virtual const Eigen::VectorXd & result_() const override;
+  bool handleDoubleSidedConstraint_() const override { return false; }
+  Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  Range nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  void removeBounds_(const Range & r) override;
+  void updateEqualityTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateInequalityTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateBoundTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateObjectiveTargetData(scheme::internal::AssignmentTarget & target) override;
 
-    void applyImpactLogic(ImpactFromChanges& impact) override;
+  void applyImpactLogic(ImpactFromChanges & impact) override;
 
+  void printProblemData_() const override;
+  void printDiagnostic_() const override;
 
-    void printProblemData_() const override;
-    void printDiagnostic_() const override;
+private:
+  using VectorXdTail = decltype(Eigen::VectorXd().tail(1));
+  using MatrixXdBottom = decltype(Eigen::MatrixXd().bottomRows(1));
 
-  private:
-    using VectorXdTail = decltype(Eigen::VectorXd().tail(1));
-    using MatrixXdBottom = decltype(Eigen::MatrixXd().bottomRows(1));
+  Eigen::MatrixXd D_; // We have Q = D^T D
+  Eigen::VectorXd e_; // We have c = D^t e
+  Eigen::MatrixXd Q_;
+  Eigen::VectorXd c_;
+  Eigen::MatrixXd A_;
+  Eigen::VectorXd b_;
+  Eigen::VectorXd xl_;
+  Eigen::VectorXd xu_;
 
-    Eigen::MatrixXd D_;   //We have Q = D^T D
-    Eigen::VectorXd e_;   //We have c = D^t e
-    Eigen::MatrixXd Q_;
-    Eigen::VectorXd c_;
-    Eigen::MatrixXd A_;
-    Eigen::VectorXd b_;
-    Eigen::VectorXd xl_;
-    Eigen::VectorXd xu_;
+  MatrixXdBottom Aineq_; // part of A_ corresponding to inequality constraints
+  VectorXdTail bineq_; // part of b_ corresponding to inequality constraints
 
-    MatrixXdBottom Aineq_; //part of A_ corresponding to inequality constraints
-    VectorXdTail bineq_; //part of b_ corresponding to inequality constraints
+  Eigen::QLDDirect qld_;
+  Eigen::HouseholderQR<Eigen::MatrixXd> qr_; // TODO add option for ColPiv variant
 
-    Eigen::QLDDirect qld_;
-    Eigen::HouseholderQR<Eigen::MatrixXd> qr_; //TODO add option for ColPiv variant
+  bool autoMinNorm_;
+  bool underspecifiedObj_; // true when nObj<n
 
-    bool autoMinNorm_;
-    bool underspecifiedObj_; //true when nObj<n
+  // options
+  double big_number_;
+  double eps_;
+  bool cholesky_; // compute the Cholesky decomposition before calling the solver.
+  double choleskyDamping_; // if nObj<n, the cholesky factor R is trapezoidal. A multiple of
+                           // the identity is used to make it triangular using this value.
+};
 
-    //options
-    double big_number_;
-    double eps_;
-    bool   cholesky_; //compute the Cholesky decomposition before calling the solver.
-    double choleskyDamping_; // if nObj<n, the cholesky factor R is trapezoidal. A multiple of
-                             // the identity is used to make it triangular using this value.
-  };
+/** A factory class to create QLDLeastSquareSolver instances with a given
+ * set of options.
+ */
+class TVM_DLLAPI QLDLSSolverFactory : public abstract::LSSolverFactory
+{
+public:
+  std::unique_ptr<abstract::LSSolverFactory> clone() const override;
 
-  /** A factory class to create QLDLeastSquareSolver instances with a given
-  * set of options.
-  */
-  class TVM_DLLAPI QLDLSSolverFactory : public abstract::LSSolverFactory
-  {
-  public:
-    std::unique_ptr<abstract::LSSolverFactory> clone() const override;
+  /** Creation of a configuration from a set of options*/
+  QLDLSSolverFactory(const QLDLSSolverOptions & options = {});
 
-    /** Creation of a configuration from a set of options*/
-    QLDLSSolverFactory(const QLDLSSolverOptions & options = {});
+  std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
 
-    std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
+private:
+  QLDLSSolverOptions options_;
+};
 
-  private:
-    QLDLSSolverOptions options_;
-  };
+} // namespace solver
 
-}
-
-}
+} // namespace tvm

--- a/include/tvm/solver/QLDLeastSquareSolver.h
+++ b/include/tvm/solver/QLDLeastSquareSolver.h
@@ -74,7 +74,7 @@ private:
   Eigen::VectorXd xu_;
 
   MatrixXdBottom Aineq_; // part of A_ corresponding to inequality constraints
-  VectorXdTail bineq_; // part of b_ corresponding to inequality constraints
+  VectorXdTail bineq_;   // part of b_ corresponding to inequality constraints
 
   Eigen::QLDDirect qld_;
   Eigen::HouseholderQR<Eigen::MatrixXd> qr_; // TODO add option for ColPiv variant
@@ -85,7 +85,7 @@ private:
   // options
   double big_number_;
   double eps_;
-  bool cholesky_; // compute the Cholesky decomposition before calling the solver.
+  bool cholesky_;          // compute the Cholesky decomposition before calling the solver.
   double choleskyDamping_; // if nObj<n, the cholesky factor R is trapezoidal. A multiple of
                            // the identity is used to make it triangular using this value.
 };

--- a/include/tvm/solver/QuadprogLeastSquareSolver.h
+++ b/include/tvm/solver/QuadprogLeastSquareSolver.h
@@ -73,21 +73,21 @@ private:
   Eigen::VectorXd b_;
 
   MatrixXdRows Aineq_; // part of A_ corresponding to inequality constraints
-  VectorXdSeg bineq_; // part of b_ corresponding to inequality constraints
-  VectorXdSeg xl_; // part of b_ corresponding to lower bound constraints
-  VectorXdSeg xu_; // part of b_ corresponding to uppor bound constraints
+  VectorXdSeg bineq_;  // part of b_ corresponding to inequality constraints
+  VectorXdSeg xl_;     // part of b_ corresponding to lower bound constraints
+  VectorXdSeg xu_;     // part of b_ corresponding to uppor bound constraints
 
   Eigen::QuadProgDense qpd_;
   Eigen::HouseholderQR<Eigen::MatrixXd> qr_; // TODO add option for ColPiv variant
 
   bool autoMinNorm_;
   bool underspecifiedObj_; // true when nObj<n
-  int nIneqInclBounds_; // number of inequality constraints including bounds.
+  int nIneqInclBounds_;    // number of inequality constraints including bounds.
 
   // options
   double big_number_;
-  double damping_; // value added to the diagonal of Q for regularization (non Cholesky case)
-  bool cholesky_; // compute the Cholesky decomposition before calling the solver.
+  double damping_;         // value added to the diagonal of Q for regularization (non Cholesky case)
+  bool cholesky_;          // compute the Cholesky decomposition before calling the solver.
   double choleskyDamping_; // if nObj<n, the cholesky factor R is trapezoidal. A multiple of
                            // the identity is used to make it triangular using this value.
 };

--- a/include/tvm/solver/QuadprogLeastSquareSolver.h
+++ b/include/tvm/solver/QuadprogLeastSquareSolver.h
@@ -13,105 +13,102 @@ namespace tvm
 
 namespace solver
 {
-  class QuadprogLSSolverFactory;
+class QuadprogLSSolverFactory;
 
-  /** A set of options for QuadprogLeastSquareSolver */
-  class TVM_DLLAPI QuadprogLSSolverOptions
-  {
-    TVM_ADD_NON_DEFAULT_OPTION  (big_number,          constant::big_number)
-    TVM_ADD_NON_DEFAULT_OPTION  (cholesky,            false)
-    TVM_ADD_NON_DEFAULT_OPTION  (choleskyDamping,     1e-6)
-    TVM_ADD_NON_DEFAULT_OPTION  (damping,             1e-12)
-    TVM_ADD_NON_DEFAULT_OPTION  (verbose,             false)
+/** A set of options for QuadprogLeastSquareSolver */
+class TVM_DLLAPI QuadprogLSSolverOptions
+{
+  TVM_ADD_NON_DEFAULT_OPTION(big_number, constant::big_number)
+  TVM_ADD_NON_DEFAULT_OPTION(cholesky, false)
+  TVM_ADD_NON_DEFAULT_OPTION(choleskyDamping, 1e-6)
+  TVM_ADD_NON_DEFAULT_OPTION(damping, 1e-12)
+  TVM_ADD_NON_DEFAULT_OPTION(verbose, false)
 
-  public:
-    using Factory = QuadprogLSSolverFactory;
-  };
+public:
+  using Factory = QuadprogLSSolverFactory;
+};
 
+/** An encapsulation of the Quadprog solver, to solve linear least-squares problems. */
+class TVM_DLLAPI QuadprogLeastSquareSolver : public abstract::LeastSquareSolver
+{
+public:
+  QuadprogLeastSquareSolver(const QuadprogLSSolverOptions & options = {});
 
-  /** An encapsulation of the Quadprog solver, to solve linear least-squares problems. */
-  class TVM_DLLAPI QuadprogLeastSquareSolver : public abstract::LeastSquareSolver
-  {
-  public:
-    QuadprogLeastSquareSolver(const QuadprogLSSolverOptions& options = {});
+protected:
+  void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) override;
+  ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) override;
+  void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) override;
+  void addEqualityConstraint_(LinearConstraintPtr cstr) override;
+  void addIneqalityConstraint_(LinearConstraintPtr cstr) override;
+  void addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight) override;
+  void setMinimumNorm_() override;
+  void preAssignmentProcess_() override;
+  void postAssignmentProcess_() override;
+  bool solve_() override;
+  virtual const Eigen::VectorXd & result_() const override;
+  bool handleDoubleSidedConstraint_() const override { return false; }
+  Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  Range nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const override;
+  void removeBounds_(const Range & range) override;
+  void updateEqualityTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateInequalityTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateBoundTargetData(scheme::internal::AssignmentTarget & target) override;
+  void updateObjectiveTargetData(scheme::internal::AssignmentTarget & target) override;
 
-  protected:
-    void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) override;
-    ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) override;
-    void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) override;
-    void addEqualityConstraint_(LinearConstraintPtr cstr) override;
-    void addIneqalityConstraint_(LinearConstraintPtr cstr) override;
-    void addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight) override;
-    void setMinimumNorm_() override;
-    void preAssignmentProcess_() override;
-    void postAssignmentProcess_() override;
-    bool solve_() override;
-    virtual const Eigen::VectorXd& result_() const override;
-    bool handleDoubleSidedConstraint_() const override { return false; }
-    Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    Range nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const override;
-    void removeBounds_(const Range& range) override;
-    void updateEqualityTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateInequalityTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateBoundTargetData(scheme::internal::AssignmentTarget& target) override;
-    void updateObjectiveTargetData(scheme::internal::AssignmentTarget& target) override;
+  void applyImpactLogic(ImpactFromChanges & impact);
 
-    void applyImpactLogic(ImpactFromChanges& impact);
+  void printProblemData_() const override;
+  void printDiagnostic_() const override;
 
+private:
+  using VectorXdSeg = decltype(Eigen::VectorXd().segment(0, 1));
+  using MatrixXdRows = decltype(Eigen::MatrixXd().middleRows(0, 1));
 
-    void printProblemData_() const override;
-    void printDiagnostic_() const override;
+  Eigen::MatrixXd D_; // We have Q = D^T D
+  Eigen::VectorXd e_; // We have c = D^t e
+  Eigen::MatrixXd Q_;
+  Eigen::VectorXd c_;
+  Eigen::MatrixXd A_;
+  Eigen::VectorXd b_;
 
-  private:
-    using VectorXdSeg = decltype(Eigen::VectorXd().segment(0,1));
-    using MatrixXdRows = decltype(Eigen::MatrixXd().middleRows(0,1));
+  MatrixXdRows Aineq_; // part of A_ corresponding to inequality constraints
+  VectorXdSeg bineq_; // part of b_ corresponding to inequality constraints
+  VectorXdSeg xl_; // part of b_ corresponding to lower bound constraints
+  VectorXdSeg xu_; // part of b_ corresponding to uppor bound constraints
 
-    Eigen::MatrixXd D_;   //We have Q = D^T D
-    Eigen::VectorXd e_;   //We have c = D^t e
-    Eigen::MatrixXd Q_;
-    Eigen::VectorXd c_;
-    Eigen::MatrixXd A_;
-    Eigen::VectorXd b_;
+  Eigen::QuadProgDense qpd_;
+  Eigen::HouseholderQR<Eigen::MatrixXd> qr_; // TODO add option for ColPiv variant
 
-    MatrixXdRows Aineq_; //part of A_ corresponding to inequality constraints
-    VectorXdSeg bineq_; //part of b_ corresponding to inequality constraints
-    VectorXdSeg xl_;    //part of b_ corresponding to lower bound constraints
-    VectorXdSeg xu_;    //part of b_ corresponding to uppor bound constraints
+  bool autoMinNorm_;
+  bool underspecifiedObj_; // true when nObj<n
+  int nIneqInclBounds_; // number of inequality constraints including bounds.
 
-    Eigen::QuadProgDense qpd_;
-    Eigen::HouseholderQR<Eigen::MatrixXd> qr_; //TODO add option for ColPiv variant
+  // options
+  double big_number_;
+  double damping_; // value added to the diagonal of Q for regularization (non Cholesky case)
+  bool cholesky_; // compute the Cholesky decomposition before calling the solver.
+  double choleskyDamping_; // if nObj<n, the cholesky factor R is trapezoidal. A multiple of
+                           // the identity is used to make it triangular using this value.
+};
 
-    bool autoMinNorm_;
-    bool underspecifiedObj_; //true when nObj<n
-    int nIneqInclBounds_; //number of inequality constraints including bounds.
+/** A factory class to create QuadprogLeastSquareSolver instances with a given
+ * set of options.
+ */
+class TVM_DLLAPI QuadprogLSSolverFactory : public abstract::LSSolverFactory
+{
+public:
+  std::unique_ptr<abstract::LSSolverFactory> clone() const override;
 
-    //options
-    double big_number_;
-    double damping_;  // value added to the diagonal of Q for regularization (non Cholesky case)
-    bool   cholesky_; // compute the Cholesky decomposition before calling the solver.
-    double choleskyDamping_; // if nObj<n, the cholesky factor R is trapezoidal. A multiple of 
-                             // the identity is used to make it triangular using this value.
-  };
+  /** Creation of a configuration from a set of options*/
+  QuadprogLSSolverFactory(const QuadprogLSSolverOptions & options = {});
 
-  
-  /** A factory class to create QuadprogLeastSquareSolver instances with a given
-    * set of options.
-    */
-  class TVM_DLLAPI QuadprogLSSolverFactory : public abstract::LSSolverFactory
-  {
-  public:
-    std::unique_ptr<abstract::LSSolverFactory> clone() const override;
-    
-    /** Creation of a configuration from a set of options*/
-    QuadprogLSSolverFactory(const QuadprogLSSolverOptions& options = {});
+  std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
 
-    std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
+private:
+  QuadprogLSSolverOptions options_;
+};
 
-  private:
-    QuadprogLSSolverOptions options_;
-  };
+} // namespace solver
 
-} // solver
-
-} // tvm
+} // namespace tvm

--- a/include/tvm/solver/abstract/LeastSquareSolver.h
+++ b/include/tvm/solver/abstract/LeastSquareSolver.h
@@ -18,227 +18,234 @@ namespace solver
 
 namespace abstract
 {
-  /** Base class for a (constrained) least-square solver.
-    *
-    * The problem to be solved has the general form
-    * min. ||Ax-b||^2
-    * s.t.      C_e x = d
-    *      l <= C_i x <= u
-    *         xl <= x <= xu
-    *
-    * where l or u might be set to -inf or +inf, and the explicit bounds are
-    * optionnal.
-    *
-    * When deriving this class, also remember to derive the factory class
-    * LSSolverFactory as well.
-    */
-  class TVM_DLLAPI LeastSquareSolver
-  {
-  public:
-    LeastSquareSolver(bool verbose = false);
-    LeastSquareSolver(const LeastSquareSolver&) = delete;
-    LeastSquareSolver& operator=(const LeastSquareSolver&) = delete;
-    virtual ~LeastSquareSolver() = default;
-    /** Open a build sequence for a problem on the current variables (set
-      * through the inherited ProblemComputationData::addVariable) with the
-      * specified dimensions, allocating the memory needed.
-      *
-      * \param x The variables of the problem. The object need to be valid until ::finalizeBuild is called.
-      * \param nObj Row size of A.
-      * \param nEq Row size of C_e.
-      * \param nIneq Row size of C_i.
-      * \param useBounds Presence of explicit bounds in the problem.
-      * \param subs Possible substitutions used for solving.
-      *
-      * Once a build is started, objective, constraints and bounds can be added
-      * through ::addObjective, ::addConstraint and ::addBound, until
-      * ::finalizeBuild is called.
-      */
-    void startBuild(const VariableVector& x, int nObj, int nEq, int nIneq, bool useBounds = true, const hint::internal::Substitutions* const subs = nullptr);
-    /** Finalize the build.*/
-    void finalizeBuild();
-
-    /** Add a bound constraint to the solver. If multiple bounds appears on the
-      * same variable, their intersection is taken.
-      */
-    void addBound(LinearConstraintPtr bound);
-
-    /** Add a constraint to the solver. */
-    void addConstraint(LinearConstraintPtr cstr);
-
-    /** Add an objective to the solver with given requirements
-      * \param obj The linear expression added in least-square form
-      * \param req The solving requirements. Only the weight-related requirements
-      *   will be taken into account
-      * \param additionalWeight An additional factor that will multiply the other weights.
-      */
-    void addObjective(LinearConstraintPtr obj, SolvingRequirementsPtr req, double additionalWeight = 1);
-
-    /** Set ||x||^2 as the least square objective of the problem.
-      * \warning this replace previously added objectives.
-      */
-    void setMinimumNorm();
-
-    /** Solve the problem
-      * \return true upon success of the resolution.
-      */
-    bool solve();
-
-    /** Get the result of the previous call to solve()*/
-    const Eigen::VectorXd& result() const;
-
-    /** Return the constraint size for the solver. This can be different from
-      * the actual constraint size if the constraint is a double-sided inequality
-      * but the solver only accept simple sided constraints
-      */
-    int constraintSize(const constraint::abstract::LinearConstraint& c) const;
-
-    /** Update the data according to the events
-      *
-      * \internal Assumes the vector of variables and substitions are the same as
-      * when the problem was built.
-      */
-    void process(const internal::SolverEvents& se);
-
-  protected:
-    struct ImpactFromChanges
-    {
-      bool equalityConstraints_   = false;
-      bool inequalityConstraints_ = false;
-      bool bounds_                = false;
-      bool objectives_            = false;
-
-      template<typename Derived>
-      static bool willReallocate(const Eigen::DenseBase<Derived>& M, int rows, int cols = 1);
-
-      ImpactFromChanges operator||(bool b);
-      ImpactFromChanges operator||(const ImpactFromChanges& other);
-      /** this = this || other*/
-      ImpactFromChanges& orAssign(const ImpactFromChanges& other);
-    };
-
-    virtual void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) = 0;
-    virtual ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) = 0;
-    virtual void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) = 0;
-    virtual void addEqualityConstraint_(LinearConstraintPtr cstr) = 0;
-    virtual void addIneqalityConstraint_(LinearConstraintPtr cstr) = 0;
-    virtual void addObjective_(LinearConstraintPtr obj, SolvingRequirementsPtr req, double additionalWeight=1) = 0;
-    virtual void setMinimumNorm_() = 0;
-    virtual void preAssignmentProcess_() {}
-    virtual void postAssignmentProcess_() {}
-    virtual bool solve_() = 0;
-    virtual const Eigen::VectorXd& result_() const = 0;
-    virtual bool handleDoubleSidedConstraint_() const = 0;
-    virtual Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const = 0;
-    virtual Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const = 0;
-    virtual Range nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const = 0;
-    /** Remove the bounds on variable at given range from the data passed to the
-      * solver (e.g. set the bounds to -/+Inf).
-      */
-    virtual void removeBounds_(const Range& range) = 0;
-    virtual void updateEqualityTargetData(scheme::internal::AssignmentTarget& target) = 0;
-    virtual void updateInequalityTargetData(scheme::internal::AssignmentTarget& target) = 0;
-    virtual void updateBoundTargetData(scheme::internal::AssignmentTarget& target) = 0;
-    virtual void updateObjectiveTargetData(scheme::internal::AssignmentTarget& target) = 0;
-
-    /** If for a derived class, the change on a category implies the change on
-      * others, \p impact is changed accordingly.
-      */
-    virtual void applyImpactLogic(ImpactFromChanges& impact);
-
-    virtual void printProblemData_() const = 0;
-    virtual void printDiagnostic_() const = 0;
-
-    const VariableVector& variables() const { return *variables_; }
-    const hint::internal::Substitutions* substitutions() const { return subs_; }
-
-    template<typename ... Args>
-    void addAssignement(Args&& ... args);
-
-  private:
-    void updateWeights(const internal::SolverEvents& se);
-    bool updateVariables(const internal::SolverEvents& se);
-    ImpactFromChanges processRemovedConstraints(const internal::SolverEvents& se);
-    ImpactFromChanges previewAddedConstraints(const internal::SolverEvents& se);
-    void processAddedConstraints(const internal::SolverEvents& se);
-
-  public:
-    struct MarkedAssignment
-    {
-      template<typename... Args>
-      MarkedAssignment(Args&&... args) : assignment(std::forward<Args>(args)...), markedForRemoval(false) {}
-      scheme::internal::Assignment assignment;
-      bool markedForRemoval;
-    };
-    template<typename K, typename T> using map = utils::internal::map<K, T>;
-    using AssignmentVector = std::vector<std::unique_ptr<MarkedAssignment>>;
-    using AssignmentPtrVector = std::vector<MarkedAssignment*>;
-    using MapToAssignment = map<constraint::abstract::LinearConstraint*, AssignmentPtrVector>;
-
-  protected:
-    int nEq_;
-    int nIneq_;
-    int nObj_;
-    int objSize_;
-    int eqSize_;
-    int ineqSize_;
-
-  private:
-    bool buildInProgress_;
-    bool verbose_;
-    VariableVector const* variables_;
-    /** Used to track what is the first bound applied to a given variable, if any. */
-    map<Variable*, std::vector<constraint::abstract::LinearConstraint*>> boundsOrder_;
-    /** List of assignments used for assembling the problem data. */
-    AssignmentVector assignments_;
-    /** Keeping tracks of which assignments are associated to a constraint.
-      * \todo most of the times, there will be a single assignment per constraint.
-      * This would be a good place to use small vector-like container.
-      */
-    MapToAssignment objectiveToAssignments_;
-    MapToAssignment equalityConstraintToAssignments_;
-    MapToAssignment inequalityConstraintToAssignments_;
-    MapToAssignment boundToAssignments_;
-    const hint::internal::Substitutions* subs_;
-  };
-
-
-  /** A base class for LeastSquareSolver factory.
+/** Base class for a (constrained) least-square solver.
+ *
+ * The problem to be solved has the general form
+ * min. ||Ax-b||^2
+ * s.t.      C_e x = d
+ *      l <= C_i x <= u
+ *         xl <= x <= xu
+ *
+ * where l or u might be set to -inf or +inf, and the explicit bounds are
+ * optionnal.
+ *
+ * When deriving this class, also remember to derive the factory class
+ * LSSolverFactory as well.
+ */
+class TVM_DLLAPI LeastSquareSolver
+{
+public:
+  LeastSquareSolver(bool verbose = false);
+  LeastSquareSolver(const LeastSquareSolver &) = delete;
+  LeastSquareSolver & operator=(const LeastSquareSolver &) = delete;
+  virtual ~LeastSquareSolver() = default;
+  /** Open a build sequence for a problem on the current variables (set
+   * through the inherited ProblemComputationData::addVariable) with the
+   * specified dimensions, allocating the memory needed.
    *
-   * The goal of this class is to be passed to a resolution scheme to specify
-   * its underlying solver.
+   * \param x The variables of the problem. The object need to be valid until ::finalizeBuild is called.
+   * \param nObj Row size of A.
+   * \param nEq Row size of C_e.
+   * \param nIneq Row size of C_i.
+   * \param useBounds Presence of explicit bounds in the problem.
+   * \param subs Possible substitutions used for solving.
+   *
+   * Once a build is started, objective, constraints and bounds can be added
+   * through ::addObjective, ::addConstraint and ::addBound, until
+   * ::finalizeBuild is called.
    */
-  class TVM_DLLAPI LSSolverFactory
+  void startBuild(const VariableVector & x,
+                  int nObj,
+                  int nEq,
+                  int nIneq,
+                  bool useBounds = true,
+                  const hint::internal::Substitutions * const subs = nullptr);
+  /** Finalize the build.*/
+  void finalizeBuild();
+
+  /** Add a bound constraint to the solver. If multiple bounds appears on the
+   * same variable, their intersection is taken.
+   */
+  void addBound(LinearConstraintPtr bound);
+
+  /** Add a constraint to the solver. */
+  void addConstraint(LinearConstraintPtr cstr);
+
+  /** Add an objective to the solver with given requirements
+   * \param obj The linear expression added in least-square form
+   * \param req The solving requirements. Only the weight-related requirements
+   *   will be taken into account
+   * \param additionalWeight An additional factor that will multiply the other weights.
+   */
+  void addObjective(LinearConstraintPtr obj, SolvingRequirementsPtr req, double additionalWeight = 1);
+
+  /** Set ||x||^2 as the least square objective of the problem.
+   * \warning this replace previously added objectives.
+   */
+  void setMinimumNorm();
+
+  /** Solve the problem
+   * \return true upon success of the resolution.
+   */
+  bool solve();
+
+  /** Get the result of the previous call to solve()*/
+  const Eigen::VectorXd & result() const;
+
+  /** Return the constraint size for the solver. This can be different from
+   * the actual constraint size if the constraint is a double-sided inequality
+   * but the solver only accept simple sided constraints
+   */
+  int constraintSize(const constraint::abstract::LinearConstraint & c) const;
+
+  /** Update the data according to the events
+   *
+   * \internal Assumes the vector of variables and substitions are the same as
+   * when the problem was built.
+   */
+  void process(const internal::SolverEvents & se);
+
+protected:
+  struct ImpactFromChanges
   {
-  protected:
-    LSSolverFactory(const std::string& solverName)
-      : solverName_(solverName) {}
+    bool equalityConstraints_ = false;
+    bool inequalityConstraints_ = false;
+    bool bounds_ = false;
+    bool objectives_ = false;
 
-  public:
-    virtual ~LSSolverFactory() = default;
+    template<typename Derived>
+    static bool willReallocate(const Eigen::DenseBase<Derived> & M, int rows, int cols = 1);
 
-    virtual std::unique_ptr<LSSolverFactory> clone() const = 0;
-    virtual std::unique_ptr<LeastSquareSolver> createSolver() const = 0;
-
-  private:
-    std::string solverName_;
+    ImpactFromChanges operator||(bool b);
+    ImpactFromChanges operator||(const ImpactFromChanges & other);
+    /** this = this || other*/
+    ImpactFromChanges & orAssign(const ImpactFromChanges & other);
   };
 
+  virtual void initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds) = 0;
+  virtual ImpactFromChanges resize_(int nObj, int nEq, int nIneq, bool useBounds) = 0;
+  virtual void addBound_(LinearConstraintPtr bound, RangePtr range, bool first) = 0;
+  virtual void addEqualityConstraint_(LinearConstraintPtr cstr) = 0;
+  virtual void addIneqalityConstraint_(LinearConstraintPtr cstr) = 0;
+  virtual void addObjective_(LinearConstraintPtr obj, SolvingRequirementsPtr req, double additionalWeight = 1) = 0;
+  virtual void setMinimumNorm_() = 0;
+  virtual void preAssignmentProcess_() {}
+  virtual void postAssignmentProcess_() {}
+  virtual bool solve_() = 0;
+  virtual const Eigen::VectorXd & result_() const = 0;
+  virtual bool handleDoubleSidedConstraint_() const = 0;
+  virtual Range nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const = 0;
+  virtual Range nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const = 0;
+  virtual Range nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const = 0;
+  /** Remove the bounds on variable at given range from the data passed to the
+   * solver (e.g. set the bounds to -/+Inf).
+   */
+  virtual void removeBounds_(const Range & range) = 0;
+  virtual void updateEqualityTargetData(scheme::internal::AssignmentTarget & target) = 0;
+  virtual void updateInequalityTargetData(scheme::internal::AssignmentTarget & target) = 0;
+  virtual void updateBoundTargetData(scheme::internal::AssignmentTarget & target) = 0;
+  virtual void updateObjectiveTargetData(scheme::internal::AssignmentTarget & target) = 0;
 
-  template<typename ...Args>
-  inline void LeastSquareSolver::addAssignement(Args&& ... args)
+  /** If for a derived class, the change on a category implies the change on
+   * others, \p impact is changed accordingly.
+   */
+  virtual void applyImpactLogic(ImpactFromChanges & impact);
+
+  virtual void printProblemData_() const = 0;
+  virtual void printDiagnostic_() const = 0;
+
+  const VariableVector & variables() const { return *variables_; }
+  const hint::internal::Substitutions * substitutions() const { return subs_; }
+
+  template<typename... Args>
+  void addAssignement(Args &&... args);
+
+private:
+  void updateWeights(const internal::SolverEvents & se);
+  bool updateVariables(const internal::SolverEvents & se);
+  ImpactFromChanges processRemovedConstraints(const internal::SolverEvents & se);
+  ImpactFromChanges previewAddedConstraints(const internal::SolverEvents & se);
+  void processAddedConstraints(const internal::SolverEvents & se);
+
+public:
+  struct MarkedAssignment
   {
-    assignments_.emplace_back(new MarkedAssignment(std::forward<Args>(args)...));
-  }
+    template<typename... Args>
+    MarkedAssignment(Args &&... args) : assignment(std::forward<Args>(args)...), markedForRemoval(false)
+    {
+    }
+    scheme::internal::Assignment assignment;
+    bool markedForRemoval;
+  };
+  template<typename K, typename T>
+  using map = utils::internal::map<K, T>;
+  using AssignmentVector = std::vector<std::unique_ptr<MarkedAssignment>>;
+  using AssignmentPtrVector = std::vector<MarkedAssignment *>;
+  using MapToAssignment = map<constraint::abstract::LinearConstraint *, AssignmentPtrVector>;
 
-  template<typename Derived>
-  inline bool LeastSquareSolver::ImpactFromChanges::willReallocate(const Eigen::DenseBase<Derived>& M, int rows, int cols)
-  {
-    return M.rows() * M.cols() != rows * cols;
-  }
+protected:
+  int nEq_;
+  int nIneq_;
+  int nObj_;
+  int objSize_;
+  int eqSize_;
+  int ineqSize_;
 
+private:
+  bool buildInProgress_;
+  bool verbose_;
+  VariableVector const * variables_;
+  /** Used to track what is the first bound applied to a given variable, if any. */
+  map<Variable *, std::vector<constraint::abstract::LinearConstraint *>> boundsOrder_;
+  /** List of assignments used for assembling the problem data. */
+  AssignmentVector assignments_;
+  /** Keeping tracks of which assignments are associated to a constraint.
+   * \todo most of the times, there will be a single assignment per constraint.
+   * This would be a good place to use small vector-like container.
+   */
+  MapToAssignment objectiveToAssignments_;
+  MapToAssignment equalityConstraintToAssignments_;
+  MapToAssignment inequalityConstraintToAssignments_;
+  MapToAssignment boundToAssignments_;
+  const hint::internal::Substitutions * subs_;
+};
+
+/** A base class for LeastSquareSolver factory.
+ *
+ * The goal of this class is to be passed to a resolution scheme to specify
+ * its underlying solver.
+ */
+class TVM_DLLAPI LSSolverFactory
+{
+protected:
+  LSSolverFactory(const std::string & solverName) : solverName_(solverName) {}
+
+public:
+  virtual ~LSSolverFactory() = default;
+
+  virtual std::unique_ptr<LSSolverFactory> clone() const = 0;
+  virtual std::unique_ptr<LeastSquareSolver> createSolver() const = 0;
+
+private:
+  std::string solverName_;
+};
+
+template<typename... Args>
+inline void LeastSquareSolver::addAssignement(Args &&... args)
+{
+  assignments_.emplace_back(new MarkedAssignment(std::forward<Args>(args)...));
 }
 
+template<typename Derived>
+inline bool LeastSquareSolver::ImpactFromChanges::willReallocate(const Eigen::DenseBase<Derived> & M,
+                                                                 int rows,
+                                                                 int cols)
+{
+  return M.rows() * M.cols() != rows * cols;
 }
 
-}
+} // namespace abstract
+
+} // namespace solver
+
+} // namespace tvm

--- a/include/tvm/solver/abstract/LeastSquareSolver.h
+++ b/include/tvm/solver/abstract/LeastSquareSolver.h
@@ -172,8 +172,7 @@ public:
   {
     template<typename... Args>
     MarkedAssignment(Args &&... args) : assignment(std::forward<Args>(args)...), markedForRemoval(false)
-    {
-    }
+    {}
     scheme::internal::Assignment assignment;
     bool markedForRemoval;
   };

--- a/include/tvm/solver/abstract/LeastSquareSolver.h
+++ b/include/tvm/solver/abstract/LeastSquareSolver.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
 #include <tvm/hint/internal/Substitutions.h>
 #include <tvm/scheme/internal/Assignment.h>
 #include <tvm/solver/internal/Option.h>

--- a/include/tvm/solver/defaultLeastSquareSolver.h
+++ b/include/tvm/solver/defaultLeastSquareSolver.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/solver/defaultLeastSquareSolver.h
+++ b/include/tvm/solver/defaultLeastSquareSolver.h
@@ -1,84 +1,84 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 /** Since all solver might not be available depending on the option compilations,
-  * this header offers conveniencies to include and use a default solver.
-  * The first solver found in this (ordered) list is taken as default:
-  * LSSOL, QLD, Quadprog
-  */
+ * this header offers conveniencies to include and use a default solver.
+ * The first solver found in this (ordered) list is taken as default:
+ * LSSOL, QLD, Quadprog
+ */
 #ifdef TVM_USE_LSSOL
-# include <tvm/solver/LSSOLLeastSquareSolver.h>
+#  include <tvm/solver/LSSOLLeastSquareSolver.h>
 #else
-# ifdef TVM_USE_QLD
-#   include <tvm/solver/QLDLeastSquareSolver.h>
-# else
-#   ifdef TVM_USE_QUADPROG
-#     include <tvm/solver/QuadprogLeastSquareSolver.h>
-#   else
-#     error "You should at least have one solver. If not, there is a problem with the CMakeLists.txt"
-#   endif
-# endif
+#  ifdef TVM_USE_QLD
+#    include <tvm/solver/QLDLeastSquareSolver.h>
+#  else
+#    ifdef TVM_USE_QUADPROG
+#      include <tvm/solver/QuadprogLeastSquareSolver.h>
+#    else
+#      error "You should at least have one solver. If not, there is a problem with the CMakeLists.txt"
+#    endif
+#  endif
 #endif
 
 namespace tvm::solver
 {
-  class DefaultLSSolverFactory;
+class DefaultLSSolverFactory;
 
-  /** A minimal set of options for the default solver.
-    *
-    * \internal There should only be non default options here.
-    */
-  class TVM_DLLAPI DefaultLSSolverOptions
-  {
-    TVM_ADD_NON_DEFAULT_OPTION(big_number, constant::big_number)
-    TVM_ADD_NON_DEFAULT_OPTION(verbose, false)
+/** A minimal set of options for the default solver.
+ *
+ * \internal There should only be non default options here.
+ */
+class TVM_DLLAPI DefaultLSSolverOptions
+{
+  TVM_ADD_NON_DEFAULT_OPTION(big_number, constant::big_number)
+  TVM_ADD_NON_DEFAULT_OPTION(verbose, false)
 
-  public:
-    using Factory = DefaultLSSolverFactory;
-  };
+public:
+  using Factory = DefaultLSSolverFactory;
+};
 
-  /** A factory class to create default solver instances with a given
-    * set of options.
-    */
-  class TVM_DLLAPI DefaultLSSolverFactory : public abstract::LSSolverFactory
-  {
-  public:
-    std::unique_ptr<abstract::LSSolverFactory> clone() const override;
+/** A factory class to create default solver instances with a given
+ * set of options.
+ */
+class TVM_DLLAPI DefaultLSSolverFactory : public abstract::LSSolverFactory
+{
+public:
+  std::unique_ptr<abstract::LSSolverFactory> clone() const override;
 
-    /** Creation of a configuration from a set of options*/
-    DefaultLSSolverFactory(const DefaultLSSolverOptions& options = {});
+  /** Creation of a configuration from a set of options*/
+  DefaultLSSolverFactory(const DefaultLSSolverOptions & options = {});
 
-    std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
+  std::unique_ptr<abstract::LeastSquareSolver> createSolver() const override;
 
-  private:
-    DefaultLSSolverOptions options_;
-  };
-}
+private:
+  DefaultLSSolverOptions options_;
+};
+} // namespace tvm::solver

--- a/include/tvm/solver/internal/Option.h
+++ b/include/tvm/solver/internal/Option.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/solver/internal/Option.h
+++ b/include/tvm/solver/internal/Option.h
@@ -1,67 +1,71 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
-#include <type_traits>
 #include <optional>
+#include <type_traits>
 
 /** Adding getter and setter for the option \a optionName of type \a type. */
 #define TVM_ADD_OPTION_GET_SET(optionName, type)                           \
 public:                                                                    \
-  const std::optional<type>& optionName() const { return optionName##_; }  \
-  auto& optionName(const type& v) { optionName##_ = v; return *this; }
+  const std::optional<type> & optionName() const { return optionName##_; } \
+  auto & optionName(const type & v)                                        \
+  {                                                                        \
+    optionName##_ = v;                                                     \
+    return *this;                                                          \
+  }
 
-/** Adding an option \a optionName of type \a type with no default value. 
-  * (The default value of the underlying solver will be used.
-  */
-#define TVM_ADD_DEFAULT_OPTION(optionName, type)  \
-private:                                          \
-  using optionName##_t = type;                    \
-  std::optional<type> optionName##_;              \
-TVM_ADD_OPTION_GET_SET(optionName, type)
+/** Adding an option \a optionName of type \a type with no default value.
+ * (The default value of the underlying solver will be used.
+ */
+#define TVM_ADD_DEFAULT_OPTION(optionName, type) \
+private:                                         \
+  using optionName##_t = type;                   \
+  std::optional<type> optionName##_;             \
+  TVM_ADD_OPTION_GET_SET(optionName, type)
 
-/** Adding an option \a optionName with new default value \a defaultValue, that 
-  * will replace the value of the underlying solver.
-  */
+/** Adding an option \a optionName with new default value \a defaultValue, that
+ * will replace the value of the underlying solver.
+ */
 #define TVM_ADD_NON_DEFAULT_OPTION(optionName, defaultValue)          \
 private:                                                              \
   using optionName##_t = std::remove_const_t<decltype(defaultValue)>; \
   std::optional<optionName##_t> optionName##_ = defaultValue;         \
-TVM_ADD_OPTION_GET_SET(optionName, optionName##_t)
+  TVM_ADD_OPTION_GET_SET(optionName, optionName##_t)
 
-/** Process \a optionName: if \a optionName has a non-default value, use 
-  * \a target.setterName to set that value for \a target.
-  */
-#define TVM_PROCESS_OPTION_2(optionName, target, setterName)  \
-if (options.optionName())                                     \
-  target.setterName(options.optionName().value());
+/** Process \a optionName: if \a optionName has a non-default value, use
+ * \a target.setterName to set that value for \a target.
+ */
+#define TVM_PROCESS_OPTION_2(optionName, target, setterName) \
+  if(options.optionName())                                   \
+    target.setterName(options.optionName().value());
 
 /** Specialized version of TVM_PROCESS_OPTION_2 where \a setterName = \a optionName. */
 #define TVM_PROCESS_OPTION(optionName, target) TVM_PROCESS_OPTION_2(optionName, target, optionName)

--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -9,165 +9,155 @@
 
 namespace tvm::solver::internal
 {
-  /** An agregation of all the events to be handled by a solver*/
-  class SolverEvents
+/** An agregation of all the events to be handled by a solver*/
+class SolverEvents
+{
+public:
+  struct WeightEvent
   {
-  public:
-    struct WeightEvent
-    {
-      constraint::abstract::LinearConstraint* c;
-      bool scalar;
-      bool vector;
-    };
-
-    struct Objective
-    {
-      LinearConstraintPtr c;
-      SolvingRequirementsPtr req;
-      double scalarizationWeight;
-    };
-
-
-    void addScalarWeigthEvent(constraint::abstract::LinearConstraint* c);
-    void addVectorWeigthEvent(constraint::abstract::LinearConstraint* c);
-
-    void addConstraint(LinearConstraintPtr c);
-    void removeConstraint(LinearConstraintPtr c);
-    void addBound(LinearConstraintPtr c);
-    void removeBound(LinearConstraintPtr c);
-    void addObjective(const Objective& o);
-    void removeObjective(LinearConstraintPtr o);
-
-    void addVariable(VariablePtr v);
-    void removeVariable(VariablePtr v);
-
-    const std::vector<WeightEvent>& weightEvents() const { return weightEvents_; }
-    const std::vector<LinearConstraintPtr>& addedConstraints() const { return addedConstraints_; }
-    const std::vector<LinearConstraintPtr>& addedBounds() const { return addedBounds_; }
-    const std::vector<Objective>& addedObjectives() const { return addedObjectives_; }
-    const std::vector<LinearConstraintPtr>& removedConstraints() const { return removedConstraints_; }
-    const std::vector<LinearConstraintPtr>& removedBounds() const { return removedBounds_; }
-    const std::vector<LinearConstraintPtr>& removedObjectives() const { return removedObjectives_; }
-
-    const std::vector<VariablePtr>& addedVariables() const { return addedVariables_; }
-    const std::vector<VariablePtr>& removedVariables() const { return removedVariables_; }
-
-    /** Adding and removing variable may cancel one another so that addedVariables 
-      * and removedVariables will not keep track of these changes. But the underlying 
-      * variable vector may have changed with a variable removed then added being
-      * at a different place.
-      */
-    bool hasHiddenVariableChange() const { return hiddenVariableChange_; }
-
-  private:
-    /** If c is in removeVec, remove it, otherwise, add it to addVec. Return true in the second case.*/
-    template<typename T>
-    bool addIfPair(T& c, std::vector<T>& addVec, std::vector<T>& removeVec);
-
-    /** \internal We don't anticipate to have many events at the same time so 
-      * that searching in the vector will be fast. If it was not the case, we can
-      * change the data structure, or add one to speed up search.*/
-    std::vector<WeightEvent> weightEvents_;
-
-    std::vector<LinearConstraintPtr> addedConstraints_;
-    std::vector<LinearConstraintPtr> addedBounds_;
-    std::vector<Objective> addedObjectives_;
-    std::vector<LinearConstraintPtr> removedConstraints_;
-    std::vector<LinearConstraintPtr> removedBounds_;
-    std::vector<LinearConstraintPtr> removedObjectives_;
-
-    std::vector<VariablePtr> addedVariables_;
-    std::vector<VariablePtr> removedVariables_;
-    bool hiddenVariableChange_;
+    constraint::abstract::LinearConstraint * c;
+    bool scalar;
+    bool vector;
   };
 
-  inline void SolverEvents::addScalarWeigthEvent(constraint::abstract::LinearConstraint* c)
+  struct Objective
   {
-    for (auto& e : weightEvents_)
-    {
-      if (e.c == c)
-      {
-        e.scalar = true;
-        return;
-      }
-    }
+    LinearConstraintPtr c;
+    SolvingRequirementsPtr req;
+    double scalarizationWeight;
+  };
 
-    weightEvents_.push_back({ c, true, false });
-  }
+  void addScalarWeigthEvent(constraint::abstract::LinearConstraint * c);
+  void addVectorWeigthEvent(constraint::abstract::LinearConstraint * c);
 
-  inline void SolverEvents::addVectorWeigthEvent(constraint::abstract::LinearConstraint* c)
-  {
-    for (auto& e : weightEvents_)
-    {
-      if (e.c == c)
-      {
-        e.vector = true;
-        return;
-      }
-    }
+  void addConstraint(LinearConstraintPtr c);
+  void removeConstraint(LinearConstraintPtr c);
+  void addBound(LinearConstraintPtr c);
+  void removeBound(LinearConstraintPtr c);
+  void addObjective(const Objective & o);
+  void removeObjective(LinearConstraintPtr o);
 
-    weightEvents_.push_back({ c, false, true });
-  }
+  void addVariable(VariablePtr v);
+  void removeVariable(VariablePtr v);
 
-  inline void SolverEvents::addConstraint(LinearConstraintPtr c)
-  {
-    addIfPair(c, addedConstraints_, removedConstraints_);
-  }
+  const std::vector<WeightEvent> & weightEvents() const { return weightEvents_; }
+  const std::vector<LinearConstraintPtr> & addedConstraints() const { return addedConstraints_; }
+  const std::vector<LinearConstraintPtr> & addedBounds() const { return addedBounds_; }
+  const std::vector<Objective> & addedObjectives() const { return addedObjectives_; }
+  const std::vector<LinearConstraintPtr> & removedConstraints() const { return removedConstraints_; }
+  const std::vector<LinearConstraintPtr> & removedBounds() const { return removedBounds_; }
+  const std::vector<LinearConstraintPtr> & removedObjectives() const { return removedObjectives_; }
 
-  inline void SolverEvents::removeConstraint(LinearConstraintPtr c)
-  {
-    addIfPair(c, removedConstraints_, addedConstraints_);
-  }
+  const std::vector<VariablePtr> & addedVariables() const { return addedVariables_; }
+  const std::vector<VariablePtr> & removedVariables() const { return removedVariables_; }
 
-  inline void SolverEvents::addBound(LinearConstraintPtr b)
-  {
-    addIfPair(b, addedBounds_, removedBounds_);
-  }
+  /** Adding and removing variable may cancel one another so that addedVariables
+   * and removedVariables will not keep track of these changes. But the underlying
+   * variable vector may have changed with a variable removed then added being
+   * at a different place.
+   */
+  bool hasHiddenVariableChange() const { return hiddenVariableChange_; }
 
-  inline void SolverEvents::removeBound(LinearConstraintPtr b)
-  {
-    addIfPair(b, removedBounds_, addedBounds_);
-  }
-
-  inline void SolverEvents::addObjective(const Objective& o)
-  {
-    auto it = std::find(removedObjectives_.begin(), removedObjectives_.end(), o.c);
-    if (it == removedObjectives_.end())
-      addedObjectives_.push_back(o);
-    else
-      removedObjectives_.erase(it);
-  }
-
-  inline void SolverEvents::removeObjective(LinearConstraintPtr o)
-  {
-    auto it = std::find_if(addedObjectives_.begin(), addedObjectives_.end(), [&o](const auto& it) {return it.c == o; });
-    if (it == addedObjectives_.end())
-      removedObjectives_.push_back(o);
-    else
-      addedObjectives_.erase(it);
-  }
-
-  inline void SolverEvents::addVariable(VariablePtr v)
-  {
-    if (!addIfPair(v, addedVariables_, removedVariables_))
-      hiddenVariableChange_ = true;
-  }
-
-  inline void SolverEvents::removeVariable(VariablePtr v)
-  {
-    if (!addIfPair(v, removedVariables_, addedVariables_))
-      hiddenVariableChange_ = true;
-  }
-
+private:
+  /** If c is in removeVec, remove it, otherwise, add it to addVec. Return true in the second case.*/
   template<typename T>
-  inline bool SolverEvents::addIfPair(T& c, std::vector<T>& addVec, std::vector<T>& removeVec)
+  bool addIfPair(T & c, std::vector<T> & addVec, std::vector<T> & removeVec);
+
+  /** \internal We don't anticipate to have many events at the same time so
+   * that searching in the vector will be fast. If it was not the case, we can
+   * change the data structure, or add one to speed up search.*/
+  std::vector<WeightEvent> weightEvents_;
+
+  std::vector<LinearConstraintPtr> addedConstraints_;
+  std::vector<LinearConstraintPtr> addedBounds_;
+  std::vector<Objective> addedObjectives_;
+  std::vector<LinearConstraintPtr> removedConstraints_;
+  std::vector<LinearConstraintPtr> removedBounds_;
+  std::vector<LinearConstraintPtr> removedObjectives_;
+
+  std::vector<VariablePtr> addedVariables_;
+  std::vector<VariablePtr> removedVariables_;
+  bool hiddenVariableChange_;
+};
+
+inline void SolverEvents::addScalarWeigthEvent(constraint::abstract::LinearConstraint * c)
+{
+  for(auto & e : weightEvents_)
   {
-    auto it = std::find(removeVec.begin(), removeVec.end(), c);
-    bool notFound = it == removeVec.end();
-    if (notFound)
-      addVec.push_back(c);
-    else
-      removeVec.erase(it);
-    return notFound;
+    if(e.c == c)
+    {
+      e.scalar = true;
+      return;
+    }
   }
+
+  weightEvents_.push_back({c, true, false});
 }
+
+inline void SolverEvents::addVectorWeigthEvent(constraint::abstract::LinearConstraint * c)
+{
+  for(auto & e : weightEvents_)
+  {
+    if(e.c == c)
+    {
+      e.vector = true;
+      return;
+    }
+  }
+
+  weightEvents_.push_back({c, false, true});
+}
+
+inline void SolverEvents::addConstraint(LinearConstraintPtr c) { addIfPair(c, addedConstraints_, removedConstraints_); }
+
+inline void SolverEvents::removeConstraint(LinearConstraintPtr c)
+{
+  addIfPair(c, removedConstraints_, addedConstraints_);
+}
+
+inline void SolverEvents::addBound(LinearConstraintPtr b) { addIfPair(b, addedBounds_, removedBounds_); }
+
+inline void SolverEvents::removeBound(LinearConstraintPtr b) { addIfPair(b, removedBounds_, addedBounds_); }
+
+inline void SolverEvents::addObjective(const Objective & o)
+{
+  auto it = std::find(removedObjectives_.begin(), removedObjectives_.end(), o.c);
+  if(it == removedObjectives_.end())
+    addedObjectives_.push_back(o);
+  else
+    removedObjectives_.erase(it);
+}
+
+inline void SolverEvents::removeObjective(LinearConstraintPtr o)
+{
+  auto it = std::find_if(addedObjectives_.begin(), addedObjectives_.end(), [&o](const auto & it) { return it.c == o; });
+  if(it == addedObjectives_.end())
+    removedObjectives_.push_back(o);
+  else
+    addedObjectives_.erase(it);
+}
+
+inline void SolverEvents::addVariable(VariablePtr v)
+{
+  if(!addIfPair(v, addedVariables_, removedVariables_))
+    hiddenVariableChange_ = true;
+}
+
+inline void SolverEvents::removeVariable(VariablePtr v)
+{
+  if(!addIfPair(v, removedVariables_, addedVariables_))
+    hiddenVariableChange_ = true;
+}
+
+template<typename T>
+inline bool SolverEvents::addIfPair(T & c, std::vector<T> & addVec, std::vector<T> & removeVec)
+{
+  auto it = std::find(removeVec.begin(), removeVec.end(), c);
+  bool notFound = it == removeVec.end();
+  if(notFound)
+    addVec.push_back(c);
+  else
+    removeVec.erase(it);
+  return notFound;
+}
+} // namespace tvm::solver::internal

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -122,8 +122,7 @@ template<class TD, class TDImpl>
 template<typename... Args>
 inline Clamped<TD, TDImpl>::Clamped(double max, Args &&... args)
 : Clamped<TD, TDImpl>({-max, max}, std::forward<Args>(args)...)
-{
-}
+{}
 
 template<class TD, class TDImpl>
 template<typename... Args>
@@ -145,8 +144,7 @@ template<class TD, class TDImpl>
 template<typename... Args>
 inline Clamped<TD, TDImpl>::Clamped(const VectorConstRef & max, Args &&... args)
 : Clamped<TD>({-max, max}, std::forward<Args>(args)...)
-{
-}
+{}
 
 template<class TD, class TDImpl>
 template<typename... Args>

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -10,6 +10,7 @@
 #include <mpark/variant.hpp>
 
 #include <tvm/defs.h>
+
 #include <tvm/function/abstract/Function.h>
 #include <tvm/task_dynamics/abstract/TaskDynamics.h>
 

--- a/include/tvm/task_dynamics/Clamped.h
+++ b/include/tvm/task_dynamics/Clamped.h
@@ -15,197 +15,207 @@
 
 namespace tvm::task_dynamics
 {
-  /** Given a task dynamics value \f$ e^{(k)*} \f$, compute the new value
-    * \f$ e_c^{(k)*} = s e^{(k)*} \f$, \f$ s \in [0, 1] \f$, such that
-    * \f$ b_{min} \leq \ e_c^{(k)*} \leq b_{max}\f$ where \f$ b_{min} \f$ and
-    * \f$ b_{max} \f$ are given bounds, specified as scalars or vectors.
-    */
-  template <class TD, class TDImpl = typename TD::Impl>
-  class Clamped : public TD
+/** Given a task dynamics value \f$ e^{(k)*} \f$, compute the new value
+ * \f$ e_c^{(k)*} = s e^{(k)*} \f$, \f$ s \in [0, 1] \f$, such that
+ * \f$ b_{min} \leq \ e_c^{(k)*} \leq b_{max}\f$ where \f$ b_{min} \f$ and
+ * \f$ b_{max} \f$ are given bounds, specified as scalars or vectors.
+ */
+template<class TD, class TDImpl = typename TD::Impl>
+class Clamped : public TD
+{
+public:
+  using Bounds = mpark::variant<double, Eigen::VectorXd>;
+
+  class Impl : public TDImpl
   {
   public:
-    using Bounds = mpark::variant<double, Eigen::VectorXd>;
+    template<typename... Args>
+    Impl(FunctionPtr f,
+         constraint::Type t,
+         const Eigen::VectorXd & rhs,
+         const Bounds & min,
+         const Bounds & max,
+         Args &&... args);
+    void updateValue() override;
+    ~Impl() override = default;
 
-    class Impl : public TDImpl
-    {
-    public:
-      template<typename ... Args>
-      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const Bounds& min, const Bounds& max, Args&& ... args);
-      void updateValue() override;
-      ~Impl() override = default;
-
-      /** Access to \f$ b_{min} \f$. */
-      const Eigen::VectorXd& min() const { return min_; }
-      /** Access to \f$ b_{min} \f$.
-        *
-        * \warning It is your responsibility to give a valid \f$ b_{min} \f$ i.e.
-        *  * correct size
-        *  * \f$ b_{min} \leq 0 \leq b_{max}\f$
-        */
-      Eigen::VectorXd& min() { return min_; }
-      /** Access to \f$ b_{max} \f$. */
-      const Eigen::VectorXd& max() const { return max_; }
-      /** Access to \f$ b_{max} \f$.
-        *
-        * \warning It is your responsibility to give a valid \f$ b_{max} \f$ i.e.
-        *  * correct size
-        *  * \f$ b_{min} \leq 0 \leq b_{max}\f$
-        */
-      Eigen::VectorXd& max() { return max_; }
-
-    private:
-      Eigen::VectorXd min_;
-      Eigen::VectorXd max_;
-    };
-
-    /** Constructor with \f$ b_{min} = -b_{max}\f$  (scalar version).
-      *
-      * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
-      *        have, in absolute value (\f$ b_{max}\f$).
-      * \param args These are forwarded to the TD constructor
-      */
-    template<typename ... Args>
-    Clamped(double max, Args&& ... args);
-
-    /** Constructor with \f$b_{min}\f$ and \f$b_{max}\f$  (scalar version).
-      *
-      * \param minMax The minimum (\f$b_{min}\f$) and maximum (\f$b_{max}\f$)
-      *               value that a component of \f$ e_c^{(k)*}\f$ can have. We require that
-      *               \f$b_{min} \leq 0 \leq b_{max}\f$.
-      * \param args These are forwarded to the TD constructor
-      */
-    template<typename ... Args>
-    Clamped(const std::pair<double, double>& minMax, Args&& ... args);
-
-    /** Constructor with \f$ b_{min} = -b_{max}\f$  (vector version).
-      *
-      * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
-      *        have, in absolute value (\f$ b_{max}\f$).
-      * \param args These are forwarded to the TD constructor
-      */
-    template<typename ... Args>
-    Clamped(const VectorConstRef& max, Args&& ... args);
-
-    /** Constructor with \f$b_{min}\f$ and \f$b_{max}\f$  (vector version).
-      *
-      * \param minMax The minimum (\f$b_{min}\f$) and maximum (\f$b_{max}\f$)
-      *               value that a component of \f$ e_c^{(k)*}\f$ can have. We require that
-      *               \f$b_{min} \leq 0 \leq b_{max}\f$.
-      * \param args These are forwarded to the TD constructor
-      */
-    template<typename ... Args>
-    Clamped(const std::pair<VectorConstRef, VectorConstRef>& minMax, Args&& ... args);
-
-    ~Clamped() override = default;
-
-  protected:
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override
-    {
-      return TD::template impl_<Impl>(f, t, rhs, min_, max_);
-    }
-
-    COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(TD, min_, max_)
+    /** Access to \f$ b_{min} \f$. */
+    const Eigen::VectorXd & min() const { return min_; }
+    /** Access to \f$ b_{min} \f$.
+     *
+     * \warning It is your responsibility to give a valid \f$ b_{min} \f$ i.e.
+     *  * correct size
+     *  * \f$ b_{min} \leq 0 \leq b_{max}\f$
+     */
+    Eigen::VectorXd & min() { return min_; }
+    /** Access to \f$ b_{max} \f$. */
+    const Eigen::VectorXd & max() const { return max_; }
+    /** Access to \f$ b_{max} \f$.
+     *
+     * \warning It is your responsibility to give a valid \f$ b_{max} \f$ i.e.
+     *  * correct size
+     *  * \f$ b_{min} \leq 0 \leq b_{max}\f$
+     */
+    Eigen::VectorXd & max() { return max_; }
 
   private:
-    Bounds min_;
-    Bounds max_;
+    Eigen::VectorXd min_;
+    Eigen::VectorXd max_;
   };
 
-  template<class TD, class TDImpl>
-  template<typename ... Args>
-  inline Clamped<TD, TDImpl>::Clamped(double max, Args&& ... args)
-    : Clamped<TD, TDImpl>({-max, max}, std::forward<Args>(args)...)
+  /** Constructor with \f$ b_{min} = -b_{max}\f$  (scalar version).
+   *
+   * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
+   *        have, in absolute value (\f$ b_{max}\f$).
+   * \param args These are forwarded to the TD constructor
+   */
+  template<typename... Args>
+  Clamped(double max, Args &&... args);
+
+  /** Constructor with \f$b_{min}\f$ and \f$b_{max}\f$  (scalar version).
+   *
+   * \param minMax The minimum (\f$b_{min}\f$) and maximum (\f$b_{max}\f$)
+   *               value that a component of \f$ e_c^{(k)*}\f$ can have. We require that
+   *               \f$b_{min} \leq 0 \leq b_{max}\f$.
+   * \param args These are forwarded to the TD constructor
+   */
+  template<typename... Args>
+  Clamped(const std::pair<double, double> & minMax, Args &&... args);
+
+  /** Constructor with \f$ b_{min} = -b_{max}\f$  (vector version).
+   *
+   * \param max The maximum value that a component of \f$ e_c^{(k)*} \f$ can
+   *        have, in absolute value (\f$ b_{max}\f$).
+   * \param args These are forwarded to the TD constructor
+   */
+  template<typename... Args>
+  Clamped(const VectorConstRef & max, Args &&... args);
+
+  /** Constructor with \f$b_{min}\f$ and \f$b_{max}\f$  (vector version).
+   *
+   * \param minMax The minimum (\f$b_{min}\f$) and maximum (\f$b_{max}\f$)
+   *               value that a component of \f$ e_c^{(k)*}\f$ can have. We require that
+   *               \f$b_{min} \leq 0 \leq b_{max}\f$.
+   * \param args These are forwarded to the TD constructor
+   */
+  template<typename... Args>
+  Clamped(const std::pair<VectorConstRef, VectorConstRef> & minMax, Args &&... args);
+
+  ~Clamped() override = default;
+
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override
   {
+    return TD::template impl_<Impl>(f, t, rhs, min_, max_);
   }
 
-  template<class TD, class TDImpl>
-  template<typename ... Args>
-  inline Clamped<TD, TDImpl>::Clamped(const std::pair<double, double> & minMax, Args&& ... args)
-    : TD(std::forward<Args>(args)...),
-      min_(minMax.first)
-    , max_(minMax.second)
+  COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(TD, min_, max_)
+
+private:
+  Bounds min_;
+  Bounds max_;
+};
+
+template<class TD, class TDImpl>
+template<typename... Args>
+inline Clamped<TD, TDImpl>::Clamped(double max, Args &&... args)
+: Clamped<TD, TDImpl>({-max, max}, std::forward<Args>(args)...)
+{
+}
+
+template<class TD, class TDImpl>
+template<typename... Args>
+inline Clamped<TD, TDImpl>::Clamped(const std::pair<double, double> & minMax, Args &&... args)
+: TD(std::forward<Args>(args)...), min_(minMax.first), max_(minMax.second)
+{
+  const auto & [min, max] = minMax;
+  if(min > 0)
   {
-    const auto& [min, max] = minMax;
-    if (min > 0)
+    throw std::runtime_error("[task_dynamics::Clamped] Minimum values must be negative.");
+  }
+  if(max < 0)
+  {
+    throw std::runtime_error("[task_dynamics::Clamped] Maximum values must be positive.");
+  }
+}
+
+template<class TD, class TDImpl>
+template<typename... Args>
+inline Clamped<TD, TDImpl>::Clamped(const VectorConstRef & max, Args &&... args)
+: Clamped<TD>({-max, max}, std::forward<Args>(args)...)
+{
+}
+
+template<class TD, class TDImpl>
+template<typename... Args>
+inline Clamped<TD, TDImpl>::Clamped(const std::pair<VectorConstRef, VectorConstRef> & minMax, Args &&... args)
+: TD(std::forward<Args>(args)...), min_(minMax.first), max_(minMax.second)
+{
+  const auto & [min, max] = minMax;
+  if(min.size() != max.size())
+  {
+    throw std::runtime_error("[task_dynamics::Clamped] The minimum and maximum must have the same size.");
+  }
+  if((min.array() > 0).any())
+  {
+    throw std::runtime_error("[task_dynamics::Clamped] Minimum values must be negative.");
+  }
+  if((max.array() < 0).any())
+  {
+    throw std::runtime_error("[task_dynamics::Clamped] Maximum values must be positive.");
+  }
+}
+
+template<class TD, class TDImpl>
+template<typename... Args>
+inline Clamped<TD, TDImpl>::Impl::Impl(FunctionPtr f,
+                                       constraint::Type t,
+                                       const Eigen::VectorXd & rhs,
+                                       const Bounds & min,
+                                       const Bounds & max,
+                                       Args &&... args)
+: TDImpl(f, t, rhs, std::forward<Args>(args)...),
+  min_(min.index() == 1 ? mpark::get<Eigen::VectorXd>(min)
+                        : Eigen::VectorXd::Constant(f->size(), mpark::get<double>(min))),
+  max_(max.index() == 1 ? mpark::get<Eigen::VectorXd>(max)
+                        : Eigen::VectorXd::Constant(f->size(), mpark::get<double>(max)))
+{
+  if(min_.size() != f->size() || max_.size() != f->size())
+  {
+    throw std::runtime_error(
+        "[task_dynamics::Clamped::Impl] Sizes of the minimum, maximum and function must be the same.");
+  }
+  if((min_.array() > 0).any())
+  {
+    throw std::runtime_error("[task_dynamics::Clamped::Impl] Minimum values must be negative.");
+  }
+  if((max_.array() < 0).any())
+  {
+    throw std::runtime_error("[task_dynamics::Clamped::Impl] Maximum values must be positive.");
+  }
+}
+
+template<class TD, class TDImpl>
+inline void Clamped<TD, TDImpl>::Impl::updateValue()
+{
+  TDImpl::updateValue();
+  double s = 1;
+  for(int i = 0; i < this->function().size(); ++i)
+  {
+    if(this->value_[i] > max_[i])
     {
-      throw std::runtime_error("[task_dynamics::Clamped] Minimum values must be negative.");
+      // innerValue[i] > max_[i] >= 0 so that innerValue[i] != 0
+      s = std::min(s, max_[i] / this->value_[i]);
     }
-    if (max < 0)
+    else if(this->value_[i] < min_[i])
     {
-      throw std::runtime_error("[task_dynamics::Clamped] Maximum values must be positive.");
+      // this->value_[i] < min_[i] <= 0 so that this->value_[i] != 0
+      s = std::min(s, min_[i] / this->value_[i]);
     }
   }
+  this->value_ *= s;
+}
 
-  template<class TD, class TDImpl>
-  template<typename ... Args>
-  inline Clamped<TD, TDImpl>::Clamped(const VectorConstRef& max, Args&& ... args)
-    : Clamped<TD>({-max, max}, std::forward<Args>(args)...)
-  {
-  }
-
-  template<class TD, class TDImpl>
-  template<typename ... Args>
-  inline Clamped<TD, TDImpl>::Clamped(const std::pair<VectorConstRef, VectorConstRef>& minMax, Args&& ... args)
-    : TD(std::forward<Args>(args)...)
-    , min_(minMax.first)
-    , max_(minMax.second)
-  {
-    const auto& [min, max] = minMax;
-    if (min.size() !=  max.size())
-    {
-      throw std::runtime_error("[task_dynamics::Clamped] The minimum and maximum must have the same size.");
-    }
-    if ((min.array() > 0).any())
-    {
-      throw std::runtime_error("[task_dynamics::Clamped] Minimum values must be negative.");
-    }
-    if ((max.array() < 0).any())
-    {
-      throw std::runtime_error("[task_dynamics::Clamped] Maximum values must be positive.");
-    }
-  }
-
-  template<class TD, class TDImpl>
-  template<typename ... Args>
-  inline Clamped<TD, TDImpl>::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Bounds& min, const Bounds& max, Args&& ... args)
-    : TDImpl(f, t, rhs, std::forward<Args>(args)...)
-    , min_(min.index() == 1 ? mpark::get<Eigen::VectorXd>(min) : Eigen::VectorXd::Constant(f->size(), mpark::get<double>(min)))
-    , max_(max.index() == 1 ? mpark::get<Eigen::VectorXd>(max) : Eigen::VectorXd::Constant(f->size(), mpark::get<double>(max)))
-  {
-    if (min_.size() != f->size() || max_.size() != f->size())
-    {
-      throw std::runtime_error("[task_dynamics::Clamped::Impl] Sizes of the minimum, maximum and function must be the same.");
-    }
-    if ((min_.array() > 0).any())
-    {
-      throw std::runtime_error("[task_dynamics::Clamped::Impl] Minimum values must be negative.");
-    }
-    if ((max_.array() < 0).any())
-    {
-      throw std::runtime_error("[task_dynamics::Clamped::Impl] Maximum values must be positive.");
-    }
-  }
-
-
-  template<class TD, class TDImpl>
-  inline void Clamped<TD, TDImpl>::Impl::updateValue()
-  {
-    TDImpl::updateValue();
-    double s = 1;
-    for (int i = 0; i < this->function().size(); ++i)
-    {
-      if (this->value_[i] > max_[i])
-      {
-        // innerValue[i] > max_[i] >= 0 so that innerValue[i] != 0
-        s = std::min(s, max_[i] / this->value_[i]);
-      }
-      else if (this->value_[i] < min_[i])
-      {
-        // this->value_[i] < min_[i] <= 0 so that this->value_[i] != 0
-        s = std::min(s, min_[i] / this->value_[i]);
-      }
-    }
-    this->value_ *= s;
-  }
-
-} // namespace task_dynamics
+} // namespace tvm::task_dynamics

--- a/include/tvm/task_dynamics/Constant.h
+++ b/include/tvm/task_dynamics/Constant.h
@@ -9,31 +9,33 @@
 namespace tvm
 {
 
-  namespace task_dynamics
+namespace task_dynamics
+{
+/** Zero order dynamics with e* = 0, i.e. f* = rhs.*/
+class TVM_DLLAPI Constant : public abstract::TaskDynamics
+{
+public:
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
   {
-    /** Zero order dynamics with e* = 0, i.e. f* = rhs.*/
-    class TVM_DLLAPI Constant : public abstract::TaskDynamics
-    {
-    public:
-      class TVM_DLLAPI Impl: public abstract::TaskDynamicsImpl
-      {
-      public:
-        Impl(FunctionPtr, constraint::Type t, const Eigen::VectorXd& rhs);
-        void updateValue() override;
-        ~Impl() override = default;
-      };
+  public:
+    Impl(FunctionPtr, constraint::Type t, const Eigen::VectorXd & rhs);
+    void updateValue() override;
+    ~Impl() override = default;
+  };
 
-      Constant();
+  Constant();
 
-      ~Constant() override = default;
+  ~Constant() override = default;
 
-    protected:
-      std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-      Order order_() const override;
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
 
-      TASK_DYNAMICS_DERIVED_FACTORY()
-    };
+  TASK_DYNAMICS_DERIVED_FACTORY()
+};
 
-  }  // namespace task_dynamics
+} // namespace task_dynamics
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/task_dynamics/FeedForward.h
+++ b/include/tvm/task_dynamics/FeedForward.h
@@ -13,75 +13,83 @@ namespace tvm
 namespace task_dynamics
 {
 
-  /** Given a task dynamics value \f$ e^{(k)*} \f$, compute the new value \f$
-   * e_ff^{(k)*} = e^{(k)*} - ff \f$, \f$ ff \f$ is data provided by another
-   * TVM node of the same size
-    */
-  template <class TD, class TDImpl = typename TD::Impl>
-  class FeedForward : public TD
+/** Given a task dynamics value \f$ e^{(k)*} \f$, compute the new value \f$
+ * e_ff^{(k)*} = e^{(k)*} - ff \f$, \f$ ff \f$ is data provided by another
+ * TVM node of the same size
+ */
+template<class TD, class TDImpl = typename TD::Impl>
+class FeedForward : public TD
+{
+public:
+  class Impl;
+
+  using getFeedForwardT = std::function<const Eigen::VectorXd &()>;
+  using addProviderDependencyT = std::function<void(Impl &)>;
+
+  template<class FFProvider, class FFSignal, typename... Args>
+  FeedForward(std::shared_ptr<FFProvider> provider,
+              const Eigen::VectorXd & (FFProvider::*method)() const,
+              FFSignal signal,
+              Args &&... args)
+  : TD(std::forward<Args>(args)...)
+  {
+    feedForward_ = [provider, method]() -> const Eigen::VectorXd & { return ((provider.get())->*method)(); };
+    addProviderDependency_ = [provider, signal](Impl & impl) {
+      impl.addInputDependency(TDImpl::Update::UpdateValue, provider, signal);
+    };
+  }
+
+  ~FeedForward() override = default;
+
+  class Impl : public TDImpl
   {
   public:
+    friend class FeedForward;
 
-    class Impl;
-
-    using getFeedForwardT = std::function<const Eigen::VectorXd&()>;
-    using addProviderDependencyT = std::function<void(Impl&)>;
-
-    template<class FFProvider, class FFSignal, typename ... Args>
-    FeedForward(std::shared_ptr<FFProvider> provider, const Eigen::VectorXd & (FFProvider::*method)() const,
-                FFSignal signal, Args && ... args)
-    : TD(std::forward<Args>(args)...)
+    template<typename... Args>
+    Impl(FunctionPtr f,
+         constraint::Type t,
+         const Eigen::VectorXd & rhs,
+         const getFeedForwardT & ff,
+         const addProviderDependencyT & addPD,
+         Args &&... args)
+    : TDImpl(f, t, rhs, std::forward<Args>(args)...), feedForward_(ff)
     {
-      feedForward_ = [provider, method]() -> const Eigen::VectorXd & {
-        return ((provider.get())->*method)();
-      };
-      addProviderDependency_ = [provider, signal](Impl& impl) {
-        impl.addInputDependency(TDImpl::Update::UpdateValue, provider, signal);
-      };
+      if(feedForward_().size() != this->function().size())
+      {
+        throw std::runtime_error(
+            "[task_dynamics::FeedForward] Feed forward term does not have the same size as the provided function");
+      }
+      addPD(*this);
     }
 
-    ~FeedForward() override = default;
+    ~Impl() override = default;
 
-    class Impl : public TDImpl
+    void updateValue() override
     {
-    public:
-      friend class FeedForward;
+      TDImpl::updateValue();
+      this->value_ += feedForward_();
+    }
 
-      template<typename ... Args>
-      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const getFeedForwardT& ff, const addProviderDependencyT& addPD, Args && ... args) : TDImpl(f, t, rhs, std::forward<Args>(args)...), feedForward_(ff)
-      {
-        if(feedForward_().size() != this->function().size())
-        {
-          throw std::runtime_error("[task_dynamics::FeedForward] Feed forward term does not have the same size as the provided function");
-        }
-        addPD(*this);
-      }
-
-      ~Impl() override = default;
-
-      void updateValue() override
-      {
-        TDImpl::updateValue();
-        this->value_ += feedForward_();
-      }
-    private:
-      getFeedForwardT feedForward_;
-    };
-
-  protected:
+  private:
     getFeedForwardT feedForward_;
-    addProviderDependencyT addProviderDependency_;
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override
-    {
-      return TD::template impl_<Impl>(f, t, rhs, feedForward_, addProviderDependency_);
-    }
-
-    COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(TD, feedForward_, addProviderDependency_)
   };
 
-  using FeedForwardPD = FeedForward<ProportionalDerivative>;
-  using FeedForwardP = FeedForward<Proportional>;
+protected:
+  getFeedForwardT feedForward_;
+  addProviderDependencyT addProviderDependency_;
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override
+  {
+    return TD::template impl_<Impl>(f, t, rhs, feedForward_, addProviderDependency_);
+  }
 
+  COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(TD, feedForward_, addProviderDependency_)
+};
+
+using FeedForwardPD = FeedForward<ProportionalDerivative>;
+using FeedForwardP = FeedForward<Proportional>;
 
 } // namespace task_dynamics
 

--- a/include/tvm/task_dynamics/None.h
+++ b/include/tvm/task_dynamics/None.h
@@ -9,33 +9,35 @@
 namespace tvm
 {
 
-  namespace task_dynamics
+namespace task_dynamics
+{
+
+/** Compute e* = -f(0) + rhs (Geometric order). For linear functions only. */
+class TVM_DLLAPI None : public abstract::TaskDynamics
+{
+public:
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
   {
+  public:
+    Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs);
+    void updateValue() override;
+    ~Impl() override = default;
 
-    /** Compute e* = -f(0) + rhs (Geometric order). For linear functions only. */
-    class TVM_DLLAPI None : public abstract::TaskDynamics
-    {
-    public:
-      class TVM_DLLAPI Impl: public abstract::TaskDynamicsImpl
-      {
-      public:
-        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs);
-        void updateValue() override;
-        ~Impl() override = default;
+  private:
+    const function::abstract::LinearFunction * lf_;
+  };
 
-      private:
-        const function::abstract::LinearFunction* lf_;
-      };
+  ~None() override = default;
 
-      ~None() override = default;
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
 
-    protected:
-      std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-      Order order_() const override;
+  TASK_DYNAMICS_DERIVED_FACTORY()
+};
 
-      TASK_DYNAMICS_DERIVED_FACTORY()
-    };
+} // namespace task_dynamics
 
-  }  // namespace task_dynamics
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/task_dynamics/Proportional.h
+++ b/include/tvm/task_dynamics/Proportional.h
@@ -17,75 +17,83 @@ namespace tvm
 namespace task_dynamics
 {
 
-  /** Compute \f$ \dot{e}^* = -k_p e \f$ (Kinematic order)
-   *  with \f$ k_p \f$ a scalar, a diagonal matrix (given as a vector) or a matrix.
-   */
-  class TVM_DLLAPI Proportional: public abstract::TaskDynamics
+/** Compute \f$ \dot{e}^* = -k_p e \f$ (Kinematic order)
+ *  with \f$ k_p \f$ a scalar, a diagonal matrix (given as a vector) or a matrix.
+ */
+class TVM_DLLAPI Proportional : public abstract::TaskDynamics
+{
+public:
+  using Gain = mpark::variant<double, Eigen::VectorXd, Eigen::MatrixXd>;
+
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
   {
   public:
-    using Gain = mpark::variant<double, Eigen::VectorXd, Eigen::MatrixXd>;
+    Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const Gain & kp);
+    void updateValue() override;
 
-    class TVM_DLLAPI Impl: public abstract::TaskDynamicsImpl
+    ~Impl() override = default;
+
+    /** Change the gain to a new scalar. */
+    void gain(double kp);
+    /** Change the gain to a new diagonal matrix. */
+    void gain(const Eigen::VectorXd & kp);
+    /** Change the gain to a new matrix. */
+    void gain(const Eigen::MatrixXd & kp);
+    /** Get the current gain.*/
+    const Gain & gain() const;
+    /** Get the current gain cast as \p T.
+     * \tparam T Type of the gain.
+     * \throw Throws if \p T has not the type corresponding to the gain actually used.
+     */
+    template<typename T>
+    const T & gain() const
     {
-    public:
-      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Gain& kp);
-      void updateValue() override;
-
-      ~Impl() override = default;
-
-      /** Change the gain to a new scalar. */
-      void gain(double kp);
-      /** Change the gain to a new diagonal matrix. */
-      void gain(const Eigen::VectorXd& kp);
-      /** Change the gain to a new matrix. */
-      void gain(const  Eigen::MatrixXd& kp);
-      /** Get the current gain.*/
-      const Gain& gain() const;
-      /** Get the current gain cast as \p T.
-        * \tparam T Type of the gain.
-        * \throw Throws if \p T has not the type corresponding to the gain actually used.
-        */
-      template<typename T>
-      const T& gain() const { return mpark::get<T>(kp_); }
-      /** Get the current gain (non-const version).
-        * \warning No check is made if you change the gain. It is your responsability
-        * to ensure that its values and its \a size are correct.
-        */
-      Gain& gain();
-      /** Get the current gain cast as \p T (non-const version).
-        * \tparam T Type of the gain.
-        * \throw Throws if \p T has not the type corresponding to the gain actually used.
-        * \warning No check is made if you change the gain. It is your responsability
-        * to ensure that its values and its \a size are correct.
-        */
-      template<typename T>
-      T& gain() { return mpark::get<T>(kp_); }
-
-    private:
-      Gain kp_;
-    };
-
-    /** Proportional dynamics with scalar gain. */
-    Proportional(double kp);
-    /** Proportional dynamics with diagonal matrix gain. */
-    Proportional(const Eigen::VectorXd& kp);
-    /** Proportional dynamics with matrix gain. */
-    Proportional(const Eigen::MatrixXd& kp);
-
-    ~Proportional() override = default;
-
-  protected:
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-    Order order_() const override;
-
-    TASK_DYNAMICS_DERIVED_FACTORY(kp_)
+      return mpark::get<T>(kp_);
+    }
+    /** Get the current gain (non-const version).
+     * \warning No check is made if you change the gain. It is your responsability
+     * to ensure that its values and its \a size are correct.
+     */
+    Gain & gain();
+    /** Get the current gain cast as \p T (non-const version).
+     * \tparam T Type of the gain.
+     * \throw Throws if \p T has not the type corresponding to the gain actually used.
+     * \warning No check is made if you change the gain. It is your responsability
+     * to ensure that its values and its \a size are correct.
+     */
+    template<typename T>
+    T & gain()
+    {
+      return mpark::get<T>(kp_);
+    }
 
   private:
     Gain kp_;
   };
 
-  /** Alias for convenience */
-  using P = Proportional;
-}  // namespace task_dynamics
+  /** Proportional dynamics with scalar gain. */
+  Proportional(double kp);
+  /** Proportional dynamics with diagonal matrix gain. */
+  Proportional(const Eigen::VectorXd & kp);
+  /** Proportional dynamics with matrix gain. */
+  Proportional(const Eigen::MatrixXd & kp);
 
-}  // namespace tvm
+  ~Proportional() override = default;
+
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
+
+  TASK_DYNAMICS_DERIVED_FACTORY(kp_)
+
+private:
+  Gain kp_;
+};
+
+/** Alias for convenience */
+using P = Proportional;
+} // namespace task_dynamics
+
+} // namespace tvm

--- a/include/tvm/task_dynamics/ProportionalDerivative.h
+++ b/include/tvm/task_dynamics/ProportionalDerivative.h
@@ -17,188 +17,202 @@ namespace tvm
 namespace task_dynamics
 {
 
-  /** Compute \f$ \ddot{e}^* = -k_v \dot{e} - k_p e\f$ (dynamic order)
-   * where \f$ k_p \f$ and \f$ k_v \f$ can be (independently) a scalar, a
-   * diagonal matrix (given as a vector) or a matrix.
-   */
-  class TVM_DLLAPI ProportionalDerivative : public abstract::TaskDynamics
+/** Compute \f$ \ddot{e}^* = -k_v \dot{e} - k_p e\f$ (dynamic order)
+ * where \f$ k_p \f$ and \f$ k_v \f$ can be (independently) a scalar, a
+ * diagonal matrix (given as a vector) or a matrix.
+ */
+class TVM_DLLAPI ProportionalDerivative : public abstract::TaskDynamics
+{
+public:
+  using Gain = mpark::variant<double, Eigen::VectorXd, Eigen::MatrixXd>;
+
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
   {
   public:
-    using Gain = mpark::variant<double, Eigen::VectorXd, Eigen::MatrixXd>;
+    Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const Gain & kp, const Gain & kv);
+    void updateValue() override;
 
-    class TVM_DLLAPI Impl: public abstract::TaskDynamicsImpl
-    {
-    public:
-      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Gain& kp, const Gain& kv);
-      void updateValue() override;
+    ~Impl() override = default;
 
-      ~Impl() override = default;
-
-      /** Get the current gains as a pair (kp, kv). */
-      std::pair<const Gain&, const Gain&> gains() const;
-      /** Set gains.
-        * \param kp Stiffness gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
-        * \param kv Damping gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
-        *
-        * \internal We keep the 9 possible overloads rather than resorting to template to
-        *  - have an easily-understandable overview of the different possibilities for the user,
-        *  - clarify the types, because the conversion of matrix-like and vector-like expression to
-        *    MatrixXd and VectorXd is tricky and does not play well with std::variant. This is also
-        *    why we don't use MatrixConstRef and VectorConstRef: conversion to those is ambiguous.
-        */
-      /**@{*/
-      void gains(double kp, double kv);
-      void gains(const Eigen::VectorXd& kp, const Eigen::VectorXd& kv);
-      void gains(const Eigen::MatrixXd& kp, const Eigen::MatrixXd& kv);
-      void gains(double kp, const Eigen::VectorXd& kv);
-      void gains(double kp, const Eigen::MatrixXd& kv);
-      void gains(const Eigen::VectorXd& kp, double kv);
-      void gains(const Eigen::VectorXd& kp, const Eigen::MatrixXd& kv);
-      void gains(const Eigen::MatrixXd& kp, double kv);
-      void gains(const Eigen::MatrixXd& kp, const Eigen::VectorXd& kv);
-      /**@}*/
-
-      /** Critically damped version.
-        * \param kp Stiffness gain.
-        * The damping gain is automatically computed to get a critically damped behavior.
-        */
-      void gains(double kp);
-      /** Critically damped version.
-        * \param kp Diagonal of the stiffness gain matrix.
-        * The damping gain is automatically computed to get a critically damped behavior.
-        */
-      void gains(const Eigen::VectorXd& kp);
-      /** Critically damped version.
-        * \param kp Stiffness gain matrix.
-        * The damping gain is automatically computed to get a critically damped behavior.
-        * For this version, \p kp is supposed to be symmetric and positive definite.
-        *
-        * \note The automatic damping computation is relatively heavy, involving a Schur
-        * decomposition, matrices multiplications and memory allocation.
-        */
-      void gains(const Eigen::MatrixXd& kp);
-
-      /** Get the current kp gain*/
-      const Gain& kp() const { return kp_; }
-      /** Get the current kp gain cast as \p T.
-        * \tparam T Type of the gain.
-        * \throw Throws if \p T has not the type corresponding to the gain actually used.
-        */
-      template<typename T>
-      const T& kp() const { return mpark::get<T>(kp_); }
-      /** Get the current kp gain (non-const version).
-        * \warning No check is made if you change the gain. It is your responsability
-        * to ensure that its values and its \a size are correct.
-        */
-      Gain& kp() { return kp_; }
-      /** Get the current kp gain cast as \p T (non-const version).
-        * \tparam T Type of the gain.
-        * \throw Throws if \p T has not the type corresponding to the gain actually used.
-        * \warning No check is made if you change the gain. It is your responsability
-        * to ensure that its values and its \a size are correct.
-        */
-      template<typename T>
-      T& kp() { return mpark::get<T>(kp_); }
-
-      /** Get the current kv gain*/
-      const Gain& kv() const { return kv_; }
-      /** Get the current kv gain cast as \p T.
-        * \tparam T Type of the gain.
-        * \throw Throws if \p T has not the type corresponding to the gain actually used.
-        */
-      template<typename T>
-      const T& kv() const { return mpark::get<T>(kv_); }
-      /** Get the current kv gain (non-const version).
-        * \warning No check is made if you change the gain. It is your responsability
-        * to ensure that its values and its \a size are correct.
-        */
-      Gain& kv() { return kv_; }
-      /** Get the current kv gain cast as \p T (non-const version).
-        * \tparam T Type of the gain.
-        * \throw Throws if \p T has not the type corresponding to the gain actually used.
-        * \warning No check is made if you change the gain. It is your responsability
-        * to ensure that its values and its \a size are correct.
-        */
-      template<typename T>
-      T& kv() { return mpark::get<T>(kv_); }
-
-    private:
-      void checkGainSize(double k) const;
-      void checkGainSize(const Eigen::VectorXd& k) const;
-      void checkGainSize(const Eigen::MatrixXd& k) const;
-      template<typename T, typename U>
-      void gains_(const T& kp, const U& kv);
-
-      Gain kp_; //Stiffness gain
-      Gain kv_; //Damping gain
-    };
-
-    /** General constructor.
-      * \param kp Stiffness gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
-      * \param kv Damping gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
-      *
-      * \internal We keep the 9 possible overloads rather than resorting to template to
-      *  - have an easily-understandable overview of the different possibilities for the user,
-      *  - clarify the types, because the conversion of matrix-like and vector-like expression to
-      *    MatrixXd and VectorXd is tricky and does not play well with std::variant. This is also
-      *    why we don't use MatrixConstRef and VectorConstRef: conversion to those is ambiguous.
-      */
+    /** Get the current gains as a pair (kp, kv). */
+    std::pair<const Gain &, const Gain &> gains() const;
+    /** Set gains.
+     * \param kp Stiffness gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
+     * \param kv Damping gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
+     *
+     * \internal We keep the 9 possible overloads rather than resorting to template to
+     *  - have an easily-understandable overview of the different possibilities for the user,
+     *  - clarify the types, because the conversion of matrix-like and vector-like expression to
+     *    MatrixXd and VectorXd is tricky and does not play well with std::variant. This is also
+     *    why we don't use MatrixConstRef and VectorConstRef: conversion to those is ambiguous.
+     */
     /**@{*/
-    ProportionalDerivative(double kp, double kv);
-    ProportionalDerivative(const Eigen::VectorXd& kp, const Eigen::VectorXd& kv);
-    ProportionalDerivative(const Eigen::MatrixXd& kp, const Eigen::MatrixXd& kv);
-    ProportionalDerivative(double kp, const Eigen::VectorXd& kv);
-    ProportionalDerivative(double kp, const Eigen::MatrixXd& kv);
-    ProportionalDerivative(const Eigen::VectorXd& kp, double kv);
-    ProportionalDerivative(const Eigen::VectorXd& kp, const Eigen::MatrixXd& kv);
-    ProportionalDerivative(const Eigen::MatrixXd& kp, double kv);
-    ProportionalDerivative(const Eigen::MatrixXd& kp, const Eigen::VectorXd& kv);
+    void gains(double kp, double kv);
+    void gains(const Eigen::VectorXd & kp, const Eigen::VectorXd & kv);
+    void gains(const Eigen::MatrixXd & kp, const Eigen::MatrixXd & kv);
+    void gains(double kp, const Eigen::VectorXd & kv);
+    void gains(double kp, const Eigen::MatrixXd & kv);
+    void gains(const Eigen::VectorXd & kp, double kv);
+    void gains(const Eigen::VectorXd & kp, const Eigen::MatrixXd & kv);
+    void gains(const Eigen::MatrixXd & kp, double kv);
+    void gains(const Eigen::MatrixXd & kp, const Eigen::VectorXd & kv);
     /**@}*/
 
     /** Critically damped version.
-      * \param kp Stiffness gain.
-      * The damping gain is automatically computed to get a critically damped behavior.
-      */
-    ProportionalDerivative(double kp);
+     * \param kp Stiffness gain.
+     * The damping gain is automatically computed to get a critically damped behavior.
+     */
+    void gains(double kp);
     /** Critically damped version.
-      * \param kp Diagonal of the stiffness gain matrix.
-      * The damping gain is automatically computed to get a critically damped behavior.
-      */
-    ProportionalDerivative(const Eigen::VectorXd& kp);
+     * \param kp Diagonal of the stiffness gain matrix.
+     * The damping gain is automatically computed to get a critically damped behavior.
+     */
+    void gains(const Eigen::VectorXd & kp);
     /** Critically damped version.
-      * \param kp Stiffness gain matrix.
-      * The damping gain is automatically computed to get a critically damped behavior.
-      * For this version, \p kp is supposed to be symmetric and positive definite.
-      *
-      * \note The automatic damping computation is relatively heavy, involving a Schur
-      * decomposition, matrices multiplications and memory allocation.
-      */
-    ProportionalDerivative(const Eigen::MatrixXd& kp);
+     * \param kp Stiffness gain matrix.
+     * The damping gain is automatically computed to get a critically damped behavior.
+     * For this version, \p kp is supposed to be symmetric and positive definite.
+     *
+     * \note The automatic damping computation is relatively heavy, involving a Schur
+     * decomposition, matrices multiplications and memory allocation.
+     */
+    void gains(const Eigen::MatrixXd & kp);
 
-    ~ProportionalDerivative() override = default;
+    /** Get the current kp gain*/
+    const Gain & kp() const { return kp_; }
+    /** Get the current kp gain cast as \p T.
+     * \tparam T Type of the gain.
+     * \throw Throws if \p T has not the type corresponding to the gain actually used.
+     */
+    template<typename T>
+    const T & kp() const
+    {
+      return mpark::get<T>(kp_);
+    }
+    /** Get the current kp gain (non-const version).
+     * \warning No check is made if you change the gain. It is your responsability
+     * to ensure that its values and its \a size are correct.
+     */
+    Gain & kp() { return kp_; }
+    /** Get the current kp gain cast as \p T (non-const version).
+     * \tparam T Type of the gain.
+     * \throw Throws if \p T has not the type corresponding to the gain actually used.
+     * \warning No check is made if you change the gain. It is your responsability
+     * to ensure that its values and its \a size are correct.
+     */
+    template<typename T>
+    T & kp()
+    {
+      return mpark::get<T>(kp_);
+    }
 
-  protected:
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-    Order order_() const override;
-
-    TASK_DYNAMICS_DERIVED_FACTORY(kp_, kv_)
+    /** Get the current kv gain*/
+    const Gain & kv() const { return kv_; }
+    /** Get the current kv gain cast as \p T.
+     * \tparam T Type of the gain.
+     * \throw Throws if \p T has not the type corresponding to the gain actually used.
+     */
+    template<typename T>
+    const T & kv() const
+    {
+      return mpark::get<T>(kv_);
+    }
+    /** Get the current kv gain (non-const version).
+     * \warning No check is made if you change the gain. It is your responsability
+     * to ensure that its values and its \a size are correct.
+     */
+    Gain & kv() { return kv_; }
+    /** Get the current kv gain cast as \p T (non-const version).
+     * \tparam T Type of the gain.
+     * \throw Throws if \p T has not the type corresponding to the gain actually used.
+     * \warning No check is made if you change the gain. It is your responsability
+     * to ensure that its values and its \a size are correct.
+     */
+    template<typename T>
+    T & kv()
+    {
+      return mpark::get<T>(kv_);
+    }
 
   private:
-    Gain kp_; //Stiffness gain
-    Gain kv_; //Damping gain
+    void checkGainSize(double k) const;
+    void checkGainSize(const Eigen::VectorXd & k) const;
+    void checkGainSize(const Eigen::MatrixXd & k) const;
+    template<typename T, typename U>
+    void gains_(const T & kp, const U & kv);
+
+    Gain kp_; // Stiffness gain
+    Gain kv_; // Damping gain
   };
 
-  /** Alias for convenience */
-  using PD = ProportionalDerivative;
+  /** General constructor.
+   * \param kp Stiffness gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
+   * \param kv Damping gain, as a scalar, a vector representing a diagonal matrix, or a matrix.
+   *
+   * \internal We keep the 9 possible overloads rather than resorting to template to
+   *  - have an easily-understandable overview of the different possibilities for the user,
+   *  - clarify the types, because the conversion of matrix-like and vector-like expression to
+   *    MatrixXd and VectorXd is tricky and does not play well with std::variant. This is also
+   *    why we don't use MatrixConstRef and VectorConstRef: conversion to those is ambiguous.
+   */
+  /**@{*/
+  ProportionalDerivative(double kp, double kv);
+  ProportionalDerivative(const Eigen::VectorXd & kp, const Eigen::VectorXd & kv);
+  ProportionalDerivative(const Eigen::MatrixXd & kp, const Eigen::MatrixXd & kv);
+  ProportionalDerivative(double kp, const Eigen::VectorXd & kv);
+  ProportionalDerivative(double kp, const Eigen::MatrixXd & kv);
+  ProportionalDerivative(const Eigen::VectorXd & kp, double kv);
+  ProportionalDerivative(const Eigen::VectorXd & kp, const Eigen::MatrixXd & kv);
+  ProportionalDerivative(const Eigen::MatrixXd & kp, double kv);
+  ProportionalDerivative(const Eigen::MatrixXd & kp, const Eigen::VectorXd & kv);
+  /**@}*/
 
-  template<typename T, typename U>
-  inline void ProportionalDerivative::Impl::gains_(const T& kp, const U& kv)
-  {
-    checkGainSize(kp);
-    checkGainSize(kv);
-    kp_ = kp;
-    kv_ = kv;
-  }
-}  // namespace task_dynamics
+  /** Critically damped version.
+   * \param kp Stiffness gain.
+   * The damping gain is automatically computed to get a critically damped behavior.
+   */
+  ProportionalDerivative(double kp);
+  /** Critically damped version.
+   * \param kp Diagonal of the stiffness gain matrix.
+   * The damping gain is automatically computed to get a critically damped behavior.
+   */
+  ProportionalDerivative(const Eigen::VectorXd & kp);
+  /** Critically damped version.
+   * \param kp Stiffness gain matrix.
+   * The damping gain is automatically computed to get a critically damped behavior.
+   * For this version, \p kp is supposed to be symmetric and positive definite.
+   *
+   * \note The automatic damping computation is relatively heavy, involving a Schur
+   * decomposition, matrices multiplications and memory allocation.
+   */
+  ProportionalDerivative(const Eigen::MatrixXd & kp);
 
-}  // namespace tvm
+  ~ProportionalDerivative() override = default;
+
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
+
+  TASK_DYNAMICS_DERIVED_FACTORY(kp_, kv_)
+
+private:
+  Gain kp_; // Stiffness gain
+  Gain kv_; // Damping gain
+};
+
+/** Alias for convenience */
+using PD = ProportionalDerivative;
+
+template<typename T, typename U>
+inline void ProportionalDerivative::Impl::gains_(const T & kp, const U & kv)
+{
+  checkGainSize(kp);
+  checkGainSize(kv);
+  kp_ = kp;
+  kv_ = kv;
+}
+} // namespace task_dynamics
+
+} // namespace tvm

--- a/include/tvm/task_dynamics/Reference.h
+++ b/include/tvm/task_dynamics/Reference.h
@@ -8,63 +8,65 @@
 
 namespace tvm::task_dynamics
 {
-  /** Compute e^(k)* = ref (at given k-th order). */
-  class TVM_DLLAPI Reference : public abstract::TaskDynamics
+/** Compute e^(k)* = ref (at given k-th order). */
+class TVM_DLLAPI Reference : public abstract::TaskDynamics
+{
+public:
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
   {
   public:
-    class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
-    {
-    public:
-      Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, Order order, FunctionPtr ref);
-      void updateValue() override;
+    Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, Order order, FunctionPtr ref);
+    void updateValue() override;
 
-      ~Impl() override = default;
+    ~Impl() override = default;
 
-      /** Getter on the reference function. */
-      FunctionPtr ref() const { return ref_; }
-      /** Setter on the reference function. */
-      void ref(const FunctionPtr& r);
+    /** Getter on the reference function. */
+    FunctionPtr ref() const { return ref_; }
+    /** Setter on the reference function. */
+    void ref(const FunctionPtr & r);
 
-    private:
-      void setReference(const FunctionPtr& ref);
-
-      FunctionPtr ref_;
-    };
-
-    /** \param order The order of derivation k of the error that need to follow the reference
-      * \param ref The reference function. 
-      */
-    Reference(Order order, const FunctionPtr& ref);
-
-    ~Reference() override = default;
-
-  protected:
-    std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-    Order order_() const override;
-
-    TASK_DYNAMICS_DERIVED_FACTORY(refOrder_, ref_)
   private:
-    Order refOrder_;
+    void setReference(const FunctionPtr & ref);
+
     FunctionPtr ref_;
   };
 
-  /** Compute dot{e}* = ref (kinematic order). 
-    *
-    * This is a simple conveniency shortcut for a Reference instance with order Order::One
-    */
-  class TVM_DLLAPI ReferenceVelocity : public Reference
-  {
-  public:
-    ReferenceVelocity(const FunctionPtr& ref);
-  };
+  /** \param order The order of derivation k of the error that need to follow the reference
+   * \param ref The reference function.
+   */
+  Reference(Order order, const FunctionPtr & ref);
 
-  /** Compute ddot{e}* = ref (dynamic order). 
-    *
-    * This is a simple conveniency shortcut for a Reference instance with order Order::Two
-    */
-  class TVM_DLLAPI ReferenceAcceleration : public Reference
-  {
-  public:
-    ReferenceAcceleration(const FunctionPtr& ref);
-  };
-}
+  ~Reference() override = default;
+
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
+
+  TASK_DYNAMICS_DERIVED_FACTORY(refOrder_, ref_)
+private:
+  Order refOrder_;
+  FunctionPtr ref_;
+};
+
+/** Compute dot{e}* = ref (kinematic order).
+ *
+ * This is a simple conveniency shortcut for a Reference instance with order Order::One
+ */
+class TVM_DLLAPI ReferenceVelocity : public Reference
+{
+public:
+  ReferenceVelocity(const FunctionPtr & ref);
+};
+
+/** Compute ddot{e}* = ref (dynamic order).
+ *
+ * This is a simple conveniency shortcut for a Reference instance with order Order::Two
+ */
+class TVM_DLLAPI ReferenceAcceleration : public Reference
+{
+public:
+  ReferenceAcceleration(const FunctionPtr & ref);
+};
+} // namespace tvm::task_dynamics

--- a/include/tvm/task_dynamics/VelocityDamper.h
+++ b/include/tvm/task_dynamics/VelocityDamper.h
@@ -11,208 +11,224 @@
 namespace tvm
 {
 
-  namespace task_dynamics
+namespace task_dynamics
+{
+
+/** A first or second order dynamic task implementing the so-called velocity
+ * damper of Faverjon and Tournassoud.
+ * For a lower bound tasks e>=0, we have, for e<=di:
+ *  - first order: dot{e}_i* = -xsi * (e_i-ds)/(di-ds)
+ *  - second order: ddot{e}_i* = -xsi/dt * (e_i-ds)/(di-ds) -dot{e}_i/dt
+ *
+ * and for e>di:
+ *   - first order: dot{e}* = big
+ *   - second order: ddot{e}* = big
+ *
+ * For upper bound tasks e <= 0 this is adapted to get the same behavior as
+ * -e >= 0.
+ *
+ * xsi can be computed automatically (see \p autoXsi parameter).
+ *
+ * \attention For xsi to be computed automatically in the first order case,
+ * the value of dot{e} is used.
+ *
+ * \attention To know when to compute xsi in automatic mode, the class keeps
+ * data on the last iterations. Consequently if the velocity damper is
+ * applied to a function \p f with variable \p x, its output value will be
+ * the same if \p x keeps the same value \p x0 and velocity \p v0 between
+ * two consecutive updates, but the same entries \p x0 and \p v0 \a may give
+ * different values for unrelated updates, because of history differences.
+ * \n This remark only applies when the automatic computation of xsi is
+ * required.
+ */
+class TVM_DLLAPI VelocityDamper : public abstract::TaskDynamics
+{
+public:
+  /** A structure grouping the parameters of a velocity damper.
+   * \sa VelocityDamper.
+   */
+  class TVM_DLLAPI Config
   {
+  public:
+    /**
+     * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
+     * \param ds safety distance \f$d_s\f$.
+     * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
+     * be computed automatically, otherwise, we need \f$\xi > 0\f$.
+     * In automatic mode, the value is recomputed each time the error value
+     * is at a distance to its bound lower or equal to \p \di with the
+     * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
+     * \xi_{\mathrm{off}} \f$.
+     * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
+     * computation of \f$\xi\f$. Used only in the case xsi=0.
+     */
+    Config(double di, double ds, double xsi, double xsiOff = 0);
 
-    /** A first or second order dynamic task implementing the so-called velocity
-      * damper of Faverjon and Tournassoud.
-      * For a lower bound tasks e>=0, we have, for e<=di:
-      *  - first order: dot{e}_i* = -xsi * (e_i-ds)/(di-ds)
-      *  - second order: ddot{e}_i* = -xsi/dt * (e_i-ds)/(di-ds) -dot{e}_i/dt
-      *
-      * and for e>di:
-      *   - first order: dot{e}* = big
-      *   - second order: ddot{e}* = big
-      *
-      * For upper bound tasks e <= 0 this is adapted to get the same behavior as
-      * -e >= 0.
-      *
-      * xsi can be computed automatically (see \p autoXsi parameter).
-      *
-      * \attention For xsi to be computed automatically in the first order case,
-      * the value of dot{e} is used.
-      *
-      * \attention To know when to compute xsi in automatic mode, the class keeps
-      * data on the last iterations. Consequently if the velocity damper is
-      * applied to a function \p f with variable \p x, its output value will be
-      * the same if \p x keeps the same value \p x0 and velocity \p v0 between
-      * two consecutive updates, but the same entries \p x0 and \p v0 \a may give
-      * different values for unrelated updates, because of history differences.
-      * \n This remark only applies when the automatic computation of xsi is
-      * required.
-      */
-    class TVM_DLLAPI VelocityDamper : public abstract::TaskDynamics
+    double di_;
+    double ds_;
+    double xsi_;
+    double xsiOff_;
+  };
+
+  /** A structure grouping the parameters for an anisotropic velocity damper.
+   * \sa VelocityDamper
+   */
+  class TVM_DLLAPI AnisotropicConfig
+  {
+  public:
+    /**
+     * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
+     * \param ds safety distance \f$d_s\f$.
+     * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
+     * be computed automatically, otherwise, we need \f$\xi > 0\f$.
+     * In automatic mode, the value is recomputed each time the error value
+     * is at a distance to its bound lower or equal to \p \di with the
+     * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
+     * \xi_{\mathrm{off}} \f$.
+     * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
+     * computation of \f$\xi\f$. Used only in the case xsi=0.
+     *
+     * All parameters must be of the same size
+     */
+    AnisotropicConfig(const VectorConstRef & di,
+                      const VectorConstRef & ds,
+                      const VectorConstRef & xsi,
+                      const std::optional<VectorConstRef> & xsiOff = std::nullopt);
+
+    /** Construct from a non-anisotropic configuration
+     *
+     * \param config Configuration to use
+     */
+    AnisotropicConfig(const Config & config);
+
+    Eigen::VectorXd di_;
+    Eigen::VectorXd ds_;
+    Eigen::VectorXd xsi_;
+    Eigen::VectorXd xsiOff_;
+  };
+
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
+  {
+  public:
+    // First order dynamics
+    Impl(FunctionPtr f,
+         constraint::Type t,
+         const Eigen::VectorXd & rhs,
+         bool autoXsi,
+         const Eigen::VectorXd & di,
+         const Eigen::VectorXd & ds,
+         const Eigen::VectorXd & xsi,
+         double big);
+    // Second order dynamics
+    Impl(FunctionPtr f,
+         constraint::Type t,
+         const Eigen::VectorXd & rhs,
+         double dt,
+         bool autoXsi,
+         const Eigen::VectorXd & di,
+         const Eigen::VectorXd & ds,
+         const Eigen::VectorXd & xsi,
+         double big);
+
+    void updateValue() override;
+
+    ~Impl() override = default;
+
+  private:
+    /** Partial update computation. \p s is a sign factor to apply on the velocity.*/
+    void updateValue_(double s);
+
+    double dt_;
+    Eigen::VectorXd ds_;
+    Eigen::VectorXd di_;
+    Eigen::VectorXd xsiOff_;
+    Eigen::VectorXd a_; // -1 / (di - ds)
+    double big_;
+
+    bool autoXsi_;
+    Eigen::VectorXd d_;
+    Eigen::VectorXd axsi_; // a * xsi = -xsi / (di - ds)
+    std::vector<bool> active_;
+  };
+
+  /** \bried Velocity damper for first order dynamics.
+   *
+   * \param config configuration of the damper. \sa VelocityDamperConfig
+   *
+   * \param big value used as infinity.
+   *
+   * \attention When \p autoXsi is \p true, the value update will declare a
+   * dependency to the \p Velocity of the error function. It is the user
+   * responsibility to ensure the velocity is correctly provided (in
+   * particular, this might require the value of the variables first
+   * derivatives to be set correctly).
+   */
+  VelocityDamper(const Config & config, double big = constant::big_number);
+
+  /** \bried Velocity damper for first order dynamics.
+   *
+   * \param config configuration of the damper. \sa VelocityDamperAnisotropicConfig
+   *
+   * \param big value used as infinity.
+   *
+   * \attention Previous remark on \p autoXsi apply. Furthermore, the
+   * dimensions of \p config must match the function for which this task
+   * dynamic will be used.
+   */
+  VelocityDamper(const AnisotropicConfig & config, double big = constant::big_number);
+
+  /** \brief Velocity damper for second order dynamics.
+   *
+   * \param dt integration time step to integrate acceleration to velocity
+   * (should be the control time step). Must be strictly positive.
+   *
+   * \param config configuration of the damper. \sa VelocityDamperConfig
+   *
+   * \param big value used as infinity.
+   */
+  VelocityDamper(double dt, const Config & config, double big = constant::big_number);
+
+  /** \brief Velocity damper for second order dynamics.
+   *
+   * \param dt integration time step to integrate acceleration to velocity
+   * (should be the control time step). Must be strictly positive.
+   *
+   * \param config configuration of the damper. \sa VelocityDamperAnisotropicConfig
+   *
+   * \param big value used as infinity.
+   */
+  VelocityDamper(double dt, const AnisotropicConfig & config, double big = constant::big_number);
+
+  ~VelocityDamper() override = default;
+
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
+
+  template<typename Derived, typename... Args>
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs,
+                                                    Args &&... args) const
+  {
+    if(dt_ > 0)
     {
-    public:
-      /** A structure grouping the parameters of a velocity damper.
-        * \sa VelocityDamper.
-        */
-      class TVM_DLLAPI Config
-      {
-      public:
-        /**
-          * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
-          * \param ds safety distance \f$d_s\f$.
-          * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
-          * be computed automatically, otherwise, we need \f$\xi > 0\f$.
-          * In automatic mode, the value is recomputed each time the error value
-          * is at a distance to its bound lower or equal to \p \di with the
-          * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
-          * \xi_{\mathrm{off}} \f$.
-          * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
-          * computation of \f$\xi\f$. Used only in the case xsi=0.
-          */
-        Config(double di, double ds, double xsi, double xsiOff=0);
+      return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., dt_, autoXsi_, di_, ds_, xsi_, big_);
+    }
+    return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., autoXsi_, di_, ds_, xsi_, big_);
+  }
 
-        double di_;
-        double ds_;
-        double xsi_;
-        double xsiOff_;
-      };
+private:
+  double dt_;
+  Eigen::VectorXd xsi_;
+  Eigen::VectorXd ds_;
+  Eigen::VectorXd di_;
+  double big_;
+  bool autoXsi_;
+};
 
-      /** A structure grouping the parameters for an anisotropic velocity damper.
-       * \sa VelocityDamper
-       */
-      class TVM_DLLAPI AnisotropicConfig
-      {
-      public:
-        /**
-          * \param di interaction distance \f$d_i\f$. We need \f$ d_i > d_s \f$.
-          * \param ds safety distance \f$d_s\f$.
-          * \param xsi damping parameter \f$\xi \f$. If xsi = 0, the value will
-          * be computed automatically, otherwise, we need \f$\xi > 0\f$.
-          * In automatic mode, the value is recomputed each time the error value
-          * is at a distance to its bound lower or equal to \p \di with the
-          * formula \f$ \xi = -\dfrac{d_i - d_s}{d^k - d_s} \dot{d}^k +
-          * \xi_{\mathrm{off}} \f$.
-          * \param xsiOff offset \f$ \xi_{\mathrm{off}} \f$ used in the automatic
-          * computation of \f$\xi\f$. Used only in the case xsi=0.
-          *
-          * All parameters must be of the same size
-          */
-        AnisotropicConfig(const VectorConstRef & di,
-                          const VectorConstRef & ds,
-                          const VectorConstRef & xsi,
-                          const std::optional<VectorConstRef> & xsiOff = std::nullopt);
+} // namespace task_dynamics
 
-        /** Construct from a non-anisotropic configuration
-         *
-         * \param config Configuration to use
-         */
-        AnisotropicConfig(const Config & config);
-
-        Eigen::VectorXd di_;
-        Eigen::VectorXd ds_;
-        Eigen::VectorXd xsi_;
-        Eigen::VectorXd xsiOff_;
-      };
-
-      class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
-      {
-      public:
-        //First order dynamics
-        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, bool autoXsi, const Eigen::VectorXd & di, const Eigen::VectorXd & ds, const Eigen::VectorXd & xsi, double big);
-        //Second order dynamics
-        Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, double dt, bool autoXsi, const Eigen::VectorXd & di, const Eigen::VectorXd & ds, const Eigen::VectorXd & xsi, double big);
-
-        void updateValue() override;
-
-        ~Impl() override = default;
-
-      private:
-        /** Partial update computation. \p s is a sign factor to apply on the velocity.*/
-        void updateValue_(double s);
-
-        double dt_;
-        Eigen::VectorXd ds_;
-        Eigen::VectorXd di_;
-        Eigen::VectorXd xsiOff_;
-        Eigen::VectorXd a_;                  // -1 / (di - ds)
-        double big_;
-
-        bool autoXsi_;
-        Eigen::VectorXd d_;
-        Eigen::VectorXd axsi_;      //a * xsi = -xsi / (di - ds)
-        std::vector<bool> active_;
-      };
-
-      /** \bried Velocity damper for first order dynamics.
-       *
-       * \param config configuration of the damper. \sa VelocityDamperConfig
-       *
-       * \param big value used as infinity.
-       *
-       * \attention When \p autoXsi is \p true, the value update will declare a
-       * dependency to the \p Velocity of the error function. It is the user
-       * responsibility to ensure the velocity is correctly provided (in
-       * particular, this might require the value of the variables first
-       * derivatives to be set correctly).
-       */
-      VelocityDamper(const Config& config, double big = constant::big_number);
-
-      /** \bried Velocity damper for first order dynamics.
-       *
-        * \param config configuration of the damper. \sa VelocityDamperAnisotropicConfig
-        *
-        * \param big value used as infinity.
-        *
-        * \attention Previous remark on \p autoXsi apply. Furthermore, the
-        * dimensions of \p config must match the function for which this task
-        * dynamic will be used.
-        */
-      VelocityDamper(const AnisotropicConfig& config, double big = constant::big_number);
-
-      /** \brief Velocity damper for second order dynamics.
-       *
-       * \param dt integration time step to integrate acceleration to velocity
-       * (should be the control time step). Must be strictly positive.
-       *
-       * \param config configuration of the damper. \sa VelocityDamperConfig
-       *
-       * \param big value used as infinity.
-       */
-      VelocityDamper(double dt, const Config& config, double big = constant::big_number);
-
-      /** \brief Velocity damper for second order dynamics.
-       *
-       * \param dt integration time step to integrate acceleration to velocity
-       * (should be the control time step). Must be strictly positive.
-       *
-       * \param config configuration of the damper. \sa VelocityDamperAnisotropicConfig
-       *
-       * \param big value used as infinity.
-       */
-      VelocityDamper(double dt, const AnisotropicConfig& config, double big = constant::big_number);
-
-      ~VelocityDamper() override = default;
-
-    protected:
-      std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const override;
-      Order order_() const override;
-
-      template<typename Derived, typename ... Args>
-      std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
-                                                        constraint::Type t,
-                                                        const Eigen::VectorXd& rhs,
-                                                        Args&& ... args) const
-      {
-        if (dt_ > 0)
-        {
-          return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., dt_, autoXsi_, di_, ds_, xsi_, big_);
-        }
-        return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., autoXsi_, di_, ds_, xsi_, big_);
-
-      }
-
-    private:
-      double dt_;
-      Eigen::VectorXd xsi_;
-      Eigen::VectorXd ds_;
-      Eigen::VectorXd di_;
-      double big_;
-      bool autoXsi_;
-    };
-
-  }  // namespace task_dynamics
-
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/task_dynamics/abstract/TaskDynamics.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamics.h
@@ -6,13 +6,13 @@
 
 #include <tvm/defs.h>
 #include <tvm/graph/abstract/Node.h>
-#include <tvm/task_dynamics/enums.h>
 #include <tvm/task_dynamics/abstract/TaskDynamicsImpl.h>
+#include <tvm/task_dynamics/enums.h>
 
 #include <Eigen/Core>
 
-//FIXME add mechanisms for when the function's output is resized
-//FIXME Consider the possibility of having variables in task dynamics?
+// FIXME add mechanisms for when the function's output is resized
+// FIXME Consider the possibility of having variables in task dynamics?
 
 namespace tvm
 {
@@ -22,48 +22,48 @@ namespace task_dynamics
 
 namespace abstract
 {
-  /** This is a base class to describe how a task is to be regulated, i.e. how
-    * to compute e^(d)* for a task with constraint part f op rhs, where f is a
-    * function, op is one operator among (==, <=, >=), rhs is a constant or a
-    * vector and e = f-rhs. d is the order of the task dynamics.
-    *
-    * TaskDynamics is a lightweight descriptor, independent of a particular
-    * task, that is meant for the end user.
-    * Internally, it is turned into a TaskDynamicsImpl when linked to a given
-    * function and rhs.
-    */
-  class TVM_DLLAPI TaskDynamics
-  {
-  public:
-    virtual ~TaskDynamics() = default;
+/** This is a base class to describe how a task is to be regulated, i.e. how
+ * to compute e^(d)* for a task with constraint part f op rhs, where f is a
+ * function, op is one operator among (==, <=, >=), rhs is a constant or a
+ * vector and e = f-rhs. d is the order of the task dynamics.
+ *
+ * TaskDynamics is a lightweight descriptor, independent of a particular
+ * task, that is meant for the end user.
+ * Internally, it is turned into a TaskDynamicsImpl when linked to a given
+ * function and rhs.
+ */
+class TVM_DLLAPI TaskDynamics
+{
+public:
+  virtual ~TaskDynamics() = default;
 
-    std::unique_ptr<TaskDynamicsImpl> impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const;
+  std::unique_ptr<TaskDynamicsImpl> impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs) const;
 
-    Order order() const;
+  Order order() const;
 
-  protected:
-    virtual std::unique_ptr<TaskDynamicsImpl> impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const = 0;
-    virtual Order order_() const = 0;
-  };
+protected:
+  virtual std::unique_ptr<TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                  constraint::Type t,
+                                                  const Eigen::VectorXd & rhs) const = 0;
+  virtual Order order_() const = 0;
+};
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace task_dynamics
+} // namespace task_dynamics
 
-}  // namespace tvm
+} // namespace tvm
 
 /** This macro can be used to define the derived factory required in
  * TaskDynamics implementation, \p Args are the arguments required by the derived
  * class, the macro arguments are members of the class passed to the derived
  * constructor */
-#define TASK_DYNAMICS_DERIVED_FACTORY(...)                                                          \
-  template<typename Derived, typename ... Args>                                                     \
-  std::unique_ptr<tvm::task_dynamics::abstract::TaskDynamicsImpl> impl_(tvm::FunctionPtr f,         \
-                                                                        tvm::constraint::Type t,    \
-                                                                        const Eigen::VectorXd& rhs, \
-                                                                        Args&& ... args) const      \
-  {                                                                                                 \
-    return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., ## __VA_ARGS__);       \
+#define TASK_DYNAMICS_DERIVED_FACTORY(...)                                                             \
+  template<typename Derived, typename... Args>                                                         \
+  std::unique_ptr<tvm::task_dynamics::abstract::TaskDynamicsImpl> impl_(                               \
+      tvm::FunctionPtr f, tvm::constraint::Type t, const Eigen::VectorXd & rhs, Args &&... args) const \
+  {                                                                                                    \
+    return std::make_unique<Derived>(f, t, rhs, std::forward<Args>(args)..., ##__VA_ARGS__);           \
   }
 
 /** This macro can be used to define the derived factory required in composable
@@ -71,12 +71,10 @@ namespace abstract
  * class, the macro variadic arguments are members of the class passed to the
  * derived constructor, the first argument is the template argument
  * representing the encapsulated TaskDynamic type */
-#define COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(T, ...)                                            \
-  template<typename Derived, typename ... Args>                                                     \
-  std::unique_ptr<tvm::task_dynamics::abstract::TaskDynamicsImpl> impl_(tvm::FunctionPtr f,         \
-                                                                        tvm::constraint::Type t,    \
-                                                                        const Eigen::VectorXd& rhs, \
-                                                                        Args&& ... args) const      \
-  {                                                                                                 \
-    return T::template impl_<Derived>(f, t, rhs, std::forward<Args>(args)..., ## __VA_ARGS__);      \
+#define COMPOSABLE_TASK_DYNAMICS_DERIVED_FACTORY(T, ...)                                               \
+  template<typename Derived, typename... Args>                                                         \
+  std::unique_ptr<tvm::task_dynamics::abstract::TaskDynamicsImpl> impl_(                               \
+      tvm::FunctionPtr f, tvm::constraint::Type t, const Eigen::VectorXd & rhs, Args &&... args) const \
+  {                                                                                                    \
+    return T::template impl_<Derived>(f, t, rhs, std::forward<Args>(args)..., ##__VA_ARGS__);          \
   }

--- a/include/tvm/task_dynamics/abstract/TaskDynamics.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamics.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tvm/defs.h>
+
 #include <tvm/graph/abstract/Node.h>
 #include <tvm/task_dynamics/abstract/TaskDynamicsImpl.h>
 #include <tvm/task_dynamics/enums.h>

--- a/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <tvm/defs.h>
 #include <tvm/constraint/enums.h>
+#include <tvm/defs.h>
 #include <tvm/graph/abstract/Node.h>
 #include <tvm/task_dynamics/enums.h>
 
@@ -14,95 +14,83 @@
 #include <memory>
 #include <typeinfo>
 
-//FIXME add mechanisms for when the function's output is resized
-//FIXME Consider the possibility of having variables in task dynamics?
+// FIXME add mechanisms for when the function's output is resized
+// FIXME Consider the possibility of having variables in task dynamics?
 
 namespace tvm
 {
 
-  namespace task_dynamics
-  {
+namespace task_dynamics
+{
 
-    namespace abstract
-    {
-      class TaskDynamics;
+namespace abstract
+{
+class TaskDynamics;
 
-      /** Base class for the implementation of a task dynamics*/
-      class TVM_DLLAPI TaskDynamicsImpl : public graph::abstract::Node<TaskDynamicsImpl>
-      {
-      public:
-        SET_OUTPUTS(TaskDynamicsImpl, Value)
-        SET_UPDATES(TaskDynamicsImpl, UpdateValue)
+/** Base class for the implementation of a task dynamics*/
+class TVM_DLLAPI TaskDynamicsImpl : public graph::abstract::Node<TaskDynamicsImpl>
+{
+public:
+  SET_OUTPUTS(TaskDynamicsImpl, Value)
+  SET_UPDATES(TaskDynamicsImpl, UpdateValue)
 
-        virtual ~TaskDynamicsImpl() = default;
+  virtual ~TaskDynamicsImpl() = default;
 
-        const Eigen::VectorXd& value() const;
-        Order order() const;
+  const Eigen::VectorXd & value() const;
+  Order order() const;
 
-        virtual void updateValue() = 0;
+  virtual void updateValue() = 0;
 
-        /** Check if this is an instance of T::Impl */
-        template<typename T>
-        bool checkType() const;
+  /** Check if this is an instance of T::Impl */
+  template<typename T>
+  bool checkType() const;
 
-      protected:
-        TaskDynamicsImpl(Order order, FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs);
+protected:
+  TaskDynamicsImpl(Order order, FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs);
 
-        /** Access to the task function.*/
-        const function::abstract::Function & function() const;
-        /** Access to the task operator. */
-        constraint::Type type() const;
-        /** Access to the task right hand side.*/
-        const Eigen::VectorXd& rhs() const;
+  /** Access to the task function.*/
+  const function::abstract::Function & function() const;
+  /** Access to the task operator. */
+  constraint::Type type() const;
+  /** Access to the task right hand side.*/
+  const Eigen::VectorXd & rhs() const;
 
-        /** Cache to store the results of updateValue()*/
-        Eigen::VectorXd value_;
+  /** Cache to store the results of updateValue()*/
+  Eigen::VectorXd value_;
 
-      private:
-        void setFunction(FunctionPtr f);
+private:
+  void setFunction(FunctionPtr f);
 
-        Order order_;
-        FunctionPtr f_;
-        constraint::Type type_;
-        Eigen::VectorXd rhs_;
+  Order order_;
+  FunctionPtr f_;
+  constraint::Type type_;
+  Eigen::VectorXd rhs_;
 
-        friend TaskDynamics;
-      };
+  friend TaskDynamics;
+};
 
-      inline const Eigen::VectorXd& TaskDynamicsImpl::value() const
-      {
-        return value_;
-      }
+inline const Eigen::VectorXd & TaskDynamicsImpl::value() const { return value_; }
 
-      inline Order TaskDynamicsImpl::order() const
-      {
-        return order_;
-      }
+inline Order TaskDynamicsImpl::order() const { return order_; }
 
-      inline const function::abstract::Function & TaskDynamicsImpl::function() const
-      {
-        assert(f_);
-        return *f_;
-      }
+inline const function::abstract::Function & TaskDynamicsImpl::function() const
+{
+  assert(f_);
+  return *f_;
+}
 
-      inline constraint::Type TaskDynamicsImpl::type() const
-      {
-        return type_;
-      }
+inline constraint::Type TaskDynamicsImpl::type() const { return type_; }
 
-      inline const Eigen::VectorXd & TaskDynamicsImpl::rhs() const
-      {
-        return rhs_;
-      }
+inline const Eigen::VectorXd & TaskDynamicsImpl::rhs() const { return rhs_; }
 
-      template<typename T>
-      inline bool TaskDynamicsImpl::checkType() const
-      {
-        return dynamic_cast<const T *>(this) != nullptr;
-      }
+template<typename T>
+inline bool TaskDynamicsImpl::checkType() const
+{
+  return dynamic_cast<const T *>(this) != nullptr;
+}
 
-    }  // namespace abstract
+} // namespace abstract
 
-  }  // namespace task_dynamics
+} // namespace task_dynamics
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
+++ b/include/tvm/task_dynamics/abstract/TaskDynamicsImpl.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include <tvm/constraint/enums.h>
 #include <tvm/defs.h>
+
+#include <tvm/constraint/enums.h>
 #include <tvm/graph/abstract/Node.h>
 #include <tvm/task_dynamics/enums.h>
 

--- a/include/tvm/task_dynamics/enums.h
+++ b/include/tvm/task_dynamics/enums.h
@@ -10,13 +10,13 @@ namespace tvm
 namespace task_dynamics
 {
 
-  enum class Order
-  {
-    Zero,
-    One,
-    Two
-  };
+enum class Order
+{
+  Zero,
+  One,
+  Two
+};
 
-}  // namespace task_dynamics
+} // namespace task_dynamics
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/utils/AffineExpr.h
+++ b/include/tvm/utils/AffineExpr.h
@@ -33,21 +33,18 @@ public:
   /** Constructor for Identity linear expression */
   template<class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::IdentityType>, int> = 0>
   LinearExpr(const tvm::VariablePtr & v) : matrix_(Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v)
-  {
-  }
+  {}
 
   /** Constructor for a*v where a is a scalar */
   template<class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::MultIdentityType>, int> = 0>
   LinearExpr(double a, const tvm::VariablePtr & v)
   : matrix_(a * Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v)
-  {
-  }
+  {}
 
   /** Constructor for -v */
   template<class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::MinusIdentityType>, int> = 0>
   LinearExpr(const tvm::VariablePtr & v) : matrix_(-Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v)
-  {
-  }
+  {}
 
   const Derived & matrix() const { return matrix_; };
   const VariablePtr & variable() const { return var_; }
@@ -78,8 +75,7 @@ public:
   template<class T = CstDerived, typename std::enable_if_t<std::is_same_v<T, internal::NoConstant>, int> = 0>
   AffineExpr(const LinearExpr<Derived> &... linear)
   : linear_(std::forward_as_tuple(linear...)), constant_(internal::NoConstant())
-  {
-  }
+  {}
 
   /** Construction from a sequence of LinearExpr, in the case of CstDerived != NoConstant (existing constant part).*/
   template<class T = CstDerived, typename std::enable_if_t<!std::is_same_v<T, internal::NoConstant>, int> = 0>
@@ -93,8 +89,7 @@ public:
   template<class T = CstDerived, typename std::enable_if_t<std::is_same_v<T, internal::NoConstant>, int> = 0>
   AffineExpr(const internal::NoConstant & constant, const std::tuple<LinearExpr<Derived>...> & linear)
   : linear_(linear), constant_(constant)
-  {
-  }
+  {}
 
   /** Construction from a tuple of LinearExpr, in the case of CstDerived != NoConstant (existing constant part).*/
   template<class T = CstDerived, typename std::enable_if_t<!std::is_same_v<T, internal::NoConstant>, int> = 0>

--- a/include/tvm/utils/AffineExpr.h
+++ b/include/tvm/utils/AffineExpr.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include <tvm/Variable.h>
 #include <tvm/api.h>
 #include <tvm/defs.h>
+
+#include <tvm/Variable.h>
 #include <tvm/internal/meta.h>
 #include <tvm/utils/internal/AffineExprDetail.h>
 

--- a/include/tvm/utils/AffineExpr.h
+++ b/include/tvm/utils/AffineExpr.h
@@ -1,37 +1,37 @@
 /* Copyright 2017-2019 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
+#include <tvm/Variable.h>
 #include <tvm/api.h>
 #include <tvm/defs.h>
-#include <tvm/Variable.h>
 #include <tvm/internal/meta.h>
 #include <tvm/utils/internal/AffineExprDetail.h>
 
@@ -43,105 +43,121 @@ namespace tvm
 {
 namespace utils
 {
-  /** A class representing an expression A * x with A a matrix expression and x a variable
-    *
-    * \tparam Derived The type of the matrix expression.
-    */
-  template<typename Derived>
-  class LinearExpr
+/** A class representing an expression A * x with A a matrix expression and x a variable
+ *
+ * \tparam Derived The type of the matrix expression.
+ */
+template<typename Derived>
+class LinearExpr
+{
+public:
+  /** General constructor */
+  LinearExpr(const Eigen::MatrixBase<Derived> & matrix, const VariablePtr & v) : matrix_(matrix.derived()), var_(v)
   {
-  public:
-    /** General constructor */
-    LinearExpr(const Eigen::MatrixBase<Derived>& matrix, const VariablePtr& v) : matrix_(matrix.derived()), var_(v) { assert(matrix.cols() == v->size()); }
-
-    /** Constructor for Identity linear expression */
-    template <class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::IdentityType>, int> = 0>
-    LinearExpr(const tvm::VariablePtr& v) : matrix_(Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v) {}
-
-    /** Constructor for a*v where a is a scalar */
-    template <class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::MultIdentityType>, int> = 0>
-    LinearExpr(double a, const tvm::VariablePtr& v) : matrix_(a* Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v) {}
-
-    /** Constructor for -v */
-    template <class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::MinusIdentityType>, int> = 0>
-    LinearExpr(const tvm::VariablePtr& v) : matrix_(-Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v) {}
-
-
-    const Derived& matrix() const { return matrix_; };
-    const VariablePtr& variable() const { return var_; }
-  private:
-    /** The matrix expression. */
-    typename internal::RefSelector_t<Derived> matrix_;
-    /** The variable */
-    const VariablePtr& var_;
-  };
-
-
-  /** A class representing an affine expression \f$ A_1 x_1 + A_2 x_2 + \ldots + A_k x_k + b \f$
-    * where \f$ A_i \f$ is a matrix expression, \f$ x_i \f$ is a Variable and 
-    * \f$ b \f$ is a vector expression.
-    *
-    * The class is essentially a list of LinearExpr in the form of a std:::tuple,
-    * and a vector expression.
-    *
-    * \tparam CstDerived The type of the constant part. Possibly NoConstant, otherwise an Eigen
-    *         expression type with the characteristics of a vector.
-    * \tparam Derived The list of matrix expression types corresponding to each Ai
-    */
-  template<typename CstDerived, typename ... Derived>
-  class AffineExpr
-  {
-  public:
-    /** Construction from a sequence of LinearExpr, in the case of CstDerived == NoConstant (absent constant part).*/
-    template<class T = CstDerived, typename std::enable_if_t<std::is_same_v<T, internal::NoConstant>, int> = 0>
-    AffineExpr(const LinearExpr<Derived>&... linear)
-      : linear_(std::forward_as_tuple(linear ...)), constant_(internal::NoConstant())
-    {}
-
-    /** Construction from a sequence of LinearExpr, in the case of CstDerived != NoConstant (existing constant part).*/
-    template <class T = CstDerived, typename std::enable_if_t<!std::is_same_v<T, internal::NoConstant>, int> = 0>
-    AffineExpr(const Eigen::MatrixBase<CstDerived>& constant, const LinearExpr<Derived>&... linear)
-      : linear_(std::forward_as_tuple(linear ...)), constant_(constant.derived())
-    {
-      EIGEN_STATIC_ASSERT_VECTOR_ONLY(CstDerived)
-    }
-
-    /** Construction from a tuple of LinearExpr, in the case of CstDerived == NoConstant (absent constant part).*/
-    template <class T = CstDerived, typename std::enable_if_t<std::is_same_v<T, internal::NoConstant>, int> = 0>
-    AffineExpr(const internal::NoConstant& constant, const std::tuple<LinearExpr<Derived>... >& linear)
-      : linear_(linear), constant_(constant)
-    {}
-
-    /** Construction from a tuple of LinearExpr, in the case of CstDerived != NoConstant (existing constant part).*/
-    template <class T = CstDerived, typename std::enable_if_t<!std::is_same_v<T, internal::NoConstant>, int> = 0>
-    AffineExpr(const Eigen::MatrixBase<CstDerived>& constant, const std::tuple<LinearExpr<Derived>... >& linear)
-      : linear_(linear), constant_(constant.derived())
-    {
-      EIGEN_STATIC_ASSERT_VECTOR_ONLY(CstDerived)
-    }
-
-    const std::tuple<LinearExpr<Derived>... >& linear() const { return linear_; }
-    const CstDerived& constant() const { return constant_; }
-
-  private:
-    // ConstantType::Type is NoConstant in case CstType==NoConstant and ref_selector<CstDerived> otherwise.
-    // Use of ref_selector<CstDerived>: for a vector, we need to keep a const ref, while for a vector
-    // expression we need to take a copy of the expression (same use as in e.g. CWiseBinaryOp).
-    template<typename T> struct ConstantType { using Type = typename internal::RefSelector_t<CstDerived>; };
-
-    /** The list of linear expressions Ai * xi */
-    std::tuple<LinearExpr<Derived>... > linear_;
-    /** The constant part b */
-    typename ConstantType<CstDerived>::Type constant_;
-  };
-
-  /** Helper function to create a AffineExpr and infer automatically the template arguments.*/
-  template<typename CstDerived, typename... Derived>
-  AffineExpr<CstDerived, Derived...> make_AffineExpr(const CstDerived& constant, const std::tuple<LinearExpr<Derived>... >& linear)
-  {
-    return { constant, linear };
+    assert(matrix.cols() == v->size());
   }
+
+  /** Constructor for Identity linear expression */
+  template<class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::IdentityType>, int> = 0>
+  LinearExpr(const tvm::VariablePtr & v) : matrix_(Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v)
+  {
+  }
+
+  /** Constructor for a*v where a is a scalar */
+  template<class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::MultIdentityType>, int> = 0>
+  LinearExpr(double a, const tvm::VariablePtr & v)
+  : matrix_(a * Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v)
+  {
+  }
+
+  /** Constructor for -v */
+  template<class T = Derived, typename std::enable_if_t<std::is_same_v<T, internal::MinusIdentityType>, int> = 0>
+  LinearExpr(const tvm::VariablePtr & v) : matrix_(-Eigen::MatrixXd::Identity(v->size(), v->size())), var_(v)
+  {
+  }
+
+  const Derived & matrix() const { return matrix_; };
+  const VariablePtr & variable() const { return var_; }
+
+private:
+  /** The matrix expression. */
+  typename internal::RefSelector_t<Derived> matrix_;
+  /** The variable */
+  const VariablePtr & var_;
+};
+
+/** A class representing an affine expression \f$ A_1 x_1 + A_2 x_2 + \ldots + A_k x_k + b \f$
+ * where \f$ A_i \f$ is a matrix expression, \f$ x_i \f$ is a Variable and
+ * \f$ b \f$ is a vector expression.
+ *
+ * The class is essentially a list of LinearExpr in the form of a std:::tuple,
+ * and a vector expression.
+ *
+ * \tparam CstDerived The type of the constant part. Possibly NoConstant, otherwise an Eigen
+ *         expression type with the characteristics of a vector.
+ * \tparam Derived The list of matrix expression types corresponding to each Ai
+ */
+template<typename CstDerived, typename... Derived>
+class AffineExpr
+{
+public:
+  /** Construction from a sequence of LinearExpr, in the case of CstDerived == NoConstant (absent constant part).*/
+  template<class T = CstDerived, typename std::enable_if_t<std::is_same_v<T, internal::NoConstant>, int> = 0>
+  AffineExpr(const LinearExpr<Derived> &... linear)
+  : linear_(std::forward_as_tuple(linear...)), constant_(internal::NoConstant())
+  {
+  }
+
+  /** Construction from a sequence of LinearExpr, in the case of CstDerived != NoConstant (existing constant part).*/
+  template<class T = CstDerived, typename std::enable_if_t<!std::is_same_v<T, internal::NoConstant>, int> = 0>
+  AffineExpr(const Eigen::MatrixBase<CstDerived> & constant, const LinearExpr<Derived> &... linear)
+  : linear_(std::forward_as_tuple(linear...)), constant_(constant.derived())
+  {
+    EIGEN_STATIC_ASSERT_VECTOR_ONLY(CstDerived)
+  }
+
+  /** Construction from a tuple of LinearExpr, in the case of CstDerived == NoConstant (absent constant part).*/
+  template<class T = CstDerived, typename std::enable_if_t<std::is_same_v<T, internal::NoConstant>, int> = 0>
+  AffineExpr(const internal::NoConstant & constant, const std::tuple<LinearExpr<Derived>...> & linear)
+  : linear_(linear), constant_(constant)
+  {
+  }
+
+  /** Construction from a tuple of LinearExpr, in the case of CstDerived != NoConstant (existing constant part).*/
+  template<class T = CstDerived, typename std::enable_if_t<!std::is_same_v<T, internal::NoConstant>, int> = 0>
+  AffineExpr(const Eigen::MatrixBase<CstDerived> & constant, const std::tuple<LinearExpr<Derived>...> & linear)
+  : linear_(linear), constant_(constant.derived())
+  {
+    EIGEN_STATIC_ASSERT_VECTOR_ONLY(CstDerived)
+  }
+
+  const std::tuple<LinearExpr<Derived>...> & linear() const { return linear_; }
+  const CstDerived & constant() const { return constant_; }
+
+private:
+  // ConstantType::Type is NoConstant in case CstType==NoConstant and ref_selector<CstDerived> otherwise.
+  // Use of ref_selector<CstDerived>: for a vector, we need to keep a const ref, while for a vector
+  // expression we need to take a copy of the expression (same use as in e.g. CWiseBinaryOp).
+  template<typename T>
+  struct ConstantType
+  {
+    using Type = typename internal::RefSelector_t<CstDerived>;
+  };
+
+  /** The list of linear expressions Ai * xi */
+  std::tuple<LinearExpr<Derived>...> linear_;
+  /** The constant part b */
+  typename ConstantType<CstDerived>::Type constant_;
+};
+
+/** Helper function to create a AffineExpr and infer automatically the template arguments.*/
+template<typename CstDerived, typename... Derived>
+AffineExpr<CstDerived, Derived...> make_AffineExpr(const CstDerived & constant,
+                                                   const std::tuple<LinearExpr<Derived>...> & linear)
+{
+  return {constant, linear};
 }
-}
+} // namespace utils
+} // namespace tvm
 
 #include <tvm/utils/internal/AffineExprOperators.h>

--- a/include/tvm/utils/AffineExpr.h
+++ b/include/tvm/utils/AffineExpr.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2019 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/ProtoTask.h
+++ b/include/tvm/utils/ProtoTask.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,195 +39,286 @@ namespace tvm
 namespace utils
 {
 
-  template<constraint::Type T, typename FunT>
-  class ProtoTaskCommon;
+template<constraint::Type T, typename FunT>
+class ProtoTaskCommon;
 
-  /** A utiliy class to represent the "constraint" part of a Task, for general functions*/
-  template<constraint::Type T>
-  using ProtoTask = ProtoTaskCommon<T, FunctionPtr>;
+/** A utiliy class to represent the "constraint" part of a Task, for general functions*/
+template<constraint::Type T>
+using ProtoTask = ProtoTaskCommon<T, FunctionPtr>;
 
-  /** A utiliy class to represent the "constraint" part of a Task, specialized for linear functions*/
-  template<constraint::Type T>
-  using LinearProtoTask = ProtoTaskCommon<T, LinearFunctionPtr>;
+/** A utiliy class to represent the "constraint" part of a Task, specialized for linear functions*/
+template<constraint::Type T>
+using LinearProtoTask = ProtoTaskCommon<T, LinearFunctionPtr>;
 
-  template<constraint::Type T, typename FunT>
-  class ProtoTaskCommon
+template<constraint::Type T, typename FunT>
+class ProtoTaskCommon
+{
+public:
+  ProtoTaskCommon(FunT f, const internal::RHS & rhs) : f_(f), rhs_(rhs)
   {
-  public:
-    ProtoTaskCommon(FunT f, const internal::RHS& rhs)
-    : f_(f), rhs_(rhs)
+    if(rhs.type_ == internal::RHSType::Vector && f->rSize() != rhs.v_.size())
     {
-      if (rhs.type_ == internal::RHSType::Vector && f->rSize() != rhs.v_.size())
-      {
-        throw std::runtime_error("The vector you provided has not the correct size.");
-      }
+      throw std::runtime_error("The vector you provided has not the correct size.");
     }
+  }
 
-    template<typename FunU>
-    ProtoTaskCommon(const ProtoTaskCommon<T, FunU> & pt)
-    : f_(pt.f_), rhs_(pt.rhs_)
-    {
-    }
-
-    FunT f_;
-    internal::RHS rhs_;
-  };
-
-  template<typename FunT>
-  class ProtoTaskCommon<constraint::Type::DOUBLE_SIDED, FunT>
+  template<typename FunU>
+  ProtoTaskCommon(const ProtoTaskCommon<T, FunU> & pt) : f_(pt.f_), rhs_(pt.rhs_)
   {
-  public:
-    ProtoTaskCommon(FunT f, const internal::RHS& l, const internal::RHS & u)
-    : f_(f), l_(l), u_(u)
+  }
+
+  FunT f_;
+  internal::RHS rhs_;
+};
+
+template<typename FunT>
+class ProtoTaskCommon<constraint::Type::DOUBLE_SIDED, FunT>
+{
+public:
+  ProtoTaskCommon(FunT f, const internal::RHS & l, const internal::RHS & u) : f_(f), l_(l), u_(u)
+  {
+    if(l.type_ == internal::RHSType::Vector && f->rSize() != l.v_.size())
     {
-      if (l.type_ == internal::RHSType::Vector && f->rSize() != l.v_.size())
-      {
-        throw std::runtime_error("The lower bound vector you provided has not the correct size.");
-      }
-      if (u.type_ == internal::RHSType::Vector && f->rSize() != u.v_.size())
-      {
-        throw std::runtime_error("The upper bound vector you provided has not the correct size.");
-      }
+      throw std::runtime_error("The lower bound vector you provided has not the correct size.");
     }
-
-    template<typename FunU>
-    ProtoTaskCommon(const ProtoTaskCommon<constraint::Type::DOUBLE_SIDED, FunU> & pt)
-    : f_(pt.f_), l_(pt.l_), u_(pt.u_)
+    if(u.type_ == internal::RHSType::Vector && f->rSize() != u.v_.size())
     {
+      throw std::runtime_error("The upper bound vector you provided has not the correct size.");
     }
+  }
 
-    FunctionPtr f_;
-    internal::RHS l_;
-    internal::RHS u_;
-  };
+  template<typename FunU>
+  ProtoTaskCommon(const ProtoTaskCommon<constraint::Type::DOUBLE_SIDED, FunU> & pt) : f_(pt.f_), l_(pt.l_), u_(pt.u_)
+  {
+  }
 
-  /** A helper alias that is IfNotLinearFunction if T is a tvm::abstract::Function, 
-    * but not a tvm::abstract::LinearFunction, IfLinearFunction if it is a 
-    * tvm::abstract::LinearFunction, and nothing (discarded by SFINAE) otherwise.
-    */
-  template<typename T, typename IfNotLinearFunction, typename IfLinearFunction>
-  using ProtoChoice = typename std::enable_if<
-                                 std::is_base_of<tvm::function::abstract::Function, T>::value, 
-                                 typename std::conditional<
-                                   std::is_base_of<tvm::function::abstract::LinearFunction, T>::value, 
-                                   IfLinearFunction, 
-                                   IfNotLinearFunction
-                                 >::type
-                               >::type;
+  FunctionPtr f_;
+  internal::RHS l_;
+  internal::RHS u_;
+};
 
-  /** Equality ProtoTask f = rhs*/
-  using ProtoTaskEQ = ProtoTask<constraint::Type::EQUAL>;
-  using LinearProtoTaskEQ = LinearProtoTask<constraint::Type::EQUAL>;
-  template<typename T>
-  using ProtoTaskEQRet = ProtoChoice<T, tvm::utils::ProtoTaskEQ, tvm::utils::LinearProtoTaskEQ>;
+/** A helper alias that is IfNotLinearFunction if T is a tvm::abstract::Function,
+ * but not a tvm::abstract::LinearFunction, IfLinearFunction if it is a
+ * tvm::abstract::LinearFunction, and nothing (discarded by SFINAE) otherwise.
+ */
+template<typename T, typename IfNotLinearFunction, typename IfLinearFunction>
+using ProtoChoice =
+    typename std::enable_if<std::is_base_of<tvm::function::abstract::Function, T>::value,
+                            typename std::conditional<std::is_base_of<tvm::function::abstract::LinearFunction, T>::value,
+                                                      IfLinearFunction,
+                                                      IfNotLinearFunction>::type>::type;
 
-  /** Inequality ProtoTask f <= rhs*/
-  using ProtoTaskLT = ProtoTask<constraint::Type::LOWER_THAN>;
-  using LinearProtoTaskLT = LinearProtoTask<constraint::Type::LOWER_THAN>;
-  template<typename T>
-  using ProtoTaskLTRet = ProtoChoice<T, tvm::utils::ProtoTaskLT, tvm::utils::LinearProtoTaskLT>;
+/** Equality ProtoTask f = rhs*/
+using ProtoTaskEQ = ProtoTask<constraint::Type::EQUAL>;
+using LinearProtoTaskEQ = LinearProtoTask<constraint::Type::EQUAL>;
+template<typename T>
+using ProtoTaskEQRet = ProtoChoice<T, tvm::utils::ProtoTaskEQ, tvm::utils::LinearProtoTaskEQ>;
 
-  /** Inequality ProtoTask f >= rhs*/
-  using ProtoTaskGT = ProtoTask<constraint::Type::GREATER_THAN>;
-  using LinearProtoTaskGT = LinearProtoTask<constraint::Type::GREATER_THAN>;
-  template<typename T>
-  using ProtoTaskGTRet = ProtoChoice<T, tvm::utils::ProtoTaskGT, tvm::utils::LinearProtoTaskGT>;
+/** Inequality ProtoTask f <= rhs*/
+using ProtoTaskLT = ProtoTask<constraint::Type::LOWER_THAN>;
+using LinearProtoTaskLT = LinearProtoTask<constraint::Type::LOWER_THAN>;
+template<typename T>
+using ProtoTaskLTRet = ProtoChoice<T, tvm::utils::ProtoTaskLT, tvm::utils::LinearProtoTaskLT>;
 
-  /** Double sided inequality ProtoTask l <= f <= u*/
-  using ProtoTaskDS = ProtoTask<constraint::Type::DOUBLE_SIDED>;
-  using LinearProtoTaskDS = LinearProtoTask<constraint::Type::DOUBLE_SIDED>;
-  template<typename T>
-  using ProtoTaskDSRet = ProtoChoice<T, tvm::utils::ProtoTaskDS, tvm::utils::LinearProtoTaskDS>;
+/** Inequality ProtoTask f >= rhs*/
+using ProtoTaskGT = ProtoTask<constraint::Type::GREATER_THAN>;
+using LinearProtoTaskGT = LinearProtoTask<constraint::Type::GREATER_THAN>;
+template<typename T>
+using ProtoTaskGTRet = ProtoChoice<T, tvm::utils::ProtoTaskGT, tvm::utils::LinearProtoTaskGT>;
+
+/** Double sided inequality ProtoTask l <= f <= u*/
+using ProtoTaskDS = ProtoTask<constraint::Type::DOUBLE_SIDED>;
+using LinearProtoTaskDS = LinearProtoTask<constraint::Type::DOUBLE_SIDED>;
+template<typename T>
+using ProtoTaskDSRet = ProtoChoice<T, tvm::utils::ProtoTaskDS, tvm::utils::LinearProtoTaskDS>;
 
 } // namespace utils
 
 } // namespace tvm
 
 /** Conveniency operators to form a ProtoTask or LinearProtoTask f op rhs
-  * (or l <= f <= u)
-  *
-  * \param f the function to form the task
-  * \param rhs a double or a Eigen::Vector with the same size as the function.
-  * Note that for a double you need to explicitely write a double (e.g 0.,
-  * not 0), otherwise the compiler won't be able to decide wich overload to
-  * pick between this and shared_ptr operator.
-  */
+ * (or l <= f <= u)
+ *
+ * \param f the function to form the task
+ * \param rhs a double or a Eigen::Vector with the same size as the function.
+ * Note that for a double you need to explicitely write a double (e.g 0.,
+ * not 0), otherwise the compiler won't be able to decide wich overload to
+ * pick between this and shared_ptr operator.
+ */
 /**@{*/
 template<typename F>
-inline tvm::utils::ProtoTaskEQRet<F> operator==(std::shared_ptr<F> f, const tvm::utils::internal::RHS& rhs) { return { f, rhs }; }
+inline tvm::utils::ProtoTaskEQRet<F> operator==(std::shared_ptr<F> f, const tvm::utils::internal::RHS & rhs)
+{
+  return {f, rhs};
+}
 template<typename F>
-inline tvm::utils::ProtoTaskEQRet<F> operator==(const tvm::utils::internal::RHS& rhs, std::shared_ptr<F> f) { return { f, rhs }; }
+inline tvm::utils::ProtoTaskEQRet<F> operator==(const tvm::utils::internal::RHS & rhs, std::shared_ptr<F> f)
+{
+  return {f, rhs};
+}
 template<typename F>
-inline tvm::utils::ProtoTaskGTRet<F> operator>=(std::shared_ptr<F> f, const tvm::utils::internal::RHS& rhs) { return { f, rhs }; }
+inline tvm::utils::ProtoTaskGTRet<F> operator>=(std::shared_ptr<F> f, const tvm::utils::internal::RHS & rhs)
+{
+  return {f, rhs};
+}
 template<typename F>
-inline tvm::utils::ProtoTaskLTRet<F> operator>=(const tvm::utils::internal::RHS& rhs, std::shared_ptr<F> f) { return { f, rhs }; }
+inline tvm::utils::ProtoTaskLTRet<F> operator>=(const tvm::utils::internal::RHS & rhs, std::shared_ptr<F> f)
+{
+  return {f, rhs};
+}
 template<typename F>
-inline tvm::utils::ProtoTaskLTRet<F> operator<=(std::shared_ptr<F> f, const tvm::utils::internal::RHS& rhs) { return { f, rhs }; }
+inline tvm::utils::ProtoTaskLTRet<F> operator<=(std::shared_ptr<F> f, const tvm::utils::internal::RHS & rhs)
+{
+  return {f, rhs};
+}
 template<typename F>
-inline tvm::utils::ProtoTaskGTRet<F> operator<=(const tvm::utils::internal::RHS& rhs, std::shared_ptr<F> f) { return { f, rhs }; }
+inline tvm::utils::ProtoTaskGTRet<F> operator<=(const tvm::utils::internal::RHS & rhs, std::shared_ptr<F> f)
+{
+  return {f, rhs};
+}
 
-inline tvm::utils::ProtoTaskDS operator>=(const tvm::utils::ProtoTaskLT& ptl, const tvm::utils::internal::RHS& rhs) { return { ptl.f_, rhs, ptl.rhs_ }; }
-inline tvm::utils::ProtoTaskDS operator<=(const tvm::utils::ProtoTaskGT& ptg, const tvm::utils::internal::RHS& rhs) { return { ptg.f_, ptg.rhs_, rhs }; }
-inline tvm::utils::LinearProtoTaskDS operator>=(const tvm::utils::LinearProtoTaskLT& ptl, const tvm::utils::internal::RHS& rhs) { return { ptl.f_, rhs, ptl.rhs_ }; }
-inline tvm::utils::LinearProtoTaskDS operator<=(const tvm::utils::LinearProtoTaskGT& ptg, const tvm::utils::internal::RHS& rhs) { return { ptg.f_, ptg.rhs_, rhs }; }
+inline tvm::utils::ProtoTaskDS operator>=(const tvm::utils::ProtoTaskLT & ptl, const tvm::utils::internal::RHS & rhs)
+{
+  return {ptl.f_, rhs, ptl.rhs_};
+}
+inline tvm::utils::ProtoTaskDS operator<=(const tvm::utils::ProtoTaskGT & ptg, const tvm::utils::internal::RHS & rhs)
+{
+  return {ptg.f_, ptg.rhs_, rhs};
+}
+inline tvm::utils::LinearProtoTaskDS operator>=(const tvm::utils::LinearProtoTaskLT & ptl,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return {ptl.f_, rhs, ptl.rhs_};
+}
+inline tvm::utils::LinearProtoTaskDS operator<=(const tvm::utils::LinearProtoTaskGT & ptg,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return {ptg.f_, ptg.rhs_, rhs};
+}
 /**@}*/
 
 #define TVM_ID(x) std::make_shared<tvm::function::IdentityFunction>(x)
 /** Conveniency operators to form a LinearProtoTask x op rhs (or l <= x <= u)
-  *
-  * \param x the variable used in the task
-  * \param rhs a double or a Eigen::Vector with the same size as the function.
-  * Note that for a double you need to explicitely write a double (e.g 0.,
-  * not 0), otherwise the compiler won't be able to decide wich overload to
-  * pick between this and shared_ptr operator.
-  */
-  /**@{*/
-inline tvm::utils::LinearProtoTaskEQ operator==(tvm::VariablePtr x, const tvm::utils::internal::RHS& rhs) { return TVM_ID(x) == rhs; }
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS& rhs, tvm::VariablePtr x) { return TVM_ID(x) == rhs; }
-inline tvm::utils::LinearProtoTaskGT operator>=(tvm::VariablePtr x, const tvm::utils::internal::RHS& rhs) { return TVM_ID(x) >= rhs; }
-inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS& rhs, tvm::VariablePtr x) { return TVM_ID(x) <= rhs; }
-inline tvm::utils::LinearProtoTaskLT operator<=(tvm::VariablePtr x, const tvm::utils::internal::RHS& rhs) { return TVM_ID(x) <= rhs; }
-inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS& rhs, tvm::VariablePtr x) { return TVM_ID(x) >= rhs; }
+ *
+ * \param x the variable used in the task
+ * \param rhs a double or a Eigen::Vector with the same size as the function.
+ * Note that for a double you need to explicitely write a double (e.g 0.,
+ * not 0), otherwise the compiler won't be able to decide wich overload to
+ * pick between this and shared_ptr operator.
+ */
+/**@{*/
+inline tvm::utils::LinearProtoTaskEQ operator==(tvm::VariablePtr x, const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_ID(x) == rhs;
+}
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS & rhs, tvm::VariablePtr x)
+{
+  return TVM_ID(x) == rhs;
+}
+inline tvm::utils::LinearProtoTaskGT operator>=(tvm::VariablePtr x, const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_ID(x) >= rhs;
+}
+inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS & rhs, tvm::VariablePtr x)
+{
+  return TVM_ID(x) <= rhs;
+}
+inline tvm::utils::LinearProtoTaskLT operator<=(tvm::VariablePtr x, const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_ID(x) <= rhs;
+}
+inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS & rhs, tvm::VariablePtr x)
+{
+  return TVM_ID(x) >= rhs;
+}
 /**@}*/
 #undef TVM_ID
 
 #define TVM_LIN(x) std::make_shared<tvm::function::BasicLinearFunction>(x)
 
 /** Conveniency operators to form a LinearProtoTask expr op rhs (or l <= expr <= u)
-  * where expr is a linear expression of the form matrixExpr * VariablePtr or an
-  * affine expression as a sum of linear expressions and vectorExpr.
-  *
-  * \param lin the linear expression to form the task
-  * \param aff the affine expression to form the task
-  * \param rhs a double or a Eigen::Vector with the same size as the function.
-  * Note that for a double you don't need to explicitely write a double (e.g 0.)
-  * to the contrary of the operators working with shared_ptr on Function.
-  */
+ * where expr is a linear expression of the form matrixExpr * VariablePtr or an
+ * affine expression as a sum of linear expressions and vectorExpr.
+ *
+ * \param lin the linear expression to form the task
+ * \param aff the affine expression to form the task
+ * \param rhs a double or a Eigen::Vector with the same size as the function.
+ * Note that for a double you don't need to explicitely write a double (e.g 0.)
+ * to the contrary of the operators working with shared_ptr on Function.
+ */
 ///@{
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::LinearExpr<Derived>& lin, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(lin) == rhs; }
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::LinearExpr<Derived> & lin,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_LIN(lin) == rhs;
+}
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS& rhs, const tvm::utils::LinearExpr<Derived>& lin) { return TVM_LIN(lin) == rhs; }
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS & rhs,
+                                                const tvm::utils::LinearExpr<Derived> & lin)
+{
+  return TVM_LIN(lin) == rhs;
+}
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::LinearExpr<Derived>& lin, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(lin) >= rhs; }
+inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::LinearExpr<Derived> & lin,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_LIN(lin) >= rhs;
+}
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS& rhs, const tvm::utils::LinearExpr<Derived>& lin) { return TVM_LIN(lin) <= rhs; }
+inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS & rhs,
+                                                const tvm::utils::LinearExpr<Derived> & lin)
+{
+  return TVM_LIN(lin) <= rhs;
+}
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::LinearExpr<Derived>& lin, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(lin) <= rhs; }
+inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::LinearExpr<Derived> & lin,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_LIN(lin) <= rhs;
+}
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS& rhs, const tvm::utils::LinearExpr<Derived>& lin) { return TVM_LIN(lin) >= rhs; }
+inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS & rhs,
+                                                const tvm::utils::LinearExpr<Derived> & lin)
+{
+  return TVM_LIN(lin) >= rhs;
+}
 
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(aff) == rhs; }
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_LIN(aff) == rhs;
+}
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS& rhs, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff) { return TVM_LIN(aff) == rhs; }
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS & rhs,
+                                                const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
+{
+  return TVM_LIN(aff) == rhs;
+}
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(aff) >= rhs; }
+inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_LIN(aff) >= rhs;
+}
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS& rhs, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff) { return TVM_LIN(aff) <= rhs; }
+inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS & rhs,
+                                                const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
+{
+  return TVM_LIN(aff) <= rhs;
+}
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(aff) <= rhs; }
+inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff,
+                                                const tvm::utils::internal::RHS & rhs)
+{
+  return TVM_LIN(aff) <= rhs;
+}
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS& rhs, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff) { return TVM_LIN(aff) >= rhs; }
+inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS & rhs,
+                                                const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
+{
+  return TVM_LIN(aff) >= rhs;
+}
 ///@}
 #undef TVM_LIN

--- a/include/tvm/utils/ProtoTask.h
+++ b/include/tvm/utils/ProtoTask.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/ProtoTask.h
+++ b/include/tvm/utils/ProtoTask.h
@@ -37,8 +37,7 @@ public:
 
   template<typename FunU>
   ProtoTaskCommon(const ProtoTaskCommon<T, FunU> & pt) : f_(pt.f_), rhs_(pt.rhs_)
-  {
-  }
+  {}
 
   FunT f_;
   internal::RHS rhs_;
@@ -62,8 +61,7 @@ public:
 
   template<typename FunU>
   ProtoTaskCommon(const ProtoTaskCommon<constraint::Type::DOUBLE_SIDED, FunU> & pt) : f_(pt.f_), l_(pt.l_), u_(pt.u_)
-  {
-  }
+  {}
 
   FunctionPtr f_;
   internal::RHS l_;

--- a/include/tvm/utils/ProtoTask.h
+++ b/include/tvm/utils/ProtoTask.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tvm/api.h>
+
 #include <tvm/utils/AffineExpr.h>
 #include <tvm/utils/internal/ProtoTaskDetails.h>
 

--- a/include/tvm/utils/ProtoTask.h
+++ b/include/tvm/utils/ProtoTask.h
@@ -119,55 +119,25 @@ using ProtoTaskDSRet = ProtoChoice<T, tvm::utils::ProtoTaskDS, tvm::utils::Linea
  * pick between this and shared_ptr operator.
  */
 /**@{*/
+// clang-format off
 template<typename F>
-inline tvm::utils::ProtoTaskEQRet<F> operator==(std::shared_ptr<F> f, const tvm::utils::internal::RHS & rhs)
-{
-  return {f, rhs};
-}
+inline tvm::utils::ProtoTaskEQRet<F> operator==(std::shared_ptr<F> f, const tvm::utils::internal::RHS& rhs) { return { f, rhs }; }
 template<typename F>
-inline tvm::utils::ProtoTaskEQRet<F> operator==(const tvm::utils::internal::RHS & rhs, std::shared_ptr<F> f)
-{
-  return {f, rhs};
-}
+inline tvm::utils::ProtoTaskEQRet<F> operator==(const tvm::utils::internal::RHS& rhs, std::shared_ptr<F> f) { return { f, rhs }; }
 template<typename F>
-inline tvm::utils::ProtoTaskGTRet<F> operator>=(std::shared_ptr<F> f, const tvm::utils::internal::RHS & rhs)
-{
-  return {f, rhs};
-}
+inline tvm::utils::ProtoTaskGTRet<F> operator>=(std::shared_ptr<F> f, const tvm::utils::internal::RHS& rhs) { return { f, rhs }; }
 template<typename F>
-inline tvm::utils::ProtoTaskLTRet<F> operator>=(const tvm::utils::internal::RHS & rhs, std::shared_ptr<F> f)
-{
-  return {f, rhs};
-}
+inline tvm::utils::ProtoTaskLTRet<F> operator>=(const tvm::utils::internal::RHS& rhs, std::shared_ptr<F> f) { return { f, rhs }; }
 template<typename F>
-inline tvm::utils::ProtoTaskLTRet<F> operator<=(std::shared_ptr<F> f, const tvm::utils::internal::RHS & rhs)
-{
-  return {f, rhs};
-}
+inline tvm::utils::ProtoTaskLTRet<F> operator<=(std::shared_ptr<F> f, const tvm::utils::internal::RHS& rhs) { return { f, rhs }; }
 template<typename F>
-inline tvm::utils::ProtoTaskGTRet<F> operator<=(const tvm::utils::internal::RHS & rhs, std::shared_ptr<F> f)
-{
-  return {f, rhs};
-}
+inline tvm::utils::ProtoTaskGTRet<F> operator<=(const tvm::utils::internal::RHS& rhs, std::shared_ptr<F> f) { return { f, rhs }; }
 
-inline tvm::utils::ProtoTaskDS operator>=(const tvm::utils::ProtoTaskLT & ptl, const tvm::utils::internal::RHS & rhs)
-{
-  return {ptl.f_, rhs, ptl.rhs_};
-}
-inline tvm::utils::ProtoTaskDS operator<=(const tvm::utils::ProtoTaskGT & ptg, const tvm::utils::internal::RHS & rhs)
-{
-  return {ptg.f_, ptg.rhs_, rhs};
-}
-inline tvm::utils::LinearProtoTaskDS operator>=(const tvm::utils::LinearProtoTaskLT & ptl,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return {ptl.f_, rhs, ptl.rhs_};
-}
-inline tvm::utils::LinearProtoTaskDS operator<=(const tvm::utils::LinearProtoTaskGT & ptg,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return {ptg.f_, ptg.rhs_, rhs};
-}
+inline tvm::utils::ProtoTaskDS operator>=(const tvm::utils::ProtoTaskLT& ptl, const tvm::utils::internal::RHS& rhs) { return { ptl.f_, rhs, ptl.rhs_ }; }
+inline tvm::utils::ProtoTaskDS operator<=(const tvm::utils::ProtoTaskGT& ptg, const tvm::utils::internal::RHS& rhs) { return { ptg.f_, ptg.rhs_, rhs }; }
+inline tvm::utils::LinearProtoTaskDS operator>=(const tvm::utils::LinearProtoTaskLT& ptl, const tvm::utils::internal::RHS& rhs) { return { ptl.f_, rhs, ptl.rhs_ }; }
+inline tvm::utils::LinearProtoTaskDS operator<=(const tvm::utils::LinearProtoTaskGT& ptg, const tvm::utils::internal::RHS& rhs) { return { ptg.f_, ptg.rhs_, rhs }; }
+// clang-format on
 /**@}*/
 
 #define TVM_ID(x) std::make_shared<tvm::function::IdentityFunction>(x)
@@ -180,30 +150,14 @@ inline tvm::utils::LinearProtoTaskDS operator<=(const tvm::utils::LinearProtoTas
  * pick between this and shared_ptr operator.
  */
 /**@{*/
-inline tvm::utils::LinearProtoTaskEQ operator==(tvm::VariablePtr x, const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_ID(x) == rhs;
-}
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS & rhs, tvm::VariablePtr x)
-{
-  return TVM_ID(x) == rhs;
-}
-inline tvm::utils::LinearProtoTaskGT operator>=(tvm::VariablePtr x, const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_ID(x) >= rhs;
-}
-inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS & rhs, tvm::VariablePtr x)
-{
-  return TVM_ID(x) <= rhs;
-}
-inline tvm::utils::LinearProtoTaskLT operator<=(tvm::VariablePtr x, const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_ID(x) <= rhs;
-}
-inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS & rhs, tvm::VariablePtr x)
-{
-  return TVM_ID(x) >= rhs;
-}
+// clang-format off
+inline tvm::utils::LinearProtoTaskEQ operator==(tvm::VariablePtr x, const tvm::utils::internal::RHS& rhs) { return TVM_ID(x) == rhs; }
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS& rhs, tvm::VariablePtr x) { return TVM_ID(x) == rhs; }
+inline tvm::utils::LinearProtoTaskGT operator>=(tvm::VariablePtr x, const tvm::utils::internal::RHS& rhs) { return TVM_ID(x) >= rhs; }
+inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS& rhs, tvm::VariablePtr x) { return TVM_ID(x) <= rhs; }
+inline tvm::utils::LinearProtoTaskLT operator<=(tvm::VariablePtr x, const tvm::utils::internal::RHS& rhs) { return TVM_ID(x) <= rhs; }
+inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS& rhs, tvm::VariablePtr x) { return TVM_ID(x) >= rhs; }
+// clang-format on
 /**@}*/
 #undef TVM_ID
 
@@ -220,78 +174,32 @@ inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS 
  * to the contrary of the operators working with shared_ptr on Function.
  */
 ///@{
+// clang-format off
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::LinearExpr<Derived> & lin,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_LIN(lin) == rhs;
-}
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::LinearExpr<Derived>& lin, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(lin) == rhs; }
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS & rhs,
-                                                const tvm::utils::LinearExpr<Derived> & lin)
-{
-  return TVM_LIN(lin) == rhs;
-}
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS& rhs, const tvm::utils::LinearExpr<Derived>& lin) { return TVM_LIN(lin) == rhs; }
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::LinearExpr<Derived> & lin,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_LIN(lin) >= rhs;
-}
+inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::LinearExpr<Derived>& lin, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(lin) >= rhs; }
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS & rhs,
-                                                const tvm::utils::LinearExpr<Derived> & lin)
-{
-  return TVM_LIN(lin) <= rhs;
-}
+inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS& rhs, const tvm::utils::LinearExpr<Derived>& lin) { return TVM_LIN(lin) <= rhs; }
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::LinearExpr<Derived> & lin,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_LIN(lin) <= rhs;
-}
+inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::LinearExpr<Derived>& lin, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(lin) <= rhs; }
 template<typename Derived>
-inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS & rhs,
-                                                const tvm::utils::LinearExpr<Derived> & lin)
-{
-  return TVM_LIN(lin) >= rhs;
-}
+inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS& rhs, const tvm::utils::LinearExpr<Derived>& lin) { return TVM_LIN(lin) >= rhs; }
 
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_LIN(aff) == rhs;
-}
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(aff) == rhs; }
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS & rhs,
-                                                const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
-{
-  return TVM_LIN(aff) == rhs;
-}
+inline tvm::utils::LinearProtoTaskEQ operator==(const tvm::utils::internal::RHS& rhs, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff) { return TVM_LIN(aff) == rhs; }
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_LIN(aff) >= rhs;
-}
+inline tvm::utils::LinearProtoTaskGT operator>=(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(aff) >= rhs; }
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS & rhs,
-                                                const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
-{
-  return TVM_LIN(aff) <= rhs;
-}
+inline tvm::utils::LinearProtoTaskLT operator>=(const tvm::utils::internal::RHS& rhs, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff) { return TVM_LIN(aff) <= rhs; }
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff,
-                                                const tvm::utils::internal::RHS & rhs)
-{
-  return TVM_LIN(aff) <= rhs;
-}
+inline tvm::utils::LinearProtoTaskLT operator<=(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const tvm::utils::internal::RHS& rhs) { return TVM_LIN(aff) <= rhs; }
 template<typename CstDerived, typename... Derived>
-inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS & rhs,
-                                                const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
-{
-  return TVM_LIN(aff) >= rhs;
-}
+inline tvm::utils::LinearProtoTaskGT operator<=(const tvm::utils::internal::RHS& rhs, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff) { return TVM_LIN(aff) >= rhs; }
+// clang-format on
 ///@}
 #undef TVM_LIN

--- a/include/tvm/utils/UpdatelessFunction.h
+++ b/include/tvm/utils/UpdatelessFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/UpdatelessFunction.h
+++ b/include/tvm/utils/UpdatelessFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,393 +42,446 @@ namespace tvm
 namespace utils
 {
 
-  /** This class wraps a function to mask the update mechanism to the user, by
-    * providing methods as value and jacobian that can be called directly with
-    * the values of the variables.
-    * It is meant for diagnostic and debugging purposes.
-    */
-  class TVM_DLLAPI UpdatelessFunction
-  {
-  public:
-    /** Constructor with the function to be wrapped. */
-    UpdatelessFunction(FunctionPtr f);
+/** This class wraps a function to mask the update mechanism to the user, by
+ * providing methods as value and jacobian that can be called directly with
+ * the values of the variables.
+ * It is meant for diagnostic and debugging purposes.
+ */
+class TVM_DLLAPI UpdatelessFunction
+{
+public:
+  /** Constructor with the function to be wrapped. */
+  UpdatelessFunction(FunctionPtr f);
 
-    /** Get the value of the function for given values of its variables.
-      * Variable values can be given as VectorXd, or as std::initializer_list.
-      * There are three possible syntaxes:
-      * - value(val1, val2, ..., valn) where val1, ..., valn are the values of
-      *   the n variables of the function, in the order they are stored in the
-      *   function (i.e. the order of the vector returned by variables() )
-      * - value(xi1, vali1, xi2, vali2, ...) where one alternates a reference
-      *   to one variable and its value. The number of variables in this case
-      *   need not be n (unspecified variables will keep their previous value),
-      *   and if a variable is given multiple times, only the last value will
-      *   be used
-      * - value(val) where val is a concatenated value for all variables in the
-      *   order they are stored in the function.
-      */
-    template<typename... Vals>
-    const Eigen::VectorXd& value(Vals&&... vals) const;
+  /** Get the value of the function for given values of its variables.
+   * Variable values can be given as VectorXd, or as std::initializer_list.
+   * There are three possible syntaxes:
+   * - value(val1, val2, ..., valn) where val1, ..., valn are the values of
+   *   the n variables of the function, in the order they are stored in the
+   *   function (i.e. the order of the vector returned by variables() )
+   * - value(xi1, vali1, xi2, vali2, ...) where one alternates a reference
+   *   to one variable and its value. The number of variables in this case
+   *   need not be n (unspecified variables will keep their previous value),
+   *   and if a variable is given multiple times, only the last value will
+   *   be used
+   * - value(val) where val is a concatenated value for all variables in the
+   *   order they are stored in the function.
+   */
+  template<typename... Vals>
+  const Eigen::VectorXd & value(Vals &&... vals) const;
 
-    /** Get the jacbian matrix with respect to x, for the given variable values.
-      * See \a value for an explanation of how to specify the values.
-      */
-    template<typename... Vals>
-    const Eigen::MatrixXd& jacobian(const Variable& x, Vals&&... vals) const;
+  /** Get the jacbian matrix with respect to x, for the given variable values.
+   * See \a value for an explanation of how to specify the values.
+   */
+  template<typename... Vals>
+  const Eigen::MatrixXd & jacobian(const Variable & x, Vals &&... vals) const;
 
-    /** Get the velocity of the function for given values and velocities of its
-      * variables.
-      * The values and velocities can be given as VectorXd, or as 
-      * std::initializer_list. There are three possible syntaxes:
-      * - velocity(val1, vel1, val2, vel2, ..., valn, veln) where val1, ...,
-      *   valn are the values of the n variables of the function, in the order
-      *   they are stored in the function (i.e. the order of the vector
-      *   returned by variables()) and vel1, ... veln are the corresponding
-      *   velocities.
-      * - velocity(xi1, vali1, veli1, xi2, vali2, veli2, ...) where one alternates
-      *   a reference to one variable and its value and velocity. The number of
-      *   variables in this case need not be n (unspecified variables will keep
-      *   their previous value), and if a variable is given multiple times,
-      *   only the last value will be used
-      * - velocity(val, vel) where val and vel are the concatenated values and
-      *   velocities for all variables in the order they are stored in the 
-      *   function.
-      */
-    template<typename... Vals>
-    const Eigen::VectorXd& velocity(Vals&&... vals) const;
+  /** Get the velocity of the function for given values and velocities of its
+   * variables.
+   * The values and velocities can be given as VectorXd, or as
+   * std::initializer_list. There are three possible syntaxes:
+   * - velocity(val1, vel1, val2, vel2, ..., valn, veln) where val1, ...,
+   *   valn are the values of the n variables of the function, in the order
+   *   they are stored in the function (i.e. the order of the vector
+   *   returned by variables()) and vel1, ... veln are the corresponding
+   *   velocities.
+   * - velocity(xi1, vali1, veli1, xi2, vali2, veli2, ...) where one alternates
+   *   a reference to one variable and its value and velocity. The number of
+   *   variables in this case need not be n (unspecified variables will keep
+   *   their previous value), and if a variable is given multiple times,
+   *   only the last value will be used
+   * - velocity(val, vel) where val and vel are the concatenated values and
+   *   velocities for all variables in the order they are stored in the
+   *   function.
+   */
+  template<typename... Vals>
+  const Eigen::VectorXd & velocity(Vals &&... vals) const;
 
-    /** Get the normalAcceleration, for the given variable values and
-      * velocities.
-      * See \a velocity for an explanation of how to specify the values and
-      * velocities.
-      */
-    template<typename... Vals>
-    const Eigen::VectorXd& normalAcceleration(Vals&&... vals) const;
+  /** Get the normalAcceleration, for the given variable values and
+   * velocities.
+   * See \a velocity for an explanation of how to specify the values and
+   * velocities.
+   */
+  template<typename... Vals>
+  const Eigen::VectorXd & normalAcceleration(Vals &&... vals) const;
 
-    /** Get the time derivative of the jacobian matrix with respect to variable
-      * x, for the given variable values and velocities.
-      * See \a velocity for an explanation of how to specify the values and
-      * velocities.
-      */
-    template<typename... Vals>
-    const Eigen::MatrixXd& JDot(const Variable& x, Vals&&... vals) const;
+  /** Get the time derivative of the jacobian matrix with respect to variable
+   * x, for the given variable values and velocities.
+   * See \a velocity for an explanation of how to specify the values and
+   * velocities.
+   */
+  template<typename... Vals>
+  const Eigen::MatrixXd & JDot(const Variable & x, Vals &&... vals) const;
 
-  private:
-    static Eigen::VectorXd toVec(std::initializer_list<double> val);
+private:
+  static Eigen::VectorXd toVec(std::initializer_list<double> val);
 
-    /** Assign val to the i-th variable. */
-    void assign(size_t i, const Eigen::VectorXd& val, bool value) const;
-    void assign(Variable& x, const Eigen::VectorXd& val, bool value) const;
+  /** Assign val to the i-th variable. */
+  void assign(size_t i, const Eigen::VectorXd & val, bool value) const;
+  void assign(Variable & x, const Eigen::VectorXd & val, bool value) const;
 
-    /** Assign all variables with a unique vector. */
-    void assign(const Eigen::VectorXd& val) const;
-    void assign(const Eigen::VectorXd& val, const Eigen::VectorXd& vel) const;
+  /** Assign all variables with a unique vector. */
+  void assign(const Eigen::VectorXd & val) const;
+  void assign(const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const;
 
-    /** \internal dispatch the parsing between values only and pairs of 
-      * variable-value. Initiate the recursion.
-      */
-    template<typename... Vals>
-    void parseValues(const Eigen::VectorXd& v, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValues(std::initializer_list<double> v, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValues(Variable& x, Vals&&... vals) const;
+  /** \internal dispatch the parsing between values only and pairs of
+   * variable-value. Initiate the recursion.
+   */
+  template<typename... Vals>
+  void parseValues(const Eigen::VectorXd & v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValues(std::initializer_list<double> v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValues(Variable & x, Vals &&... vals) const;
 
-    /** \internal Recursion over the values.*/
-    template<typename... Vals>
-    void parseValues_(int i, const Eigen::VectorXd& v, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValues_(int i, std::initializer_list<double> v, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValues_(Variable& x, const Eigen::VectorXd& v, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValues_(Variable& x, std::initializer_list<double> v, Vals&&... vals) const;
+  /** \internal Recursion over the values.*/
+  template<typename... Vals>
+  void parseValues_(int i, const Eigen::VectorXd & v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValues_(int i, std::initializer_list<double> v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValues_(Variable & x, const Eigen::VectorXd & v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValues_(Variable & x, std::initializer_list<double> v, Vals &&... vals) const;
 
-    /** \internal Catch wrong number of arguments*/
-    template<typename T>
-    void parseValues_(T) const;
-
-    /** \internal End of recursion for the parsing of values*/
-    void parseValues_(int i, const Eigen::VectorXd& v) const;
-    void parseValues_(int i, std::initializer_list<double> v) const;
-    void parseValues_(Variable& x, const Eigen::VectorXd& v) const;
-    void parseValues_(Variable& x, std::initializer_list<double> v) const;
-
-    /** \internal dispatch the parsing between pairs value-velocity only and 
-      * triplets variable-value-velocity. Initiate the recursion.
-      */
-    template<typename... Vals>
-    void parseValuesAndVelocities(const Eigen::VectorXd& v,  Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities(std::initializer_list<double> v, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities(Variable& x, Vals&&... vals) const;
-
-    /** \internal Recursion over the values and velocities.*/
-    template<typename... Vals>
-    void parseValuesAndVelocities_(int i, const Eigen::VectorXd& val, const Eigen::VectorXd& vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(int i, const Eigen::VectorXd& val, std::initializer_list<double> vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(int i, std::initializer_list<double> val, const Eigen::VectorXd& vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(int i, std::initializer_list<double> val, std::initializer_list<double> vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(Variable& x, const Eigen::VectorXd& val, const Eigen::VectorXd& vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(Variable& x, const Eigen::VectorXd& val, std::initializer_list<double> vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(Variable& x, std::initializer_list<double> val, const Eigen::VectorXd& vel, Vals&&... vals) const;
-    template<typename... Vals>
-    void parseValuesAndVelocities_(Variable& x, std::initializer_list<double> val, std::initializer_list<double> vel, Vals&&... vals) const;
-
-    /** \internal Catch wrong number of arguments*/
-    template<typename T>
-    void parseValuesAndVelocities_(T) const;
-    template<typename T>
-    void parseValuesAndVelocities_(int, T) const;
-    template<typename T, typename U>
-    void parseValuesAndVelocities_(T, U) const;
-
-    /**  \internal End of recursion.*/
-    void parseValuesAndVelocities_(int i, const Eigen::VectorXd& val, const Eigen::VectorXd& vel) const;
-    void parseValuesAndVelocities_(int i, const Eigen::VectorXd& val, std::initializer_list<double> vel) const;
-    void parseValuesAndVelocities_(int i, std::initializer_list<double> val, const Eigen::VectorXd& vel) const;
-    void parseValuesAndVelocities_(int i, std::initializer_list<double> val, std::initializer_list<double> vel) const;
-    void parseValuesAndVelocities_(Variable& x, const Eigen::VectorXd& val, const Eigen::VectorXd& vel) const;
-    void parseValuesAndVelocities_(Variable& x, const Eigen::VectorXd& val, std::initializer_list<double> vel) const;
-    void parseValuesAndVelocities_(Variable& x, std::initializer_list<double> val, const Eigen::VectorXd& vel) const;
-    void parseValuesAndVelocities_(Variable& x, std::initializer_list<double> val, std::initializer_list<double> vel) const;
-
-
-    FunctionPtr f_;
-    tvm::graph::CallGraph valueGraph_;
-    tvm::graph::CallGraph jacobianGraph_;
-    tvm::graph::CallGraph velocityGraph_;
-    tvm::graph::CallGraph normalAccelerationGraph_;
-    tvm::graph::CallGraph JDotGraph_;
-    //ensure that derivative will exist.
-    std::vector<VariablePtr> dx_;
-  };
-
-
-  template<typename ...Vals>
-  inline const Eigen::VectorXd & UpdatelessFunction::value(Vals && ...vals) const
-  {
-    using Output = tvm::function::abstract::Function::Output;
-    if (f_->isOutputEnabled(Output::Value))
-    {
-      parseValues(std::forward<Vals>(vals)...);
-      valueGraph_.execute();
-      return f_->value();
-    }
-    else
-    {
-      throw std::runtime_error("Underlying function does not provide a value output.");
-    }
-  }
-
-  template<typename ...Vals>
-  inline const Eigen::MatrixXd & UpdatelessFunction::jacobian(const Variable & x, Vals && ...vals) const
-  {
-    using Output = tvm::function::abstract::Function::Output;
-    if (f_->isOutputEnabled(Output::Jacobian))
-    {
-      parseValues(std::forward<Vals>(vals)...);
-      jacobianGraph_.execute();
-      return f_->jacobian(x);
-    }
-    else
-    {
-      throw std::runtime_error("Underlying function does not provide a jacobian output.");
-    }
-  }
-
-  template<typename ...Vals>
-  inline const Eigen::VectorXd & UpdatelessFunction::velocity(Vals && ...vals) const
-  {
-    using Output = tvm::function::abstract::Function::Output;
-    if (f_->isOutputEnabled(Output::Velocity))
-    {
-      parseValuesAndVelocities(std::forward<Vals>(vals)...);
-      velocityGraph_.execute();
-      return f_->velocity();
-    }
-    else
-    {
-      throw std::runtime_error("Underlying function does not provide a velocity output.");
-    }
-  }
-
-  template<typename ...Vals>
-  inline const Eigen::VectorXd & UpdatelessFunction::normalAcceleration(Vals && ...vals) const
-  {
-    using Output = tvm::function::abstract::Function::Output;
-    if (f_->isOutputEnabled(Output::NormalAcceleration))
-    {
-      parseValuesAndVelocities(std::forward<Vals>(vals)...);
-      normalAccelerationGraph_.execute();
-      return f_->normalAcceleration();
-    }
-    else
-    {
-      throw std::runtime_error("Underlying function does not provide a normalAcceleration output.");
-    }
-  }
-
-  template<typename ...Vals>
-  inline const Eigen::MatrixXd & UpdatelessFunction::JDot(const Variable & x, Vals && ...vals) const
-  {
-    using Output = tvm::function::abstract::Function::Output;
-    if (f_->isOutputEnabled(Output::JDot))
-    {
-      parseValuesAndVelocities(std::forward<Vals>(vals)...);
-      JDotGraph_.execute();
-      return f_->JDot(x);
-    }
-    else
-    {
-      throw std::runtime_error("Underlying function does not provide a JDot output.");
-    }
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues(const Eigen::VectorXd & v, Vals && ...vals) const
-  {
-    parseValues_(0, v, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues(std::initializer_list<double> v, Vals && ...vals) const
-  {
-    parseValues_(0, v, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues(Variable & x, Vals && ...vals) const
-  {
-    parseValues_(x, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues_(int i, const Eigen::VectorXd & v, Vals && ...vals) const
-  {
-    assign(i, v, true);
-    parseValues_(i + 1, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues_(int i, std::initializer_list<double> v, Vals && ...vals) const
-  {
-    parseValues_(i, toVec(v), std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues_(Variable & x, const Eigen::VectorXd & v, Vals && ...vals) const
-  {
-    assign(x, v, true);
-    parseValues_(std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValues_(Variable & x, std::initializer_list<double> v, Vals && ...vals) const
-  {
-    parseValues_(x, toVec(v), std::forward<Vals>(vals)...);
-  }
-
+  /** \internal Catch wrong number of arguments*/
   template<typename T>
-  inline void UpdatelessFunction::parseValues_(T) const
-  {
-    static_assert(::tvm::internal::always_false<T>::value, "Incorrect number of argument. You likely did not observe the alternance between variables and values.");
-  }
+  void parseValues_(T) const;
 
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities(const Eigen::VectorXd & v, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(0, v, std::forward<Vals>(vals)...);
-  }
+  /** \internal End of recursion for the parsing of values*/
+  void parseValues_(int i, const Eigen::VectorXd & v) const;
+  void parseValues_(int i, std::initializer_list<double> v) const;
+  void parseValues_(Variable & x, const Eigen::VectorXd & v) const;
+  void parseValues_(Variable & x, std::initializer_list<double> v) const;
 
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities(std::initializer_list<double> v, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(0, v, std::forward<Vals>(vals)...);
-  }
+  /** \internal dispatch the parsing between pairs value-velocity only and
+   * triplets variable-value-velocity. Initiate the recursion.
+   */
+  template<typename... Vals>
+  void parseValuesAndVelocities(const Eigen::VectorXd & v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities(std::initializer_list<double> v, Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities(Variable & x, Vals &&... vals) const;
 
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities(Variable & x, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(x, std::forward<Vals>(vals)...);
-  }
+  /** \internal Recursion over the values and velocities.*/
+  template<typename... Vals>
+  void parseValuesAndVelocities_(int i,
+                                 const Eigen::VectorXd & val,
+                                 const Eigen::VectorXd & vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(int i,
+                                 const Eigen::VectorXd & val,
+                                 std::initializer_list<double> vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(int i,
+                                 std::initializer_list<double> val,
+                                 const Eigen::VectorXd & vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(int i,
+                                 std::initializer_list<double> val,
+                                 std::initializer_list<double> vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(Variable & x,
+                                 const Eigen::VectorXd & val,
+                                 const Eigen::VectorXd & vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(Variable & x,
+                                 const Eigen::VectorXd & val,
+                                 std::initializer_list<double> vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(Variable & x,
+                                 std::initializer_list<double> val,
+                                 const Eigen::VectorXd & vel,
+                                 Vals &&... vals) const;
+  template<typename... Vals>
+  void parseValuesAndVelocities_(Variable & x,
+                                 std::initializer_list<double> val,
+                                 std::initializer_list<double> vel,
+                                 Vals &&... vals) const;
 
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(int i, const Eigen::VectorXd & val, const Eigen::VectorXd & vel, Vals && ...vals) const
-  {
-    assign(i, val, true);
-    assign(i, vel, false);
-    parseValuesAndVelocities_(i+1, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(int i, const Eigen::VectorXd & val, std::initializer_list<double> vel, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(i, val, toVec(vel), std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(int i, std::initializer_list<double> val, const Eigen::VectorXd & vel, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(i, toVec(val), vel, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(int i, std::initializer_list<double> val, std::initializer_list<double> vel, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(i, toVec(val), toVec(vel), std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, const Eigen::VectorXd & val, const Eigen::VectorXd & vel, Vals && ...vals) const
-  {
-    assign(x, val, true);
-    assign(x, vel, false);
-    parseValuesAndVelocities_(std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, const Eigen::VectorXd & val, std::initializer_list<double> vel, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(x, val, toVec(vel), std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, std::initializer_list<double> val, const Eigen::VectorXd & vel, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(x, toVec(val), vel, std::forward<Vals>(vals)...);
-  }
-
-  template<typename ...Vals>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, std::initializer_list<double> val, std::initializer_list<double> vel, Vals && ...vals) const
-  {
-    parseValuesAndVelocities_(x, toVec(val), toVec(vel), std::forward<Vals>(vals)...);
-  }
-
+  /** \internal Catch wrong number of arguments*/
   template<typename T>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(T) const
-  {
-    static_assert(::tvm::internal::always_false<T>::value, "Incorrect number of argument. You likely did not observe the alternance between variables, values and velocities.");
-  }
-
+  void parseValuesAndVelocities_(T) const;
   template<typename T>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(int, T) const
-  {
-    static_assert(::tvm::internal::always_false<T>::value, "Incorrect number of argument. You likely forgot a value or velocity.");
-  }
-
+  void parseValuesAndVelocities_(int, T) const;
   template<typename T, typename U>
-  inline void UpdatelessFunction::parseValuesAndVelocities_(T, U) const
+  void parseValuesAndVelocities_(T, U) const;
+
+  /**  \internal End of recursion.*/
+  void parseValuesAndVelocities_(int i, const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const;
+  void parseValuesAndVelocities_(int i, const Eigen::VectorXd & val, std::initializer_list<double> vel) const;
+  void parseValuesAndVelocities_(int i, std::initializer_list<double> val, const Eigen::VectorXd & vel) const;
+  void parseValuesAndVelocities_(int i, std::initializer_list<double> val, std::initializer_list<double> vel) const;
+  void parseValuesAndVelocities_(Variable & x, const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const;
+  void parseValuesAndVelocities_(Variable & x, const Eigen::VectorXd & val, std::initializer_list<double> vel) const;
+  void parseValuesAndVelocities_(Variable & x, std::initializer_list<double> val, const Eigen::VectorXd & vel) const;
+  void parseValuesAndVelocities_(Variable & x,
+                                 std::initializer_list<double> val,
+                                 std::initializer_list<double> vel) const;
+
+  FunctionPtr f_;
+  tvm::graph::CallGraph valueGraph_;
+  tvm::graph::CallGraph jacobianGraph_;
+  tvm::graph::CallGraph velocityGraph_;
+  tvm::graph::CallGraph normalAccelerationGraph_;
+  tvm::graph::CallGraph JDotGraph_;
+  // ensure that derivative will exist.
+  std::vector<VariablePtr> dx_;
+};
+
+template<typename... Vals>
+inline const Eigen::VectorXd & UpdatelessFunction::value(Vals &&... vals) const
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(f_->isOutputEnabled(Output::Value))
   {
-    static_assert(::tvm::internal::always_false<T>::value, "Incorrect number of argument. You likely did not observe the alternance between variables, values and velocities.");
+    parseValues(std::forward<Vals>(vals)...);
+    valueGraph_.execute();
+    return f_->value();
   }
+  else
+  {
+    throw std::runtime_error("Underlying function does not provide a value output.");
+  }
+}
+
+template<typename... Vals>
+inline const Eigen::MatrixXd & UpdatelessFunction::jacobian(const Variable & x, Vals &&... vals) const
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(f_->isOutputEnabled(Output::Jacobian))
+  {
+    parseValues(std::forward<Vals>(vals)...);
+    jacobianGraph_.execute();
+    return f_->jacobian(x);
+  }
+  else
+  {
+    throw std::runtime_error("Underlying function does not provide a jacobian output.");
+  }
+}
+
+template<typename... Vals>
+inline const Eigen::VectorXd & UpdatelessFunction::velocity(Vals &&... vals) const
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(f_->isOutputEnabled(Output::Velocity))
+  {
+    parseValuesAndVelocities(std::forward<Vals>(vals)...);
+    velocityGraph_.execute();
+    return f_->velocity();
+  }
+  else
+  {
+    throw std::runtime_error("Underlying function does not provide a velocity output.");
+  }
+}
+
+template<typename... Vals>
+inline const Eigen::VectorXd & UpdatelessFunction::normalAcceleration(Vals &&... vals) const
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(f_->isOutputEnabled(Output::NormalAcceleration))
+  {
+    parseValuesAndVelocities(std::forward<Vals>(vals)...);
+    normalAccelerationGraph_.execute();
+    return f_->normalAcceleration();
+  }
+  else
+  {
+    throw std::runtime_error("Underlying function does not provide a normalAcceleration output.");
+  }
+}
+
+template<typename... Vals>
+inline const Eigen::MatrixXd & UpdatelessFunction::JDot(const Variable & x, Vals &&... vals) const
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(f_->isOutputEnabled(Output::JDot))
+  {
+    parseValuesAndVelocities(std::forward<Vals>(vals)...);
+    JDotGraph_.execute();
+    return f_->JDot(x);
+  }
+  else
+  {
+    throw std::runtime_error("Underlying function does not provide a JDot output.");
+  }
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues(const Eigen::VectorXd & v, Vals &&... vals) const
+{
+  parseValues_(0, v, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues(std::initializer_list<double> v, Vals &&... vals) const
+{
+  parseValues_(0, v, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues(Variable & x, Vals &&... vals) const
+{
+  parseValues_(x, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues_(int i, const Eigen::VectorXd & v, Vals &&... vals) const
+{
+  assign(i, v, true);
+  parseValues_(i + 1, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues_(int i, std::initializer_list<double> v, Vals &&... vals) const
+{
+  parseValues_(i, toVec(v), std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues_(Variable & x, const Eigen::VectorXd & v, Vals &&... vals) const
+{
+  assign(x, v, true);
+  parseValues_(std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValues_(Variable & x, std::initializer_list<double> v, Vals &&... vals) const
+{
+  parseValues_(x, toVec(v), std::forward<Vals>(vals)...);
+}
+
+template<typename T>
+inline void UpdatelessFunction::parseValues_(T) const
+{
+  static_assert(
+      ::tvm::internal::always_false<T>::value,
+      "Incorrect number of argument. You likely did not observe the alternance between variables and values.");
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities(const Eigen::VectorXd & v, Vals &&... vals) const
+{
+  parseValuesAndVelocities_(0, v, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities(std::initializer_list<double> v, Vals &&... vals) const
+{
+  parseValuesAndVelocities_(0, v, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities(Variable & x, Vals &&... vals) const
+{
+  parseValuesAndVelocities_(x, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                          const Eigen::VectorXd & val,
+                                                          const Eigen::VectorXd & vel,
+                                                          Vals &&... vals) const
+{
+  assign(i, val, true);
+  assign(i, vel, false);
+  parseValuesAndVelocities_(i + 1, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                          const Eigen::VectorXd & val,
+                                                          std::initializer_list<double> vel,
+                                                          Vals &&... vals) const
+{
+  parseValuesAndVelocities_(i, val, toVec(vel), std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                          std::initializer_list<double> val,
+                                                          const Eigen::VectorXd & vel,
+                                                          Vals &&... vals) const
+{
+  parseValuesAndVelocities_(i, toVec(val), vel, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                          std::initializer_list<double> val,
+                                                          std::initializer_list<double> vel,
+                                                          Vals &&... vals) const
+{
+  parseValuesAndVelocities_(i, toVec(val), toVec(vel), std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                          const Eigen::VectorXd & val,
+                                                          const Eigen::VectorXd & vel,
+                                                          Vals &&... vals) const
+{
+  assign(x, val, true);
+  assign(x, vel, false);
+  parseValuesAndVelocities_(std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                          const Eigen::VectorXd & val,
+                                                          std::initializer_list<double> vel,
+                                                          Vals &&... vals) const
+{
+  parseValuesAndVelocities_(x, val, toVec(vel), std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                          std::initializer_list<double> val,
+                                                          const Eigen::VectorXd & vel,
+                                                          Vals &&... vals) const
+{
+  parseValuesAndVelocities_(x, toVec(val), vel, std::forward<Vals>(vals)...);
+}
+
+template<typename... Vals>
+inline void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                          std::initializer_list<double> val,
+                                                          std::initializer_list<double> vel,
+                                                          Vals &&... vals) const
+{
+  parseValuesAndVelocities_(x, toVec(val), toVec(vel), std::forward<Vals>(vals)...);
+}
+
+template<typename T>
+inline void UpdatelessFunction::parseValuesAndVelocities_(T) const
+{
+  static_assert(::tvm::internal::always_false<T>::value, "Incorrect number of argument. You likely did not observe the "
+                                                         "alternance between variables, values and velocities.");
+}
+
+template<typename T>
+inline void UpdatelessFunction::parseValuesAndVelocities_(int, T) const
+{
+  static_assert(::tvm::internal::always_false<T>::value,
+                "Incorrect number of argument. You likely forgot a value or velocity.");
+}
+
+template<typename T, typename U>
+inline void UpdatelessFunction::parseValuesAndVelocities_(T, U) const
+{
+  static_assert(::tvm::internal::always_false<T>::value, "Incorrect number of argument. You likely did not observe the "
+                                                         "alternance between variables, values and velocities.");
+}
 
 } // namespace utils
 

--- a/include/tvm/utils/checkFunction.h
+++ b/include/tvm/utils/checkFunction.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -37,46 +37,46 @@ namespace tvm
 
 namespace utils
 {
-  /** A small structure to specify options for the checks in \ref checkGroup.
-    *  - \a step is the increment that will be taken for finite difference schemes
-    *  - \a prec is the precision with which the equality of two vectors is tested.
-    *    It corresponds to the \a prec parameter of Eigen's \a isApprox method.
-    *  - if \a verbose is true, the functions will display some indications when a
-    *    mismatch is detected.
-    */
-  class CheckOptions
-  {
-  public:
-    CheckOptions() : step(1e-7), prec(1e-6), verbose(true) {}
-    CheckOptions(double s, double p, bool v) : step(s), prec(p), verbose(v) {}
-    double step;
-    double prec;
-    bool verbose;
-  };
+/** A small structure to specify options for the checks in \ref checkGroup.
+ *  - \a step is the increment that will be taken for finite difference schemes
+ *  - \a prec is the precision with which the equality of two vectors is tested.
+ *    It corresponds to the \a prec parameter of Eigen's \a isApprox method.
+ *  - if \a verbose is true, the functions will display some indications when a
+ *    mismatch is detected.
+ */
+class CheckOptions
+{
+public:
+  CheckOptions() : step(1e-7), prec(1e-6), verbose(true) {}
+  CheckOptions(double s, double p, bool v) : step(s), prec(p), verbose(v) {}
+  double step;
+  double prec;
+  bool verbose;
+};
 
-  /** \defgroup checkGroup */
-  /**@{*/
-  /** Check the jacobian matrices of function \a f by forward finite differences.*/
-  bool TVM_DLLAPI checkJacobian(FunctionPtr f, CheckOptions opt = CheckOptions());
+/** \defgroup checkGroup */
+/**@{*/
+/** Check the jacobian matrices of function \a f by forward finite differences.*/
+bool TVM_DLLAPI checkJacobian(FunctionPtr f, CheckOptions opt = CheckOptions());
 
-  /** Check the velocity of the function \a f by comparing it to J*\dot{x}.
-    * Assume that the jacobian matrices are correct.
-    */
-  bool TVM_DLLAPI checkVelocity(FunctionPtr f, CheckOptions opt = CheckOptions());
+/** Check the velocity of the function \a f by comparing it to J*\dot{x}.
+ * Assume that the jacobian matrices are correct.
+ */
+bool TVM_DLLAPI checkVelocity(FunctionPtr f, CheckOptions opt = CheckOptions());
 
-  /** Check the normal acceleration of the function \a f.
-    * Noting v=f(x), this is done by comparing it to ddot{v}-J\ddot{x}, where
-    * \ddot{x} is taken constant over the interval opt.step, and ddot{v} is obtained
-    * by finite differences.
-    * Assume that the jacobian matrices and the velocity are correct.
-    */
-  bool TVM_DLLAPI checkNormalAcceleration(FunctionPtr f, CheckOptions opt = CheckOptions());
+/** Check the normal acceleration of the function \a f.
+ * Noting v=f(x), this is done by comparing it to ddot{v}-J\ddot{x}, where
+ * \ddot{x} is taken constant over the interval opt.step, and ddot{v} is obtained
+ * by finite differences.
+ * Assume that the jacobian matrices and the velocity are correct.
+ */
+bool TVM_DLLAPI checkNormalAcceleration(FunctionPtr f, CheckOptions opt = CheckOptions());
 
-  /** Check the jacobian matrics, velocity and normal acceleration of the
-    * function \a f
-    */
-  bool TVM_DLLAPI checkFunction(FunctionPtr f, CheckOptions opt = CheckOptions());
-  /**@}*/
-}
+/** Check the jacobian matrics, velocity and normal acceleration of the
+ * function \a f
+ */
+bool TVM_DLLAPI checkFunction(FunctionPtr f, CheckOptions opt = CheckOptions());
+/**@}*/
+} // namespace utils
 
-}
+} // namespace tvm

--- a/include/tvm/utils/checkFunction.h
+++ b/include/tvm/utils/checkFunction.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/graph.h
+++ b/include/tvm/utils/graph.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/graph.h
+++ b/include/tvm/utils/graph.h
@@ -1,37 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/graph/CallGraph.h>
-#include <tvm/utils/internal/graphDetails.h>
 #include <tvm/graph/internal/Inputs.h>
+#include <tvm/utils/internal/graphDetails.h>
 
 #include <memory>
 
@@ -41,26 +41,26 @@ namespace tvm
 namespace utils
 {
 
-  /** Generate the graph of updates for a list of objects and their specified outputs
-    *
-    * g = generateUpdateGraph(obj1, o1_1, ..., o1_n1, obj2, o2_1, ..., o2_n2, ..., objk, ok_1, ..., ok_nk)
-    * generates a graph g such that g.execute() ensures that outputs o1_1, ... o1_n1
-    * for obj1, o2_1, ... o2_1 for obj2, etc. are up to date.
-    */
-  template<typename Object, typename... Args>
-  inline std::unique_ptr<graph::CallGraph> generateUpdateGraph(std::shared_ptr<Object> obj, Args&&... args);
+/** Generate the graph of updates for a list of objects and their specified outputs
+ *
+ * g = generateUpdateGraph(obj1, o1_1, ..., o1_n1, obj2, o2_1, ..., o2_n2, ..., objk, ok_1, ..., ok_nk)
+ * generates a graph g such that g.execute() ensures that outputs o1_1, ... o1_n1
+ * for obj1, o2_1, ... o2_1 for obj2, etc. are up to date.
+ */
+template<typename Object, typename... Args>
+inline std::unique_ptr<graph::CallGraph> generateUpdateGraph(std::shared_ptr<Object> obj, Args &&... args);
 
-  template<typename Object, typename... Args>
-  inline std::unique_ptr<graph::CallGraph> generateUpdateGraph(std::shared_ptr<Object> obj, Args&&... args)
-  {
-    auto ptr = std::unique_ptr<graph::CallGraph>(new graph::CallGraph());
-    auto user = std::make_shared<graph::internal::Inputs>();
-    internal::parseSourcesAndOutputs(ptr.get(), user, obj, std::forward<Args>(args)...);
-    ptr->update();
+template<typename Object, typename... Args>
+inline std::unique_ptr<graph::CallGraph> generateUpdateGraph(std::shared_ptr<Object> obj, Args &&... args)
+{
+  auto ptr = std::unique_ptr<graph::CallGraph>(new graph::CallGraph());
+  auto user = std::make_shared<graph::internal::Inputs>();
+  internal::parseSourcesAndOutputs(ptr.get(), user, obj, std::forward<Args>(args)...);
+  ptr->update();
 
-    return ptr;
-  }
-
+  return ptr;
 }
 
-}
+} // namespace utils
+
+} // namespace tvm

--- a/include/tvm/utils/internal/AffineExprDetail.h
+++ b/include/tvm/utils/internal/AffineExprDetail.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/internal/AffineExprDetail.h
+++ b/include/tvm/utils/internal/AffineExprDetail.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -41,82 +41,92 @@ namespace utils
 namespace internal
 {
 
-  /** Type of Eigen::MatrixXd::Identity() */
-  using IdentityType = decltype(Eigen::MatrixXd::Identity());
-  /** Type of double*Eigen::MatrixXd::Identity() */
-  using MultIdentityType = decltype(2. * Eigen::MatrixXd::Identity());
-  /** Type of -Eigen::MatrixXd::Identity() */
-  using MinusIdentityType = decltype(-Eigen::MatrixXd::Identity());
+/** Type of Eigen::MatrixXd::Identity() */
+using IdentityType = decltype(Eigen::MatrixXd::Identity());
+/** Type of double*Eigen::MatrixXd::Identity() */
+using MultIdentityType = decltype(2. * Eigen::MatrixXd::Identity());
+/** Type of -Eigen::MatrixXd::Identity() */
+using MinusIdentityType = decltype(-Eigen::MatrixXd::Identity());
 
-  /** A dummy class to represent the absence of constant part in an affine expression. */
-  class NoConstant 
-  {
-  public:
-    NoConstant operator-() const { return {}; }
-  };
+/** A dummy class to represent the absence of constant part in an affine expression. */
+class NoConstant
+{
+public:
+  NoConstant operator-() const { return {}; }
+};
 
-  /** Adding an absent constant part with an existing constant part. */
-  template<typename RhsType>
-  inline const RhsType& operator+ (const NoConstant&, const Eigen::MatrixBase<RhsType>& rhs) { return rhs.derived(); }
-
-  /** Adding an existing constant part with an absent constant part. */
-  template<typename LhsType>
-  inline const LhsType& operator+ (const Eigen::MatrixBase<LhsType>& lhs, const NoConstant&) { return lhs.derived(); }
-
-  /** Adding two absent constant parts. */
-  inline auto operator+ (const NoConstant&, const NoConstant&) { return NoConstant(); }
-
-  /** Overload for post-multiplying by NoConstant. In this case, we need to return NoConstant.*/
-  template<typename MultType>
-  inline NoConstant operator* (const MultType& /*m*/, const NoConstant&) { return {}; }
-
-  /** Shortcut to an internal Eigen type to store expressions or matrices.
-    * 
-    * When keeping internally a reference to an Eigen object, we need to have different behaviors
-    * depending on wether the object has a large memory and should not be copied or is a 
-    * lightweight proxy.
-    * For matrix, we need to keep a const ref, while for matrix expression  we need to take a copy
-    * of the expression.This is exactly the purpose of ref_selector, that is used to this effect
-    * in e.g.CWiseBinaryOp.
-    */
-  template<typename Derived>
-  struct RefSelector
-  {
-    using type = typename Eigen::internal::ref_selector<Derived>::type;
-  };
-  template<>
-  struct RefSelector<NoConstant>
-  {
-    using type = NoConstant;
-  };
-
-  template<typename Derived>
-  using RefSelector_t = typename RefSelector<Derived>::type;
-
-  /** Result type for the addition of two constant parts, existing or not.*/
-  template<typename LhsType, typename RhsType>
-  using AddConstantsRetType = std::remove_const_t<std::remove_reference_t<decltype(std::declval<LhsType>() + std::declval<RhsType>())> >;
-
-  /** Taking the opposite of each element i of the input tuple where the i's
-    * are the elements given by the sequence of index.
-    */
-  template<typename Tuple, size_t ... Indices>
-  auto tupleUnaryMinus(const Tuple& tuple, std::index_sequence<Indices...>)
-  {
-    return std::make_tuple((-std::get<Indices>(tuple))...);
-  }
-
-  /** Premultiplication by m of each element i of the input tuple where the i's
-    * are the elements given by the sequence of index.
-    */
-  template<typename MultType, typename Tuple, size_t ... Indices>
-  auto tuplePremult(const MultType& m, const Tuple& tuple, std::index_sequence<Indices...>)
-  {
-    return std::make_tuple((m * std::get<Indices>(tuple))...);
-  }
+/** Adding an absent constant part with an existing constant part. */
+template<typename RhsType>
+inline const RhsType & operator+(const NoConstant &, const Eigen::MatrixBase<RhsType> & rhs)
+{
+  return rhs.derived();
 }
+
+/** Adding an existing constant part with an absent constant part. */
+template<typename LhsType>
+inline const LhsType & operator+(const Eigen::MatrixBase<LhsType> & lhs, const NoConstant &)
+{
+  return lhs.derived();
 }
+
+/** Adding two absent constant parts. */
+inline auto operator+(const NoConstant &, const NoConstant &) { return NoConstant(); }
+
+/** Overload for post-multiplying by NoConstant. In this case, we need to return NoConstant.*/
+template<typename MultType>
+inline NoConstant operator*(const MultType & /*m*/, const NoConstant &)
+{
+  return {};
 }
+
+/** Shortcut to an internal Eigen type to store expressions or matrices.
+ *
+ * When keeping internally a reference to an Eigen object, we need to have different behaviors
+ * depending on wether the object has a large memory and should not be copied or is a
+ * lightweight proxy.
+ * For matrix, we need to keep a const ref, while for matrix expression  we need to take a copy
+ * of the expression.This is exactly the purpose of ref_selector, that is used to this effect
+ * in e.g.CWiseBinaryOp.
+ */
+template<typename Derived>
+struct RefSelector
+{
+  using type = typename Eigen::internal::ref_selector<Derived>::type;
+};
+template<>
+struct RefSelector<NoConstant>
+{
+  using type = NoConstant;
+};
+
+template<typename Derived>
+using RefSelector_t = typename RefSelector<Derived>::type;
+
+/** Result type for the addition of two constant parts, existing or not.*/
+template<typename LhsType, typename RhsType>
+using AddConstantsRetType =
+    std::remove_const_t<std::remove_reference_t<decltype(std::declval<LhsType>() + std::declval<RhsType>())>>;
+
+/** Taking the opposite of each element i of the input tuple where the i's
+ * are the elements given by the sequence of index.
+ */
+template<typename Tuple, size_t... Indices>
+auto tupleUnaryMinus(const Tuple & tuple, std::index_sequence<Indices...>)
+{
+  return std::make_tuple((-std::get<Indices>(tuple))...);
+}
+
+/** Premultiplication by m of each element i of the input tuple where the i's
+ * are the elements given by the sequence of index.
+ */
+template<typename MultType, typename Tuple, size_t... Indices>
+auto tuplePremult(const MultType & m, const Tuple & tuple, std::index_sequence<Indices...>)
+{
+  return std::make_tuple((m * std::get<Indices>(tuple))...);
+}
+} // namespace internal
+} // namespace utils
+} // namespace tvm
 
 namespace Eigen
 {
@@ -127,5 +137,5 @@ template<>
 struct traits<tvm::utils::internal::NoConstant> : public traits<tvm::utils::internal::IdentityType>
 {
 };
-}
-}
+} // namespace internal
+} // namespace Eigen

--- a/include/tvm/utils/internal/AffineExprDetail.h
+++ b/include/tvm/utils/internal/AffineExprDetail.h
@@ -108,7 +108,6 @@ namespace internal
 /** This is required to get GCC to compile the SFINAE constructors. */
 template<>
 struct traits<tvm::utils::internal::NoConstant> : public traits<tvm::utils::internal::IdentityType>
-{
-};
+{};
 } // namespace internal
 } // namespace Eigen

--- a/include/tvm/utils/internal/AffineExprOperators.h
+++ b/include/tvm/utils/internal/AffineExprOperators.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/internal/AffineExprOperators.h
+++ b/include/tvm/utils/internal/AffineExprOperators.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,108 +39,123 @@ namespace utils
 
 /** Lin = -Lin */
 template<typename Derived>
-inline auto operator-(const tvm::utils::LinearExpr<Derived>& lin)
+inline auto operator-(const tvm::utils::LinearExpr<Derived> & lin)
 {
   return tvm::utils::LinearExpr<std::remove_const_t<decltype(-std::declval<Derived>())>>(-lin.matrix(), lin.variable());
 }
 
 /** Aff = -Aff */
 template<typename CstDerived, typename... Derived>
-inline auto operator-(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff)
+inline auto operator-(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
 {
-  return make_AffineExpr(-aff.constant(), tvm::utils::internal::tupleUnaryMinus(aff.linear(), std::make_index_sequence<sizeof...(Derived)>{}));
+  return make_AffineExpr(-aff.constant(), tvm::utils::internal::tupleUnaryMinus(
+                                              aff.linear(), std::make_index_sequence<sizeof...(Derived)>{}));
 }
 
-/** Aff = m*Aff, where \p m is any type accepted by Eigen for pre-multiplication 
-  * (in particular scalar or matrix expression).
-  */
+/** Aff = m*Aff, where \p m is any type accepted by Eigen for pre-multiplication
+ * (in particular scalar or matrix expression).
+ */
 template<typename MultDerived, typename CstDerived, typename... Derived>
-inline auto operator*(const MultDerived& m, const tvm::utils::AffineExpr<CstDerived, Derived...>& aff)
+inline auto operator*(const MultDerived & m, const tvm::utils::AffineExpr<CstDerived, Derived...> & aff)
 {
-  return make_AffineExpr(m * aff.constant(), tvm::utils::internal::tuplePremult(m, aff.linear(), std::make_index_sequence<sizeof...(Derived)>{}));
+  return make_AffineExpr(m * aff.constant(), tvm::utils::internal::tuplePremult(
+                                                 m, aff.linear(), std::make_index_sequence<sizeof...(Derived)>{}));
 }
 
 /** Aff = Lin + b */
 template<typename Derived, typename CstDerived>
-inline tvm::utils::AffineExpr<CstDerived, Derived>
-operator+(const tvm::utils::LinearExpr<Derived>& lin, const Eigen::MatrixBase<CstDerived>& cst)
+inline tvm::utils::AffineExpr<CstDerived, Derived> operator+(const tvm::utils::LinearExpr<Derived> & lin,
+                                                             const Eigen::MatrixBase<CstDerived> & cst)
 {
-  return { cst, lin };
+  return {cst, lin};
 }
 
 /** Aff = b + Lin */
 template<typename Derived, typename CstDerived>
-inline tvm::utils::AffineExpr<CstDerived, Derived>
-operator+(const Eigen::MatrixBase<CstDerived>& cst, const tvm::utils::LinearExpr<Derived>& lin)
+inline tvm::utils::AffineExpr<CstDerived, Derived> operator+(const Eigen::MatrixBase<CstDerived> & cst,
+                                                             const tvm::utils::LinearExpr<Derived> & lin)
 {
-  return { cst, lin };
+  return {cst, lin};
 }
 
 /** Aff = Lin + Lin */
 template<typename LhsDerived, typename RhsDerived>
-inline tvm::utils::AffineExpr<tvm::utils::internal::NoConstant, LhsDerived, RhsDerived>
-operator+(const tvm::utils::LinearExpr<LhsDerived>& lhs, const tvm::utils::LinearExpr<RhsDerived>& rhs)
+inline tvm::utils::AffineExpr<tvm::utils::internal::NoConstant, LhsDerived, RhsDerived> operator+(
+    const tvm::utils::LinearExpr<LhsDerived> & lhs,
+    const tvm::utils::LinearExpr<RhsDerived> & rhs)
 {
-  return { lhs, rhs };
+  return {lhs, rhs};
 }
 
 /** Aff = Aff + Lin */
-template<typename RhsDerived, typename CstDerived, typename ... LhsDerived>
-inline tvm::utils::AffineExpr<CstDerived, LhsDerived..., RhsDerived>
-operator+(const tvm::utils::AffineExpr<CstDerived, LhsDerived...>& lhs, const tvm::utils::LinearExpr<RhsDerived>& rhs)
+template<typename RhsDerived, typename CstDerived, typename... LhsDerived>
+inline tvm::utils::AffineExpr<CstDerived, LhsDerived..., RhsDerived> operator+(
+    const tvm::utils::AffineExpr<CstDerived, LhsDerived...> & lhs,
+    const tvm::utils::LinearExpr<RhsDerived> & rhs)
 {
-  return { lhs.constant(), std::tuple_cat(lhs.linear(), std::forward_as_tuple(rhs)) };
+  return {lhs.constant(), std::tuple_cat(lhs.linear(), std::forward_as_tuple(rhs))};
 }
 
 /** Aff = Lin + Aff */
-template<typename LhsDerived, typename CstDerived, typename ... RhsDerived>
-inline tvm::utils::AffineExpr<CstDerived, LhsDerived, RhsDerived...>
-operator+(const tvm::utils::LinearExpr<LhsDerived>& lhs, const tvm::utils::AffineExpr<CstDerived, RhsDerived...>& rhs)
+template<typename LhsDerived, typename CstDerived, typename... RhsDerived>
+inline tvm::utils::AffineExpr<CstDerived, LhsDerived, RhsDerived...> operator+(
+    const tvm::utils::LinearExpr<LhsDerived> & lhs,
+    const tvm::utils::AffineExpr<CstDerived, RhsDerived...> & rhs)
 {
-  return { rhs.constant(), std::tuple_cat(std::forward_as_tuple(lhs), rhs.linear()) };
+  return {rhs.constant(), std::tuple_cat(std::forward_as_tuple(lhs), rhs.linear())};
 }
 
 /** Aff = Aff + b */
-template<typename RhsDerived, typename CstDerived, typename ... LhsDerived>
+template<typename RhsDerived, typename CstDerived, typename... LhsDerived>
 inline tvm::utils::AffineExpr<tvm::utils::internal::AddConstantsRetType<CstDerived, RhsDerived>, LhsDerived...>
-operator+(const tvm::utils::AffineExpr<CstDerived, LhsDerived...>& lhs, const Eigen::MatrixBase<RhsDerived>& rhs)
+    operator+(const tvm::utils::AffineExpr<CstDerived, LhsDerived...> & lhs, const Eigen::MatrixBase<RhsDerived> & rhs)
 {
-  return { lhs.constant() + rhs, lhs.linear() };
+  return {lhs.constant() + rhs, lhs.linear()};
 }
 
 /** Aff = b + Aff */
-template<typename LhsDerived, typename CstDerived, typename ... RhsDerived>
+template<typename LhsDerived, typename CstDerived, typename... RhsDerived>
 inline tvm::utils::AffineExpr<tvm::utils::internal::AddConstantsRetType<LhsDerived, CstDerived>, RhsDerived...>
-operator+(const Eigen::MatrixBase<LhsDerived>& lhs, const tvm::utils::AffineExpr<CstDerived, RhsDerived...>& rhs)
+    operator+(const Eigen::MatrixBase<LhsDerived> & lhs, const tvm::utils::AffineExpr<CstDerived, RhsDerived...> & rhs)
 {
-  return { lhs + rhs.constant(), rhs.linear() };
+  return {lhs + rhs.constant(), rhs.linear()};
 }
 
 /** Aff = Aff + Aff */
-template<typename LCstDerived, typename RCstDerived, typename ... LhsDerived, typename ... RhsDerived>
-inline tvm::utils::AffineExpr<tvm::utils::internal::AddConstantsRetType<LCstDerived, RCstDerived>, LhsDerived..., RhsDerived...>
-operator+(const tvm::utils::AffineExpr<LCstDerived, LhsDerived...>& lhs, const tvm::utils::AffineExpr<RCstDerived, RhsDerived...>& rhs)
+template<typename LCstDerived, typename RCstDerived, typename... LhsDerived, typename... RhsDerived>
+inline tvm::utils::
+    AffineExpr<tvm::utils::internal::AddConstantsRetType<LCstDerived, RCstDerived>, LhsDerived..., RhsDerived...>
+    operator+(const tvm::utils::AffineExpr<LCstDerived, LhsDerived...> & lhs,
+              const tvm::utils::AffineExpr<RCstDerived, RhsDerived...> & rhs)
 {
-  return { lhs.constant() + rhs.constant(), std::tuple_cat(lhs.linear(), rhs.linear()) };
+  return {lhs.constant() + rhs.constant(), std::tuple_cat(lhs.linear(), rhs.linear())};
 }
 
 /** Lin = m * Lin */
 template<typename MultType, typename Derived>
-inline auto operator*(const MultType& m, const tvm::utils::LinearExpr<Derived>& lin)
+inline auto operator*(const MultType & m, const tvm::utils::LinearExpr<Derived> & lin)
 {
-  return tvm::utils::LinearExpr<std::remove_const_t<decltype(m * std::declval<Derived>())>>(m * lin.matrix(), lin.variable());
+  return tvm::utils::LinearExpr<std::remove_const_t<decltype(m * std::declval<Derived>())>>(m * lin.matrix(),
+                                                                                            lin.variable());
 }
 
 /** Aff = Lin - a */
-template<typename Derived, typename SubType, typename tvm::internal::enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
-inline auto operator-(const tvm::utils::LinearExpr<Derived>& lin, const SubType& rhs)
+template<typename Derived,
+         typename SubType,
+         typename tvm::internal::
+             enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
+inline auto operator-(const tvm::utils::LinearExpr<Derived> & lin, const SubType & rhs)
 {
   return lin + -rhs;
 }
 
 /** Aff = Aff - a */
-template<typename CstDerived, typename SubType, typename... Derived, typename tvm::internal::enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
-inline auto operator-(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff, const SubType& rhs)
+template<typename CstDerived,
+         typename SubType,
+         typename... Derived,
+         typename tvm::internal::
+             enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
+inline auto operator-(const tvm::utils::AffineExpr<CstDerived, Derived...> & aff, const SubType & rhs)
 {
   return aff + -rhs;
 }
@@ -149,62 +164,70 @@ inline auto operator-(const tvm::utils::AffineExpr<CstDerived, Derived...>& aff,
 
 /** Lin = M * x */
 template<typename Derived>
-inline tvm::utils::LinearExpr<Derived>
-operator*(const Eigen::MatrixBase<Derived>& matrix, const tvm::VariablePtr& v)
+inline tvm::utils::LinearExpr<Derived> operator*(const Eigen::MatrixBase<Derived> & matrix, const tvm::VariablePtr & v)
 {
-  return { matrix, v };
+  return {matrix, v};
 }
 
 /** Lin = -var */
-inline tvm::utils::LinearExpr<tvm::utils::internal::MinusIdentityType> operator-(const tvm::VariablePtr& v)
+inline tvm::utils::LinearExpr<tvm::utils::internal::MinusIdentityType> operator-(const tvm::VariablePtr & v)
 {
   return v;
 }
 
 /** Lin = scalar * var */
-inline tvm::utils::LinearExpr<tvm::utils::internal::MultIdentityType> operator*(double s, const tvm::VariablePtr& v)
+inline tvm::utils::LinearExpr<tvm::utils::internal::MultIdentityType> operator*(double s, const tvm::VariablePtr & v)
 {
   assert(s != 0);
-  return { s, v };
+  return {s, v};
 }
 
 /** Aff = var + var */
-inline auto operator+(const tvm::VariablePtr& u, const tvm::VariablePtr& v)
+inline auto operator+(const tvm::VariablePtr & u, const tvm::VariablePtr & v)
 {
-  return tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(u) 
-    + tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(v);
+  return tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(u)
+         + tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(v);
 }
 
 /** Aff = a + var */
-template<typename AddType, typename tvm::internal::enable_for_templated_t<AddType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
-inline auto operator+(const AddType& a, const tvm::VariablePtr& v)
+template<typename AddType,
+         typename tvm::internal::
+             enable_for_templated_t<AddType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
+inline auto operator+(const AddType & a, const tvm::VariablePtr & v)
 {
   return a + tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(v);
 }
 
 /** Aff = var + a */
-template<typename AddType, typename tvm::internal::enable_for_templated_t<AddType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
-inline auto operator+(const tvm::VariablePtr& v, const AddType& a)
+template<typename AddType,
+         typename tvm::internal::
+             enable_for_templated_t<AddType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
+inline auto operator+(const tvm::VariablePtr & v, const AddType & a)
 {
   return tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(v) + a;
 }
 
 /** Aff = var - var */
-inline auto operator-(const tvm::VariablePtr& u, const tvm::VariablePtr& v)
+inline auto operator-(const tvm::VariablePtr & u, const tvm::VariablePtr & v)
 {
-  return tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(u) + tvm::utils::LinearExpr<tvm::utils::internal::MinusIdentityType>(v);
+  return tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(u)
+         + tvm::utils::LinearExpr<tvm::utils::internal::MinusIdentityType>(v);
 }
 
 /** Aff = vec - var */
-template<typename SubType, typename tvm::internal::enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
-inline auto operator-(const SubType& a, const tvm::VariablePtr& v)
+template<typename SubType,
+         typename tvm::internal::
+             enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
+inline auto operator-(const SubType & a, const tvm::VariablePtr & v)
 {
   return a + tvm::utils::LinearExpr<tvm::utils::internal::MinusIdentityType>(v);
 }
 
 /** Aff = var - vec */
-template<typename SubType, typename tvm::internal::enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
-inline auto operator-(const tvm::VariablePtr& v, const SubType& a)
+template<typename SubType,
+         typename tvm::internal::
+             enable_for_templated_t<SubType, Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr> = 0>
+inline auto operator-(const tvm::VariablePtr & v, const SubType & a)
 {
   return tvm::utils::LinearExpr<tvm::utils::internal::IdentityType>(v) + -a;
 }

--- a/include/tvm/utils/internal/BufferedMatrix.h
+++ b/include/tvm/utils/internal/BufferedMatrix.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/internal/BufferedMatrix.h
+++ b/include/tvm/utils/internal/BufferedMatrix.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,66 +39,62 @@ namespace utils
 
 namespace internal
 {
-  /** This class provides a matrix with resizable buffer, so that allocations
-    * are made only if there is not enough space.
-    * 
-    */
-  class BufferedMatrix
+/** This class provides a matrix with resizable buffer, so that allocations
+ * are made only if there is not enough space.
+ *
+ */
+class BufferedMatrix
+{
+public:
+  /** Build a m-by-n BufferedMatrix. A buffer twice as big as needed is
+   * created.
+   */
+  BufferedMatrix(Eigen::DenseIndex m, Eigen::DenseIndex n);
+
+  /** Get a map to the matrix. The matrix has the size specified at
+   * construction or during the last resize.\
+   */
+  Eigen::Map<const Eigen::MatrixXd, Eigen::Aligned> get() const;
+  /** Get a map to the matrix. The matrix has the size specified at
+   * construction or during the last resize.
+   */
+  Eigen::Map<Eigen::MatrixXd, Eigen::Aligned> get();
+
+  /** Resize the matrix. If the buffer is not big enough, reallocate memory
+   * to twice the neede size.
+   */
+  void resize(Eigen::DenseIndex m, Eigen::DenseIndex n);
+
+private:
+  Eigen::DenseIndex m_; /** Row size of the matrix*/
+  Eigen::DenseIndex n_; /** Column size of the matrix*/
+  Eigen::VectorXd buffer_; /** vector, used as buffer*/
+};
+
+inline BufferedMatrix::BufferedMatrix(Eigen::DenseIndex m, Eigen::DenseIndex n) { resize(m, n); }
+
+inline Eigen::Map<const Eigen::MatrixXd, Eigen::Aligned> BufferedMatrix::get() const
+{
+  return Eigen::Map<const Eigen::MatrixXd, Eigen::Aligned>(buffer_.data(), m_, n_);
+}
+
+inline Eigen::Map<Eigen::MatrixXd, Eigen::Aligned> BufferedMatrix::get()
+{
+  return Eigen::Map<Eigen::MatrixXd, Eigen::Aligned>(buffer_.data(), m_, n_);
+}
+
+inline void BufferedMatrix::resize(Eigen::DenseIndex m, Eigen::DenseIndex n)
+{
+  if(m * n > buffer_.size())
   {
-  public:
-    /** Build a m-by-n BufferedMatrix. A buffer twice as big as needed is
-      * created.
-      */
-    BufferedMatrix(Eigen::DenseIndex m, Eigen::DenseIndex n);
-
-    /** Get a map to the matrix. The matrix has the size specified at
-      * construction or during the last resize.\
-      */
-    Eigen::Map<const Eigen::MatrixXd, Eigen::Aligned> get() const;
-    /** Get a map to the matrix. The matrix has the size specified at
-      * construction or during the last resize.
-      */
-    Eigen::Map<Eigen::MatrixXd, Eigen::Aligned> get();
-
-    /** Resize the matrix. If the buffer is not big enough, reallocate memory
-      * to twice the neede size.
-      */
-    void resize(Eigen::DenseIndex m, Eigen::DenseIndex n);
-
-  private:
-    Eigen::DenseIndex m_;     /** Row size of the matrix*/
-    Eigen::DenseIndex n_;     /** Column size of the matrix*/
-    Eigen::VectorXd buffer_;  /** vector, used as buffer*/
-  };
-
-  inline BufferedMatrix::BufferedMatrix(Eigen::DenseIndex m, Eigen::DenseIndex n)
-  {
-    resize(m, n);
+    buffer_.resize(2 * m * n);
   }
+  m_ = m;
+  n_ = n;
+}
 
-  inline Eigen::Map<const Eigen::MatrixXd, Eigen::Aligned> BufferedMatrix::get() const
-  {
-    return Eigen::Map<const Eigen::MatrixXd, Eigen::Aligned>(buffer_.data(), m_, n_);
-  }
+} // namespace internal
 
-  inline Eigen::Map<Eigen::MatrixXd, Eigen::Aligned> BufferedMatrix::get()
-  {
-    return Eigen::Map<Eigen::MatrixXd, Eigen::Aligned>(buffer_.data(), m_, n_);
-  }
+} // namespace utils
 
-  inline void BufferedMatrix::resize(Eigen::DenseIndex m, Eigen::DenseIndex n)
-  {
-    if (m*n > buffer_.size())
-    {
-      buffer_.resize(2 * m*n);
-    }
-    m_ = m;
-    n_ = n;
-  }
-
-
-} //internal
-
-} // utils
-
-} //utils
+} // namespace tvm

--- a/include/tvm/utils/internal/BufferedMatrix.h
+++ b/include/tvm/utils/internal/BufferedMatrix.h
@@ -39,8 +39,8 @@ public:
   void resize(Eigen::DenseIndex m, Eigen::DenseIndex n);
 
 private:
-  Eigen::DenseIndex m_; /** Row size of the matrix*/
-  Eigen::DenseIndex n_; /** Column size of the matrix*/
+  Eigen::DenseIndex m_;    /** Row size of the matrix*/
+  Eigen::DenseIndex n_;    /** Column size of the matrix*/
   Eigen::VectorXd buffer_; /** vector, used as buffer*/
 };
 

--- a/include/tvm/utils/internal/ProtoTaskDetails.h
+++ b/include/tvm/utils/internal/ProtoTaskDetails.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/internal/ProtoTaskDetails.h
+++ b/include/tvm/utils/internal/ProtoTaskDetails.h
@@ -1,37 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/defs.h>
 #include <tvm/constraint/enums.h>
+#include <tvm/defs.h>
 #include <tvm/function/IdentityFunction.h>
 #include <tvm/function/abstract/Function.h>
 
@@ -45,60 +45,59 @@ namespace utils
 
 namespace internal
 {
-  /** Describe the type of a right-hand-side argument.
-    * - Zero: the rhs is the zero vector
-    * - Double: the rhs is a vector with all elements equal to a given double
-    * - Vector: the rhs is a general vector
-    */
-  enum class RHSType
-  {
-    Zero,
-    Double,
-    Vector
-  };
+/** Describe the type of a right-hand-side argument.
+ * - Zero: the rhs is the zero vector
+ * - Double: the rhs is a vector with all elements equal to a given double
+ * - Vector: the rhs is a general vector
+ */
+enum class RHSType
+{
+  Zero,
+  Double,
+  Vector
+};
 
-  /** A union-like class, that can represent nothing, a double or a vector.
-    * Which of these 3 options is described by its RHSType
-    */
-  class RHS
-  {
-  public:
-    RHS(double d);
-    template<typename Derived>
-    RHS(const Eigen::MatrixBase<Derived>& v);
-
-    Eigen::VectorXd toVector(Eigen::DenseIndex n) const;
-
-    RHSType type_;
-    double d_;
-    Eigen::VectorXd v_;
-  };
-
-
-  inline RHS::RHS(double d)
-    : type_(d == 0 ? RHSType::Zero : RHSType::Double)
-    , d_(d)
-  {
-  }
-
+/** A union-like class, that can represent nothing, a double or a vector.
+ * Which of these 3 options is described by its RHSType
+ */
+class RHS
+{
+public:
+  RHS(double d);
   template<typename Derived>
-  inline RHS::RHS(const Eigen::MatrixBase<Derived>& v)
-    : type_(RHSType::Vector)
-    , v_(v)
-  {
-  }
+  RHS(const Eigen::MatrixBase<Derived> & v);
 
+  Eigen::VectorXd toVector(Eigen::DenseIndex n) const;
 
-  inline Eigen::VectorXd RHS::toVector(Eigen::DenseIndex n) const
+  RHSType type_;
+  double d_;
+  Eigen::VectorXd v_;
+};
+
+inline RHS::RHS(double d) : type_(d == 0 ? RHSType::Zero : RHSType::Double), d_(d) {}
+
+template<typename Derived>
+inline RHS::RHS(const Eigen::MatrixBase<Derived> & v) : type_(RHSType::Vector), v_(v)
+{
+}
+
+inline Eigen::VectorXd RHS::toVector(Eigen::DenseIndex n) const
+{
+  switch(type_)
   {
-    switch (type_)
-    {
-    case tvm::utils::internal::RHSType::Zero: return Eigen::VectorXd::Zero(n);
-    case tvm::utils::internal::RHSType::Double: return Eigen::VectorXd::Constant(n, d_);
-    case tvm::utils::internal::RHSType::Vector: assert(v_.size() == n); return v_;
-    default: assert(false); return Eigen::VectorXd(); break;
-    }
+    case tvm::utils::internal::RHSType::Zero:
+      return Eigen::VectorXd::Zero(n);
+    case tvm::utils::internal::RHSType::Double:
+      return Eigen::VectorXd::Constant(n, d_);
+    case tvm::utils::internal::RHSType::Vector:
+      assert(v_.size() == n);
+      return v_;
+    default:
+      assert(false);
+      return Eigen::VectorXd();
+      break;
   }
+}
 
 } // namespace internal
 

--- a/include/tvm/utils/internal/ProtoTaskDetails.h
+++ b/include/tvm/utils/internal/ProtoTaskDetails.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include <tvm/api.h>
-#include <tvm/constraint/enums.h>
 #include <tvm/defs.h>
+
+#include <tvm/constraint/enums.h>
 #include <tvm/function/IdentityFunction.h>
 #include <tvm/function/abstract/Function.h>
 

--- a/include/tvm/utils/internal/ProtoTaskDetails.h
+++ b/include/tvm/utils/internal/ProtoTaskDetails.h
@@ -51,8 +51,7 @@ inline RHS::RHS(double d) : type_(d == 0 ? RHSType::Zero : RHSType::Double), d_(
 
 template<typename Derived>
 inline RHS::RHS(const Eigen::MatrixBase<Derived> & v) : type_(RHSType::Vector), v_(v)
-{
-}
+{}
 
 inline Eigen::VectorXd RHS::toVector(Eigen::DenseIndex n) const
 {

--- a/include/tvm/utils/internal/graphDetails.h
+++ b/include/tvm/utils/internal/graphDetails.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/internal/graphDetails.h
+++ b/include/tvm/utils/internal/graphDetails.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -42,57 +42,73 @@ namespace utils
 
 namespace internal
 {
-  /** Recursion over the sources and outputs. 
-    * Case where the next element to parse is an output.
-    */
-  template<typename Object, typename Output, typename... Args>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user, 
-                                     std::shared_ptr<Object> obj, Output output, Args&&... args);
+/** Recursion over the sources and outputs.
+ * Case where the next element to parse is an output.
+ */
+template<typename Object, typename Output, typename... Args>
+inline void parseSourcesAndOutputs(graph::CallGraph * g,
+                                   std::shared_ptr<graph::internal::Inputs> user,
+                                   std::shared_ptr<Object> obj,
+                                   Output output,
+                                   Args &&... args);
 
-  /** Recursion over the sources and outputs. 
-    * Case where the next element to parse is a source.
-    */
-  template<typename Object1, typename Object2, typename... Args>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user,
-                                     std::shared_ptr<Object1> obj1, std::shared_ptr<Object2> obj2, Args&&... args);
-  
-  /** Recursion over the sources and outputs. 
-    * End of recursion.
-    */
-  template<typename Object>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user, std::shared_ptr<Object> obj);
-  
-  template<typename Object, typename Output, typename... Args>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user,
-    std::shared_ptr<Object> obj, Output output, Args&&... args)
-  {
-    user->addInput(obj, output);
-    parseSourcesAndOutputs(g, user, obj, std::forward<Args>(args)...);
-  }
+/** Recursion over the sources and outputs.
+ * Case where the next element to parse is a source.
+ */
+template<typename Object1, typename Object2, typename... Args>
+inline void parseSourcesAndOutputs(graph::CallGraph * g,
+                                   std::shared_ptr<graph::internal::Inputs> user,
+                                   std::shared_ptr<Object1> obj1,
+                                   std::shared_ptr<Object2> obj2,
+                                   Args &&... args);
 
-  /** Recursion over the sources and outputs.
-  * Case where the next element to parse is a source.
-  */
-  template<typename Object1, typename Object2, typename... Args>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user,
-    std::shared_ptr<Object1>, std::shared_ptr<Object2> obj2, Args&&... args)
-  {
-    g->add(user);
-    auto newUser = std::make_shared<graph::internal::Inputs>();
-    parseSourcesAndOutputs(g, newUser, obj2, std::forward<Args>(args)...);
-  }
+/** Recursion over the sources and outputs.
+ * End of recursion.
+ */
+template<typename Object>
+inline void parseSourcesAndOutputs(graph::CallGraph * g,
+                                   std::shared_ptr<graph::internal::Inputs> user,
+                                   std::shared_ptr<Object> obj);
 
-  /** Recursion over the sources and outputs.
-  * End of recursion.
-  */
-  template<typename Object>
-  inline void parseSourcesAndOutputs(graph::CallGraph* g, std::shared_ptr<graph::internal::Inputs> user, std::shared_ptr<Object>)
-  {
-    g->add(user);
-  }
-
+template<typename Object, typename Output, typename... Args>
+inline void parseSourcesAndOutputs(graph::CallGraph * g,
+                                   std::shared_ptr<graph::internal::Inputs> user,
+                                   std::shared_ptr<Object> obj,
+                                   Output output,
+                                   Args &&... args)
+{
+  user->addInput(obj, output);
+  parseSourcesAndOutputs(g, user, obj, std::forward<Args>(args)...);
 }
 
+/** Recursion over the sources and outputs.
+ * Case where the next element to parse is a source.
+ */
+template<typename Object1, typename Object2, typename... Args>
+inline void parseSourcesAndOutputs(graph::CallGraph * g,
+                                   std::shared_ptr<graph::internal::Inputs> user,
+                                   std::shared_ptr<Object1>,
+                                   std::shared_ptr<Object2> obj2,
+                                   Args &&... args)
+{
+  g->add(user);
+  auto newUser = std::make_shared<graph::internal::Inputs>();
+  parseSourcesAndOutputs(g, newUser, obj2, std::forward<Args>(args)...);
 }
 
+/** Recursion over the sources and outputs.
+ * End of recursion.
+ */
+template<typename Object>
+inline void parseSourcesAndOutputs(graph::CallGraph * g,
+                                   std::shared_ptr<graph::internal::Inputs> user,
+                                   std::shared_ptr<Object>)
+{
+  g->add(user);
 }
+
+} // namespace internal
+
+} // namespace utils
+
+} // namespace tvm

--- a/include/tvm/utils/internal/map.h
+++ b/include/tvm/utils/internal/map.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/internal/map.h
+++ b/include/tvm/utils/internal/map.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -39,28 +39,21 @@ namespace utils
 
 namespace internal
 {
-  template<typename ObjWithId>
-  class IdComparator
-  {
-  public:
-    using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
-    bool operator() (const T* const lhs, const T* const rhs) const
-    {
-      return lhs->id() < rhs->id();
-    }
+template<typename ObjWithId>
+class IdComparator
+{
+public:
+  using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
+  bool operator()(const T * const lhs, const T * const rhs) const { return lhs->id() < rhs->id(); }
 
-    bool operator() (const T& lhs, const T& rhs) const
-    {
-      return lhs.id() < rhs.id();
-    }
-  };
+  bool operator()(const T & lhs, const T & rhs) const { return lhs.id() < rhs.id(); }
+};
 
-  template<typename KeyWithId, typename Value, 
-           typename Allocator = std::allocator< std::pair<const KeyWithId, Value> > >
-  using map = std::map<KeyWithId, Value, IdComparator<KeyWithId>, Allocator >;
+template<typename KeyWithId, typename Value, typename Allocator = std::allocator<std::pair<const KeyWithId, Value>>>
+using map = std::map<KeyWithId, Value, IdComparator<KeyWithId>, Allocator>;
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace utils
+} // namespace utils
 
-}  // namespace tvm
+} // namespace tvm

--- a/include/tvm/utils/sch.h
+++ b/include/tvm/utils/sch.h
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #pragma once
 

--- a/include/tvm/utils/sch.h
+++ b/include/tvm/utils/sch.h
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #pragma once
 
@@ -37,8 +37,8 @@
  */
 #include <tvm/api.h>
 
-#include <sch/S_Polyhedron/S_Polyhedron.h>
 #include <sch/CD/CD_Pair.h>
+#include <sch/S_Polyhedron/S_Polyhedron.h>
 
 #include <SpaceVecAlg/SpaceVecAlg>
 
@@ -50,27 +50,27 @@ namespace tvm
 namespace utils
 {
 
-  /** Set \p obj pose to \p t */
-  TVM_DLLAPI void transform(sch::S_Object& obj, const sva::PTransformd& t);
+/** Set \p obj pose to \p t */
+TVM_DLLAPI void transform(sch::S_Object & obj, const sva::PTransformd & t);
 
-  /** Loads an sch::S_Polyhedron object using \p filename */
-  TVM_DLLAPI std::unique_ptr<sch::S_Polyhedron> Polyhedron(const std::string& filename);
+/** Loads an sch::S_Polyhedron object using \p filename */
+TVM_DLLAPI std::unique_ptr<sch::S_Polyhedron> Polyhedron(const std::string & filename);
 
-  /** Compute distance between two objects
-   *
-   * \param pair pair of SCH objects
-   *
-   * \param p1 will be the closest point in the first object
-   *
-   * \param p2 will be the closes point in the second object
-   *
-   * \returns The squared distance between the two objects, returns a negative
-   * distance in case of inter-penetration
-   *
-   */
-  TVM_DLLAPI double distance(sch::CD_Pair& pair, Eigen::Vector3d& p1, Eigen::Vector3d& p2);
+/** Compute distance between two objects
+ *
+ * \param pair pair of SCH objects
+ *
+ * \param p1 will be the closest point in the first object
+ *
+ * \param p2 will be the closes point in the second object
+ *
+ * \returns The squared distance between the two objects, returns a negative
+ * distance in case of inter-penetration
+ *
+ */
+TVM_DLLAPI double distance(sch::CD_Pair & pair, Eigen::Vector3d & p1, Eigen::Vector3d & p2);
 
-} // utils
+} // namespace utils
 
 } // namespace tvm
 

--- a/src/Clock.cpp
+++ b/src/Clock.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Clock.h>
 

--- a/src/Clock.cpp
+++ b/src/Clock.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/Clock.h>
 
@@ -34,15 +34,8 @@
 namespace tvm
 {
 
-Clock::Clock(double dt)
-: dt_(dt)
-{
-  assert(dt > 0);
-}
+Clock::Clock(double dt) : dt_(dt) { assert(dt > 0); }
 
-void Clock::advance()
-{
-  ticks_++;
-}
+void Clock::advance() { ticks_++; }
 
 } // namespace tvm

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -1,140 +1,125 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/ControlProblem.h>
 
 namespace tvm
 {
 
-  TaskWithRequirements::TaskWithRequirements(const Task& t, requirements::SolvingRequirements req)
-    : task(t)
-    , requirements(req)
+TaskWithRequirements::TaskWithRequirements(const Task & t, requirements::SolvingRequirements req)
+: task(t), requirements(req)
+{
+}
+
+TaskWithRequirementsPtr ControlProblem::add(const Task & task, const requirements::SolvingRequirements & req)
+{
+  auto tr = std::make_shared<TaskWithRequirements>(task, req);
+  add(tr);
+  return tr;
+}
+
+void ControlProblem::add(TaskWithRequirementsPtr tr)
+{
+  tr_.push_back(tr);
+  addCallBackToTask(tr);
+  notify(
+      scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskAddition, tr.get()));
+  finalized_ = false;
+}
+
+void ControlProblem::remove(TaskWithRequirements * tr)
+{
+  auto it = std::find_if(tr_.begin(), tr_.end(), [tr](const TaskWithRequirementsPtr & p) { return p.get() == tr; });
+  if(it != tr_.end())
+    tr_.erase(it);
+  notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
+  callbackTokens_.erase(tr);
+  finalized_ = false;
+}
+
+const std::vector<TaskWithRequirementsPtr> & ControlProblem::tasks() const { return tr_; }
+
+int ControlProblem::size() const { return static_cast<int>(tr_.size()); }
+
+void ControlProblem::update()
+{
+  finalize();
+  updater_.run();
+  update_();
+}
+
+void ControlProblem::finalize()
+{
+  if(!finalized_)
   {
+    updater_.refresh();
+    finalize_();
+    finalized_ = true;
   }
+}
 
-
-  TaskWithRequirementsPtr ControlProblem::add(const Task& task, const requirements::SolvingRequirements& req)
+void ControlProblem::notify(const scheme::internal::ProblemDefinitionEvent & e)
+{
+  for(auto & c : computationData_)
   {
-    auto tr = std::make_shared<TaskWithRequirements>(task, req);
-    add(tr);
-    return tr;
+    c.second->addEvent(e);
   }
+}
 
-  void ControlProblem::add(TaskWithRequirementsPtr tr)
+void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
+{
+  using EventType = scheme::internal::ProblemDefinitionEvent::Type;
+  std::vector<internal::PairElementToken> tokens;
+  TaskWithRequirements * t = tr.get();
+
+  auto l1 = [this, t]() { this->notify({EventType::WeightChange, t}); };
+  tokens.emplace_back(tr->requirements.weight().registerCallback(l1));
+
+  auto l2 = [this, t]() { this->notify({EventType::AnisotropicWeightChange, t}); };
+  tokens.emplace_back(tr->requirements.anisotropicWeight().registerCallback(l2));
+
+  callbackTokens_[t] = std::move(tokens);
+}
+
+ControlProblem::Updater::Updater() : upToDate_(false), inputs_(new graph::internal::Inputs) {}
+
+void ControlProblem::Updater::refresh()
+{
+  if(!upToDate_)
   {
-    tr_.push_back(tr);
-    addCallBackToTask(tr);
-    notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskAddition, tr.get()));
-    finalized_ = false;
+    updateGraph_.clear();
+    updateGraph_.add(inputs_);
+    updateGraph_.update();
+    upToDate_ = true;
   }
+}
 
-  void ControlProblem::remove(TaskWithRequirements* tr)
-  {
-    auto it = std::find_if(tr_.begin(), tr_.end(), [tr](const TaskWithRequirementsPtr& p) {return p.get() == tr; });
-    if (it != tr_.end())
-      tr_.erase(it);
-    notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
-    callbackTokens_.erase(tr);
-    finalized_ = false;
-  }
+void ControlProblem::Updater::run() { updateGraph_.execute(); }
 
-  const std::vector<TaskWithRequirementsPtr>& ControlProblem::tasks() const
-  {
-    return tr_;
-  }
-
-  int ControlProblem::size() const
-  {
-    return static_cast<int>(tr_.size());
-  }
-
-  void ControlProblem::update()
-  {
-    finalize();
-    updater_.run();
-    update_();
-  }
-
-  void ControlProblem::finalize()
-  {
-    if (!finalized_)
-    {
-      updater_.refresh();
-      finalize_();
-      finalized_ = true;
-    }
-  }
-
-  void ControlProblem::notify(const scheme::internal::ProblemDefinitionEvent& e)
-  {
-    for (auto& c : computationData_)
-    {
-      c.second->addEvent(e);
-    }
-  }
-
-  void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
-  {
-    using EventType = scheme::internal::ProblemDefinitionEvent::Type;
-    std::vector<internal::PairElementToken> tokens;
-    TaskWithRequirements* t = tr.get();
-    
-    auto l1 = [this, t]() {this->notify({ EventType::WeightChange, t }); };
-    tokens.emplace_back(tr->requirements.weight().registerCallback(l1));
-    
-    auto l2 = [this, t]() {this->notify({ EventType::AnisotropicWeightChange, t }); };
-    tokens.emplace_back(tr->requirements.anisotropicWeight().registerCallback(l2));
-
-    callbackTokens_[t] = std::move(tokens);
-  }
-
-
-  ControlProblem::Updater::Updater()
-    : upToDate_(false)
-    , inputs_(new graph::internal::Inputs)
-  {
-  }
-
-  void ControlProblem::Updater::refresh()
-  {
-    if (!upToDate_)
-    {
-      updateGraph_.clear();
-      updateGraph_.add(inputs_);
-      updateGraph_.update();
-      upToDate_ = true;
-    }
-  }
-
-  void ControlProblem::Updater::run()
-  {
-    updateGraph_.execute();
-  }
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -7,8 +7,7 @@ namespace tvm
 
 TaskWithRequirements::TaskWithRequirements(const Task & t, requirements::SolvingRequirements req)
 : task(t), requirements(req)
-{
-}
+{}
 
 TaskWithRequirementsPtr ControlProblem::add(const Task & task, const requirements::SolvingRequirements & req)
 {

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/ControlProblem.h>
 

--- a/src/LinearizedControlProblem.cpp
+++ b/src/LinearizedControlProblem.cpp
@@ -1,162 +1,159 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/LinearizedControlProblem.h>
 
 #include <tvm/constraint/internal/LinearizedTaskConstraint.h>
-#include <tvm/scheme/internal/helpers.h>
 #include <tvm/scheme/internal/LinearizedProblemComputationData.h>
+#include <tvm/scheme/internal/helpers.h>
 
 namespace tvm
 {
-  LinearizedControlProblem::LinearizedControlProblem()
-  {
-  }
+LinearizedControlProblem::LinearizedControlProblem() {}
 
-  LinearizedControlProblem::LinearizedControlProblem(const ControlProblem& pb)
-  : ControlProblem()
-  {
-    for (auto tr : pb.tasks())
-      add(tr);
-  }
-
-  TaskWithRequirementsPtr LinearizedControlProblem::add(const Task& task, const requirements::SolvingRequirements& req)
-  {
-    auto tr = std::make_shared<TaskWithRequirements>(task, req);
+LinearizedControlProblem::LinearizedControlProblem(const ControlProblem & pb) : ControlProblem()
+{
+  for(auto tr : pb.tasks())
     add(tr);
-    return tr;
-  }
+}
 
-  void LinearizedControlProblem::add(TaskWithRequirementsPtr tr)
+TaskWithRequirementsPtr LinearizedControlProblem::add(const Task & task, const requirements::SolvingRequirements & req)
+{
+  auto tr = std::make_shared<TaskWithRequirements>(task, req);
+  add(tr);
+  return tr;
+}
+
+void LinearizedControlProblem::add(TaskWithRequirementsPtr tr)
+{
+  ControlProblem::add(tr);
+
+  // FIXME A lot of work can be done here based on the properties of the task's jacobian.
+  // In particular, we could detect bounds, pairs of tasks forming a double-sided constraints...
+  LinearConstraintWithRequirements lcr;
+  lcr.constraint = std::make_shared<constraint::internal::LinearizedTaskConstraint>(tr->task);
+  // we use the aliasing constructor of std::shared_ptr to ensure that
+  // lcr.requirements points to and doesn't outlive tr->requirements.
+  lcr.requirements = std::shared_ptr<requirements::SolvingRequirementsWithCallbacks>(tr, &tr->requirements);
+  lcr.bound = scheme::internal::isBound(lcr.constraint);
+  constraints_[tr.get()] = lcr;
+
+  using CstrOutput = internal::FirstOrderProvider::Output;
+  updater_.addInput(lcr.constraint, CstrOutput::Jacobian);
+  switch(tr->task.type())
   {
-    ControlProblem::add(tr);
-
-    //FIXME A lot of work can be done here based on the properties of the task's jacobian.
-    //In particular, we could detect bounds, pairs of tasks forming a double-sided constraints...
-    LinearConstraintWithRequirements lcr;
-    lcr.constraint = std::make_shared<constraint::internal::LinearizedTaskConstraint>(tr->task);
-    //we use the aliasing constructor of std::shared_ptr to ensure that
-    //lcr.requirements points to and doesn't outlive tr->requirements.
-    lcr.requirements = std::shared_ptr<requirements::SolvingRequirementsWithCallbacks>(tr, &tr->requirements);
-    lcr.bound = scheme::internal::isBound(lcr.constraint);
-    constraints_[tr.get()] = lcr;
-
-    using CstrOutput = internal::FirstOrderProvider::Output;
-    updater_.addInput(lcr.constraint, CstrOutput::Jacobian);
-    switch (tr->task.type())
-    {
-    case constraint::Type::EQUAL: updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::E); break;
-    case constraint::Type::GREATER_THAN: updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::L); break;
-    case constraint::Type::LOWER_THAN: updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::U); break;
-    case constraint::Type::DOUBLE_SIDED: updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::L, constraint::abstract::Constraint::Output::U); break;
-    }
+    case constraint::Type::EQUAL:
+      updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::E);
+      break;
+    case constraint::Type::GREATER_THAN:
+      updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::L);
+      break;
+    case constraint::Type::LOWER_THAN:
+      updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::U);
+      break;
+    case constraint::Type::DOUBLE_SIDED:
+      updater_.addInput(lcr.constraint, constraint::abstract::Constraint::Output::L,
+                        constraint::abstract::Constraint::Output::U);
+      break;
   }
+}
 
-  void LinearizedControlProblem::remove(TaskWithRequirements* tr)
-  {
-    ControlProblem::remove(tr);
-    // if the above line did not throw, tr exists in the problem and in constraints_
-    auto it = constraints_.find(tr);
-    assert(it != constraints_.end());
-    updater_.removeInput(it->second.constraint.get());
-    constraints_.erase(it);
-  }
+void LinearizedControlProblem::remove(TaskWithRequirements * tr)
+{
+  ControlProblem::remove(tr);
+  // if the above line did not throw, tr exists in the problem and in constraints_
+  auto it = constraints_.find(tr);
+  assert(it != constraints_.end());
+  updater_.removeInput(it->second.constraint.get());
+  constraints_.erase(it);
+}
 
-  void LinearizedControlProblem::add(const hint::Substitution & s)
-  {
-    substitutions_.add(s);
-  }
+void LinearizedControlProblem::add(const hint::Substitution & s) { substitutions_.add(s); }
 
-  const hint::internal::Substitutions & LinearizedControlProblem::substitutions() const
-  {
-    return substitutions_;
-  }
+const hint::internal::Substitutions & LinearizedControlProblem::substitutions() const { return substitutions_; }
 
-  VariableVector LinearizedControlProblem::variables() const
-  {
-    VariableVector variables;
-    for (auto c : constraints_)
-      variables.add(c.second.constraint->variables());
+VariableVector LinearizedControlProblem::variables() const
+{
+  VariableVector variables;
+  for(auto c : constraints_)
+    variables.add(c.second.constraint->variables());
 
-    return variables;
-  }
+  return variables;
+}
 
-  std::vector<LinearConstraintWithRequirements> LinearizedControlProblem::constraints() const
-  {
-    std::vector<LinearConstraintWithRequirements> constraints;
-    constraints.reserve(constraints_.size());
-    for (auto c: constraints_)
-      constraints.push_back(c.second);
+std::vector<LinearConstraintWithRequirements> LinearizedControlProblem::constraints() const
+{
+  std::vector<LinearConstraintWithRequirements> constraints;
+  constraints.reserve(constraints_.size());
+  for(auto c : constraints_)
+    constraints.push_back(c.second);
 
-    return constraints;
-  }
+  return constraints;
+}
 
-  LinearConstraintPtr LinearizedControlProblem::constraint(TaskWithRequirements* t) const
-  {
-    return constraints_.at(t).constraint;
-  }
+LinearConstraintPtr LinearizedControlProblem::constraint(TaskWithRequirements * t) const
+{
+  return constraints_.at(t).constraint;
+}
 
-  LinearConstraintPtr LinearizedControlProblem::constraintNoThrow(TaskWithRequirements* t) const
-  {
-    auto it = constraints_.find(t);
-    if (it != constraints_.end())
-      return it->second.constraint;
-    else
-      return {};
-  }
+LinearConstraintPtr LinearizedControlProblem::constraintNoThrow(TaskWithRequirements * t) const
+{
+  auto it = constraints_.find(t);
+  if(it != constraints_.end())
+    return it->second.constraint;
+  else
+    return {};
+}
 
-  const LinearConstraintWithRequirements& LinearizedControlProblem::constraintWithRequirements(TaskWithRequirements* t) const
-  {
-    return constraints_.at(t);
-  }
+const LinearConstraintWithRequirements & LinearizedControlProblem::constraintWithRequirements(
+    TaskWithRequirements * t) const
+{
+  return constraints_.at(t);
+}
 
-  std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>> LinearizedControlProblem::constraintWithRequirementsNoThrow(TaskWithRequirements* t) const
-  {
-    auto it = constraints_.find(t);
-    if (it != constraints_.end())
-      return it->second;
-    else
-      return {};
-  }
+std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>>
+    LinearizedControlProblem::constraintWithRequirementsNoThrow(TaskWithRequirements * t) const
+{
+  auto it = constraints_.find(t);
+  if(it != constraints_.end())
+    return it->second;
+  else
+    return {};
+}
 
-  const tvm::utils::internal::map<TaskWithRequirements*, LinearConstraintWithRequirements>& LinearizedControlProblem::constraintMap() const
-  {
-    return constraints_;
-  }
+const tvm::utils::internal::map<TaskWithRequirements *, LinearConstraintWithRequirements> &
+    LinearizedControlProblem::constraintMap() const
+{
+  return constraints_;
+}
 
-  void LinearizedControlProblem::update_()
-  {
-    substitutions_.updateSubstitutions();
-  }
+void LinearizedControlProblem::update_() { substitutions_.updateSubstitutions(); }
 
-  void LinearizedControlProblem::finalize_()
-  {
-    substitutions_.finalize();
-  }
-}  // namespace tvm
+void LinearizedControlProblem::finalize_() { substitutions_.finalize(); }
+} // namespace tvm

--- a/src/LinearizedControlProblem.cpp
+++ b/src/LinearizedControlProblem.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/LinearizedControlProblem.h>
 

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Robot.h>
 

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/Robot.h>
 
@@ -33,18 +33,21 @@
 
 #include <RBDyn/CoM.h>
 #include <RBDyn/EulerIntegration.h>
+#include <RBDyn/FA.h>
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
-#include <RBDyn/FA.h>
 
 namespace tvm
 {
 
-Robot::Robot(Clock & clock, const std::string & name, rbd::MultiBodyGraph & mbg, rbd::MultiBody mb, rbd::MultiBodyConfig mbc, const rbd::parsers::Limits & limits)
-: clock_(clock), last_tick_(clock.ticks()),
-  name_(name), mb_(mb), mbc_(mbc),
-  normalAccB_(mbc_.bodyAccB.size()), fd_(mb_),
-  bodyTransforms_(mbg.bodiesBaseTransform(mb_.body(0).name())),
+Robot::Robot(Clock & clock,
+             const std::string & name,
+             rbd::MultiBodyGraph & mbg,
+             rbd::MultiBody mb,
+             rbd::MultiBodyConfig mbc,
+             const rbd::parsers::Limits & limits)
+: clock_(clock), last_tick_(clock.ticks()), name_(name), mb_(mb), mbc_(mbc), normalAccB_(mbc_.bodyAccB.size()),
+  fd_(mb_), bodyTransforms_(mbg.bodiesBaseTransform(mb_.body(0).name())),
   tau_(tvm::Space(mb_.nrDof()).createVariable("tau"))
 {
   if(mb.nrJoints() > 0 && mb.joint(0).type() == rbd::Joint::Free)
@@ -60,36 +63,40 @@ Robot::Robot(Clock & clock, const std::string & name, rbd::MultiBodyGraph & mbg,
   /** Bounds generic initialization */
   lQBound_.resize(q_joints_->size());
   lQBound_.setConstant(-tvm::constant::big_number);
-  uQBound_ = - lQBound_;
+  uQBound_ = -lQBound_;
   lVelBound_.resize(q_joints_->size());
   lVelBound_.setConstant(-tvm::constant::big_number);
-  uVelBound_ = - lVelBound_;
+  uVelBound_ = -lVelBound_;
   lTauBound_.resize(q_joints_->size() + q_ff_->space().tSize());
   lTauBound_.head(q_ff_->space().tSize()).setZero();
   lTauBound_.tail(q_joints_->size()).setConstant(-tvm::constant::big_number);
-  uTauBound_ = - lTauBound_;
+  uTauBound_ = -lTauBound_;
   /** Bounds initialization based on provided limits */
   {
-  const auto & jIndexByName = mb_.jointIndexByName();
-  auto map2bound = [this,&jIndexByName](const std::map<std::string, std::vector<double>> & bound, double mul, Eigen::VectorXd & out, int ffOffset, int(rbd::MultiBody::*posMethod)(int) const)
-  {
-    for(const auto & qi : bound)
-    {
-      if(!jIndexByName.count(qi.first)) { continue; }
-      auto jIndex = jIndexByName.at(qi.first);
-      auto pos = (mb_.*posMethod)(jIndex) - ffOffset;
-      for(size_t i = 0; i < qi.second.size(); ++i)
+    const auto & jIndexByName = mb_.jointIndexByName();
+    auto map2bound = [this, &jIndexByName](const std::map<std::string, std::vector<double>> & bound, double mul,
+                                           Eigen::VectorXd & out, int ffOffset,
+                                           int (rbd::MultiBody::*posMethod)(int) const) {
+      for(const auto & qi : bound)
       {
-        out(pos + i) = mul * qi.second[i];
+        if(!jIndexByName.count(qi.first))
+        {
+          continue;
+        }
+        auto jIndex = jIndexByName.at(qi.first);
+        auto pos = (mb_.*posMethod)(jIndex)-ffOffset;
+        for(size_t i = 0; i < qi.second.size(); ++i)
+        {
+          out(pos + i) = mul * qi.second[i];
+        }
       }
-    }
-  };
-  map2bound(limits.lower, 1, lQBound_, q_ff_->size(), &rbd::MultiBody::jointPosInParam);
-  map2bound(limits.upper, 1, uQBound_, q_ff_->size(), &rbd::MultiBody::jointPosInParam);
-  map2bound(limits.velocity, -1, lVelBound_, q_ff_->space().tSize(), &rbd::MultiBody::jointPosInDof);
-  map2bound(limits.velocity, 1, uVelBound_, q_ff_->space().tSize(), &rbd::MultiBody::jointPosInDof);
-  map2bound(limits.torque, -1, lTauBound_, 0, &rbd::MultiBody::jointPosInDof);
-  map2bound(limits.torque, 1, uTauBound_, 0, &rbd::MultiBody::jointPosInDof);
+    };
+    map2bound(limits.lower, 1, lQBound_, q_ff_->size(), &rbd::MultiBody::jointPosInParam);
+    map2bound(limits.upper, 1, uQBound_, q_ff_->size(), &rbd::MultiBody::jointPosInParam);
+    map2bound(limits.velocity, -1, lVelBound_, q_ff_->space().tSize(), &rbd::MultiBody::jointPosInDof);
+    map2bound(limits.velocity, 1, uVelBound_, q_ff_->space().tSize(), &rbd::MultiBody::jointPosInDof);
+    map2bound(limits.torque, -1, lTauBound_, 0, &rbd::MultiBody::jointPosInDof);
+    map2bound(limits.torque, 1, uTauBound_, 0, &rbd::MultiBody::jointPosInDof);
   }
   /** Variables creation */
   q_.add(q_ff_);
@@ -103,6 +110,7 @@ Robot::Robot(Clock & clock, const std::string & name, rbd::MultiBodyGraph & mbg,
   ddq_.value(Eigen::VectorXd::Zero(ddq_.value().size()));
   tau_->value(Eigen::VectorXd::Zero(tau_->value().size()));
   /** Signals */
+  // clang-format off
   registerUpdates(Update::Time, &Robot::updateTimeDependency,
                   Update::FK, &Robot::updateFK,
                   Update::FV, &Robot::updateFV,
@@ -111,6 +119,7 @@ Robot::Robot(Clock & clock, const std::string & name, rbd::MultiBodyGraph & mbg,
                   Update::CoM, &Robot::updateCoM,
                   Update::H, &Robot::updateH,
                   Update::C, &Robot::updateC);
+  // clang-format on
   /** Input dependencies */
   addInputDependency(Update::Time, clock_, Clock::Output::Time);
   /** Output dependencies */
@@ -170,25 +179,13 @@ void Robot::updateTimeDependency()
   }
 }
 
-void Robot::updateFK()
-{
-  rbd::forwardKinematics(mb_, mbc_);
-}
+void Robot::updateFK() { rbd::forwardKinematics(mb_, mbc_); }
 
-void Robot::updateFV()
-{
-  rbd::forwardVelocity(mb_, mbc_);
-}
+void Robot::updateFV() { rbd::forwardVelocity(mb_, mbc_); }
 
-void Robot::updateFA()
-{
-  rbd::forwardAcceleration(mb_, mbc_);
-}
+void Robot::updateFA() { rbd::forwardAcceleration(mb_, mbc_); }
 
-void Robot::updateNormalAcceleration()
-{
-  computeNormalAccB();
-}
+void Robot::updateNormalAcceleration() { computeNormalAccB(); }
 
 void Robot::computeNormalAccB()
 {
@@ -214,19 +211,10 @@ void Robot::computeNormalAccB()
   }
 }
 
-void Robot::updateH()
-{
-  fd_.computeH(mb_, mbc_);
-}
+void Robot::updateH() { fd_.computeH(mb_, mbc_); }
 
-void Robot::updateC()
-{
-  fd_.computeC(mb_, mbc_);
-}
+void Robot::updateC() { fd_.computeC(mb_, mbc_); }
 
-void Robot::updateCoM()
-{
-  com_ = rbd::computeCoM(mb_, mbc_);
-}
+void Robot::updateCoM() { com_ = rbd::computeCoM(mb_, mbc_); }
 
-}
+} // namespace tvm

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/Space.h>
 
@@ -35,67 +35,57 @@
 
 namespace tvm
 {
-  Space::Space(int size)
-    : Space(size, size, size)
-  {
-  }
+Space::Space(int size) : Space(size, size, size) {}
 
-  Space::Space(int size, int representationSize)
-    : Space(size, representationSize, size)
-  {
-  }
+Space::Space(int size, int representationSize) : Space(size, representationSize, size) {}
 
-  Space::Space(int size, int representationSize, int tangentRepresentationSize)
-    : mSize_(size), rSize_(representationSize), tSize_(tangentRepresentationSize)
-    , type_((size==representationSize&&size==tangentRepresentationSize)?Type::Euclidean:Type::Unspecified)
-  {
-    assert(size >= 0);
-    assert(representationSize >= size);
-    assert(tangentRepresentationSize >= size);
-  }
+Space::Space(int size, int representationSize, int tangentRepresentationSize)
+: mSize_(size), rSize_(representationSize), tSize_(tangentRepresentationSize),
+  type_((size == representationSize && size == tangentRepresentationSize) ? Type::Euclidean : Type::Unspecified)
+{
+  assert(size >= 0);
+  assert(representationSize >= size);
+  assert(tangentRepresentationSize >= size);
+}
 
-  Space::Space(Type type, int size)
-    : type_(type)
+Space::Space(Type type, int size) : type_(type)
+{
+  switch(type)
   {
-    switch (type)
-    {
-    case Type::Euclidean: mSize_ = rSize_ = tSize_ = size; break;
-    case Type::SO3: assert(size < 0); mSize_ = 3; rSize_ = 4; tSize_ = 3; break;
-    case Type::SE3: assert(size < 0); mSize_ = 6; rSize_ = 7; tSize_ = 6; break;
+    case Type::Euclidean:
+      mSize_ = rSize_ = tSize_ = size;
+      break;
+    case Type::SO3:
+      assert(size < 0);
+      mSize_ = 3;
+      rSize_ = 4;
+      tSize_ = 3;
+      break;
+    case Type::SE3:
+      assert(size < 0);
+      mSize_ = 6;
+      rSize_ = 7;
+      tSize_ = 6;
+      break;
     case Type::Unspecified:
     default:
       throw std::runtime_error("[Space::Space] Unable to build the required space.");
-    }
   }
+}
 
-  std::unique_ptr<Variable> Space::createVariable(const std::string& name) const
-  {
-    return std::unique_ptr<Variable>(new Variable(*this, name));
-  }
+std::unique_ptr<Variable> Space::createVariable(const std::string & name) const
+{
+  return std::unique_ptr<Variable>(new Variable(*this, name));
+}
 
-  int Space::size() const
-  {
-    return mSize_;
-  }
+int Space::size() const { return mSize_; }
 
-  int Space::rSize() const
-  {
-    return rSize_;
-  }
+int Space::rSize() const { return rSize_; }
 
-  int Space::tSize() const
-  {
-    return tSize_;
-  }
+int Space::tSize() const { return tSize_; }
 
-  Space::Type Space::type() const
-  {
-    return type_;
-  }
+Space::Type Space::type() const { return type_; }
 
-  bool Space::isEuclidean() const
-  {
-    return type_ == Type::Euclidean;
-  }
+bool Space::isEuclidean() const { return type_ == Type::Euclidean; }
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Space.h>
 

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/Task.h>
 
@@ -33,93 +33,82 @@
 
 #include <stdexcept>
 
-
 namespace tvm
 {
-  Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td)
-    : f_(f)
-    , type_(t)
-    , td_(td.impl(f, t, Eigen::VectorXd::Zero(f->size())))
-  {
-    if (t == constraint::Type::DOUBLE_SIDED)
-      throw std::runtime_error("Double sided tasks need to have non-zero bounds.");
-    if (!f->imageSpace().isEuclidean())
-      throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
-  }
+Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td)
+: f_(f), type_(t), td_(td.impl(f, t, Eigen::VectorXd::Zero(f->size())))
+{
+  if(t == constraint::Type::DOUBLE_SIDED)
+    throw std::runtime_error("Double sided tasks need to have non-zero bounds.");
+  if(!f->imageSpace().isEuclidean())
+    throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
+}
 
-  Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, double rhs)
-    : Task(f, t, td, Eigen::VectorXd::Constant(f->size(),rhs))
-  {
-  }
+Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td, double rhs)
+: Task(f, t, td, Eigen::VectorXd::Constant(f->size(), rhs))
+{
+}
 
-  Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, const Eigen::VectorXd & rhs)
-    : f_(f)
-    , type_(t)
-    , td_(std::move(td.impl(f, t, rhs)))
-  {
-    if (t == constraint::Type::DOUBLE_SIDED)
-      throw std::runtime_error("Double sided tasks need to have two bounds.");
-    if (!f->imageSpace().isEuclidean())
-      throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
-  }
+Task::Task(FunctionPtr f,
+           constraint::Type t,
+           const task_dynamics::abstract::TaskDynamics & td,
+           const Eigen::VectorXd & rhs)
+: f_(f), type_(t), td_(std::move(td.impl(f, t, rhs)))
+{
+  if(t == constraint::Type::DOUBLE_SIDED)
+    throw std::runtime_error("Double sided tasks need to have two bounds.");
+  if(!f->imageSpace().isEuclidean())
+    throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
+}
 
-  Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, double l, double u)
-    : Task(f, t, td, Eigen::VectorXd::Constant(f->size(), l), Eigen::VectorXd::Constant(f->size(), u))
-  {
-  }
+Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td, double l, double u)
+: Task(f, t, td, Eigen::VectorXd::Constant(f->size(), l), Eigen::VectorXd::Constant(f->size(), u))
+{
+}
 
-  Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics& td, const Eigen::VectorXd & l, const Eigen::VectorXd & u)
-    : f_(f)
-    , type_(t)
-    , td_(td.impl(f, constraint::Type::GREATER_THAN, l))
-    , td2_(td.impl(f, constraint::Type::LOWER_THAN, u))
-  {
-    if (t != constraint::Type::DOUBLE_SIDED)
-      throw std::runtime_error("This constructor is for double sided constraints only.");
-    if (!f->imageSpace().isEuclidean())
-      throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
-  }
+Task::Task(FunctionPtr f,
+           constraint::Type t,
+           const task_dynamics::abstract::TaskDynamics & td,
+           const Eigen::VectorXd & l,
+           const Eigen::VectorXd & u)
+: f_(f), type_(t), td_(td.impl(f, constraint::Type::GREATER_THAN, l)), td2_(td.impl(f, constraint::Type::LOWER_THAN, u))
+{
+  if(t != constraint::Type::DOUBLE_SIDED)
+    throw std::runtime_error("This constructor is for double sided constraints only.");
+  if(!f->imageSpace().isEuclidean())
+    throw std::runtime_error("[Task::Task] Can't create a task for a function into a non-Euclidean space.");
+}
 
-  Task::Task(utils::ProtoTaskEQ proto, const task_dynamics::abstract::TaskDynamics& td)
-    : Task(proto.f_, constraint::Type::EQUAL, td, proto.rhs_.toVector(proto.f_->size()))
-  {
-  }
+Task::Task(utils::ProtoTaskEQ proto, const task_dynamics::abstract::TaskDynamics & td)
+: Task(proto.f_, constraint::Type::EQUAL, td, proto.rhs_.toVector(proto.f_->size()))
+{
+}
 
-  Task::Task(utils::ProtoTaskLT proto, const task_dynamics::abstract::TaskDynamics& td)
-    : Task(proto.f_, constraint::Type::LOWER_THAN, td, proto.rhs_.toVector(proto.f_->size()))
-  {
-  }
+Task::Task(utils::ProtoTaskLT proto, const task_dynamics::abstract::TaskDynamics & td)
+: Task(proto.f_, constraint::Type::LOWER_THAN, td, proto.rhs_.toVector(proto.f_->size()))
+{
+}
 
-  Task::Task(utils::ProtoTaskGT proto, const task_dynamics::abstract::TaskDynamics& td)
-    : Task(proto.f_, constraint::Type::GREATER_THAN, td, proto.rhs_.toVector(proto.f_->size()))
-  {
-  }
+Task::Task(utils::ProtoTaskGT proto, const task_dynamics::abstract::TaskDynamics & td)
+: Task(proto.f_, constraint::Type::GREATER_THAN, td, proto.rhs_.toVector(proto.f_->size()))
+{
+}
 
-  Task::Task(utils::ProtoTaskDS proto, const task_dynamics::abstract::TaskDynamics& td)
-    : Task(proto.f_, constraint::Type::DOUBLE_SIDED, td, 
-            proto.l_.toVector(proto.f_->size()), proto.u_.toVector(proto.f_->size()))
-  {
-  }
+Task::Task(utils::ProtoTaskDS proto, const task_dynamics::abstract::TaskDynamics & td)
+: Task(proto.f_,
+       constraint::Type::DOUBLE_SIDED,
+       td,
+       proto.l_.toVector(proto.f_->size()),
+       proto.u_.toVector(proto.f_->size()))
+{
+}
 
+FunctionPtr Task::function() const { return f_; }
 
-  FunctionPtr Task::function() const
-  {
-    return f_;
-  }
+constraint::Type Task::type() const { return type_; }
 
-  constraint::Type Task::type() const
-  {
-    return type_;
-  }
+TaskDynamicsPtr Task::taskDynamics() const { return td_; }
 
-  TaskDynamicsPtr Task::taskDynamics() const
-  {
-    return td_;
-  }
+TaskDynamicsPtr Task::secondBoundTaskDynamics() const { return td2_; }
 
-  TaskDynamicsPtr Task::secondBoundTaskDynamics() const
-  {
-      return td2_;
-  }
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Task.h>
 

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -19,8 +19,7 @@ Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::Tas
 
 Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td, double rhs)
 : Task(f, t, td, Eigen::VectorXd::Constant(f->size(), rhs))
-{
-}
+{}
 
 Task::Task(FunctionPtr f,
            constraint::Type t,
@@ -36,8 +35,7 @@ Task::Task(FunctionPtr f,
 
 Task::Task(FunctionPtr f, constraint::Type t, const task_dynamics::abstract::TaskDynamics & td, double l, double u)
 : Task(f, t, td, Eigen::VectorXd::Constant(f->size(), l), Eigen::VectorXd::Constant(f->size(), u))
-{
-}
+{}
 
 Task::Task(FunctionPtr f,
            constraint::Type t,
@@ -54,18 +52,15 @@ Task::Task(FunctionPtr f,
 
 Task::Task(utils::ProtoTaskEQ proto, const task_dynamics::abstract::TaskDynamics & td)
 : Task(proto.f_, constraint::Type::EQUAL, td, proto.rhs_.toVector(proto.f_->size()))
-{
-}
+{}
 
 Task::Task(utils::ProtoTaskLT proto, const task_dynamics::abstract::TaskDynamics & td)
 : Task(proto.f_, constraint::Type::LOWER_THAN, td, proto.rhs_.toVector(proto.f_->size()))
-{
-}
+{}
 
 Task::Task(utils::ProtoTaskGT proto, const task_dynamics::abstract::TaskDynamics & td)
 : Task(proto.f_, constraint::Type::GREATER_THAN, td, proto.rhs_.toVector(proto.f_->size()))
-{
-}
+{}
 
 Task::Task(utils::ProtoTaskDS proto, const task_dynamics::abstract::TaskDynamics & td)
 : Task(proto.f_,
@@ -73,8 +68,7 @@ Task::Task(utils::ProtoTaskDS proto, const task_dynamics::abstract::TaskDynamics
        td,
        proto.l_.toVector(proto.f_->size()),
        proto.u_.toVector(proto.f_->size()))
-{
-}
+{}
 
 FunctionPtr Task::function() const { return f_; }
 

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/Variable.h>
 
@@ -36,187 +36,152 @@
 namespace tvm
 {
 
-  VariablePtr dot(VariablePtr var, int ndiff)
+VariablePtr dot(VariablePtr var, int ndiff)
+{
+  assert(ndiff > 0 && "you cannot derive less than 1 time.");
+  int i;
+  Variable * derivative = var.get();
+
+  // find the ndiff-th derivative of var, or the largest i such that the i-th
+  // derivative exists.
+  for(i = 0; i < ndiff; ++i)
   {
-    assert(ndiff > 0 && "you cannot derive less than 1 time.");
-    int i;
-    Variable* derivative = var.get();
-
-    //find the ndiff-th derivative of var, or the largest i such that the i-th
-    //derivative exists.
-    for (i = 0; i < ndiff; ++i)
-    {
-      if (!derivative->derivative_)
-        break;
-      else
-        derivative = derivative->derivative_.get();
-    }
-
-    if (i == ndiff)                 //the ndiff-th derivative already exists
-      return { var, derivative };
-    else                            //we need to create the derivatives from i+1 to ndiff
-    {
-      for (; i < ndiff; ++i)
-      {
-        auto primitive = derivative;
-        primitive->derivative_.reset(new Variable(derivative));
-        derivative = primitive->derivative_.get();
-      }
-      return { var, derivative };
-    }
+    if(!derivative->derivative_)
+      break;
+    else
+      derivative = derivative->derivative_.get();
   }
 
-
-
-  VariablePtr Variable::duplicate(const std::string& n) const
+  if(i == ndiff) // the ndiff-th derivative already exists
+    return {var, derivative};
+  else // we need to create the derivatives from i+1 to ndiff
   {
-    VariablePtr newPrimitive;
-    if (n.empty())
+    for(; i < ndiff; ++i)
     {
-      newPrimitive = space_.createVariable(basePrimitive()->name() + "'");
+      auto primitive = derivative;
+      primitive->derivative_.reset(new Variable(derivative));
+      derivative = primitive->derivative_.get();
+    }
+    return {var, derivative};
+  }
+}
+
+VariablePtr Variable::duplicate(const std::string & n) const
+{
+  VariablePtr newPrimitive;
+  if(n.empty())
+  {
+    newPrimitive = space_.createVariable(basePrimitive()->name() + "'");
+  }
+  else
+  {
+    newPrimitive = space_.createVariable(n);
+  }
+  if(derivativeNumber_)
+  {
+    auto r = dot(newPrimitive, derivativeNumber_);
+    r->value(value_);
+    return r;
+  }
+  else
+  {
+    newPrimitive->value(value_);
+    return newPrimitive;
+  }
+}
+
+const std::string & Variable::name() const { return name_; }
+
+int Variable::size() const { return static_cast<int>(value_.size()); }
+
+const Space & Variable::space() const { return space_; }
+
+bool Variable::isEuclidean() const { return space_.isEuclidean() || !isBasePrimitive(); }
+
+const Eigen::VectorXd & Variable::value() const { return value_; }
+
+void Variable::value(const VectorConstRef & x)
+{
+  if(x.size() == size())
+    value_ = x;
+  else
+    throw std::runtime_error("x has not the correct size.");
+}
+
+void Variable::setZero() { value_.setZero(); }
+
+int Variable::derivativeNumber() const { return derivativeNumber_; }
+
+bool Variable::isDerivativeOf(const Variable & v) const
+{
+  return basePrimitive() == v.basePrimitive() && derivativeNumber_ > v.derivativeNumber();
+}
+
+bool Variable::isPrimitiveOf(const Variable & v) const
+{
+  return basePrimitive() == v.basePrimitive() && derivativeNumber_ < v.derivativeNumber();
+}
+
+bool Variable::isBasePrimitive() const { return derivativeNumber_ == 0; }
+
+VariablePtr Variable::basePrimitive() const
+{
+  if(isBasePrimitive())
+  {
+    // while it does not seem ideal to cast the constness away, it is coherent
+    // with the general case: from a const derived variable, we can get a non
+    // const primitive. This is equivalent to have primitive_ be a shared_ptr
+    // to this in the case of a base primitive, what we can obviously not do.
+    return const_cast<Variable *>(this)->shared_from_this();
+  }
+  else
+  {
+    const Variable * ptr = this;
+    for(int i = 0; i < derivativeNumber_ - 1; ++i)
+      ptr = ptr->primitive_;
+
+    return ptr->primitive_->shared_from_this();
+  }
+}
+
+Range Variable::getMappingIn(const VariableVector & variables) const
+{
+  if(mappingHelper_.stamp == variables.stamp())
+    return {mappingHelper_.start, size()};
+  else
+  {
+    if(variables.contains(*this))
+    {
+      variables.computeMapping();
+      return {mappingHelper_.start, size()};
     }
     else
-    {
-      newPrimitive = space_.createVariable(n);
-    }
-    if (derivativeNumber_)
-    {
-      auto r = dot(newPrimitive, derivativeNumber_);
-      r->value(value_);
-      return r;
-    }
-    else
-    {
-      newPrimitive->value(value_);
-      return newPrimitive;
-    }
+      throw std::runtime_error("This variable is not part of the vector of variables.");
   }
+}
 
-  const std::string & Variable::name() const
+Variable::Variable(const Space & s, const std::string & name)
+: name_(name), space_(s), value_(s.rSize()), derivativeNumber_(0), primitive_(nullptr), derivative_(nullptr),
+  mappingHelper_()
+{
+  value_.setZero();
+}
+
+Variable::Variable(Variable * var)
+: space_(var->space_), value_(var->space_.tSize()), derivativeNumber_(var->derivativeNumber_ + 1), primitive_(var),
+  derivative_(nullptr), mappingHelper_()
+{
+  std::stringstream ss;
+  if(derivativeNumber_ == 1)
   {
-    return name_;
+    ss << "d " << basePrimitive()->name_ << " / dt";
   }
-
-  int Variable::size() const
+  else
   {
-    return static_cast<int>(value_.size());
+    ss << "d" << derivativeNumber_ << " " << basePrimitive()->name_ << " / dt" << derivativeNumber_;
   }
+  name_ = ss.str();
+  value_.setZero();
+}
 
-  const Space & Variable::space() const
-  {
-    return space_;
-  }
-
-  bool Variable::isEuclidean() const
-  {
-    return space_.isEuclidean() || !isBasePrimitive();
-  }
-
-  const Eigen::VectorXd & Variable::value() const
-  {
-    return value_;
-  }
-
-  void Variable::value(const VectorConstRef& x)
-  {
-    if (x.size() == size())
-      value_ = x;
-    else
-      throw std::runtime_error("x has not the correct size.");
-  }
-
-  void Variable::setZero()
-  {
-    value_.setZero();
-  }
-
-  int Variable::derivativeNumber() const
-  {
-    return derivativeNumber_;
-  }
-
-  bool Variable::isDerivativeOf(const Variable & v) const
-  {
-    return basePrimitive() == v.basePrimitive() && derivativeNumber_ > v.derivativeNumber();
-  }
-
-  bool Variable::isPrimitiveOf(const Variable & v) const
-  {
-    return basePrimitive() == v.basePrimitive() && derivativeNumber_ < v.derivativeNumber();
-  }
-
-  bool Variable::isBasePrimitive() const
-  {
-    return derivativeNumber_ == 0;
-  }
-
-  VariablePtr Variable::basePrimitive() const
-  {
-    if (isBasePrimitive())
-    {
-      // while it does not seem ideal to cast the constness away, it is coherent
-      // with the general case: from a const derived variable, we can get a non
-      // const primitive. This is equivalent to have primitive_ be a shared_ptr
-      // to this in the case of a base primitive, what we can obviously not do.
-      return const_cast<Variable*>(this)->shared_from_this();
-    }
-    else
-    {
-      const Variable* ptr = this;
-      for (int i = 0; i < derivativeNumber_ - 1; ++i)
-        ptr = ptr->primitive_;
-
-      return ptr->primitive_->shared_from_this();
-    }
-  }
-
-  Range Variable::getMappingIn(const VariableVector& variables) const
-  {
-    if (mappingHelper_.stamp == variables.stamp())
-      return{ mappingHelper_.start, size() };
-    else
-    {
-      if (variables.contains(*this))
-      {
-        variables.computeMapping();
-        return{ mappingHelper_.start, size() };
-      }
-      else
-        throw std::runtime_error("This variable is not part of the vector of variables.");
-    }
-  }
-
-  Variable::Variable(const Space & s, const std::string & name)
-    : name_(name)
-    , space_(s)
-    , value_(s.rSize())
-    , derivativeNumber_(0)
-    , primitive_(nullptr)
-    , derivative_(nullptr)
-    , mappingHelper_()
-  {
-    value_.setZero();
-  }
-
-  Variable::Variable(Variable* var)
-    : space_(var->space_)
-    , value_(var->space_.tSize())
-    , derivativeNumber_(var->derivativeNumber_ + 1)
-    , primitive_(var)
-    , derivative_(nullptr)
-    , mappingHelper_()
-  {
-    std::stringstream ss;
-    if (derivativeNumber_ == 1)
-    {
-      ss << "d " << basePrimitive()->name_ << " / dt";
-    }
-    else
-    {
-      ss << "d" << derivativeNumber_ << " " << basePrimitive()->name_ << " / dt" << derivativeNumber_;
-    }
-    name_ = ss.str();
-    value_.setZero();
-  }
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Variable.h>
 

--- a/src/VariableVector.cpp
+++ b/src/VariableVector.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/VariableVector.h>
 
@@ -33,206 +33,185 @@
 
 namespace tvm
 {
-  int VariableVector::counter = 0;
+int VariableVector::counter = 0;
 
-  VariableVector::VariableVector()
-    : size_(0)
+VariableVector::VariableVector() : size_(0) { getNewStamp(); }
+
+bool VariableVector::add(VariablePtr v)
+{
+  if(contains(*v.get()))
   {
-    getNewStamp();
+    return false;
   }
+  add_(v);
+  return true;
+}
 
-  bool VariableVector::add(VariablePtr v)
+bool VariableVector::add(std::unique_ptr<Variable> v) { return add(VariablePtr(std::move(v))); }
+
+void VariableVector::add(const std::vector<VariablePtr> & variables)
+{
+  for(auto & v : variables)
+    add(v);
+}
+
+void VariableVector::add(const VariableVector & variables) { add(variables.variables()); }
+
+int VariableVector::addAndGetIndex(VariablePtr v)
+{
+  auto it =
+      find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) { return (it.get() == v.get()); });
+  if(it == variables_.end())
   {
-    if (contains(*v.get()))
-    {
-      return false;
-    }
     add_(v);
-    return true;
+    return static_cast<int>(variables_.size() - 1);
   }
-
-  bool VariableVector::add(std::unique_ptr<Variable> v)
+  else
   {
-    return add(VariablePtr(std::move(v)));
+    return static_cast<int>(it - variables_.begin());
   }
+}
 
-
-  void VariableVector::add(const std::vector<VariablePtr>& variables)
+bool VariableVector::remove(const Variable & v)
+{
+  if(!contains(v))
   {
-    for (auto& v : variables)
-      add(v);
+    return false;
   }
+  auto it =
+      std::find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) { return (it.get() == &v); });
+  remove_(it);
+  return true;
+}
 
-  void VariableVector::add(const VariableVector& variables)
+void VariableVector::remove(int i)
+{
+  if(i < 0 || i >= static_cast<int>(variables_.size()))
   {
-    add(variables.variables());
+    throw std::out_of_range("[VariableVector::remove] Invalid index.");
   }
 
-  int VariableVector::addAndGetIndex(VariablePtr v)
+  auto it = variables_.begin() + i;
+  remove_(it);
+}
+
+int VariableVector::totalSize() const { return size_; }
+
+int VariableVector::numberOfVariables() const { return static_cast<int>(variables_.size()); }
+
+const VariablePtr VariableVector::operator[](int i) const
+{
+  assert(i >= 0 && i < numberOfVariables());
+  return variables_[i];
+}
+
+const std::vector<VariablePtr> & VariableVector::variables() const { return variables_; }
+
+const Eigen::VectorXd & VariableVector::value() const
+{
+  value_.resize(size_);
+  int n = 0;
+  for(const auto & v : variables_)
   {
-    auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr& it) {return (it.get() == v.get()); });
-    if (it == variables_.end())
-    {
-      add_(v);
-      return static_cast<int>(variables_.size() - 1);
-    }
-    else
-    {
-      return static_cast<int>(it - variables_.begin());
-    }
+    int s = v->size();
+    value_.segment(n, s) = v->value();
+    n += s;
   }
+  return value_;
+}
 
-  bool VariableVector::remove(const Variable& v)
+void VariableVector::value(const VectorConstRef & val)
+{
+  assert(val.size() == totalSize());
+  int n = 0;
+  for(const auto & v : variables_)
   {
-    if (!contains(v))
-    {
-      return false;
-    }
-    auto it = std::find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr& it) {return (it.get() == &v); });
-    remove_(it);
-    return true;
+    int s = v->size();
+    v->value(val.segment(n, s));
+    n += s;
   }
+}
 
-  void VariableVector::remove(int i)
+void VariableVector::setZero()
+{
+  for(auto & v : variables_)
   {
-    if (i < 0 || i >= static_cast<int>(variables_.size()))
-    {
-      throw std::out_of_range("[VariableVector::remove] Invalid index.");
-    }
-
-    auto it = variables_.begin() + i;
-    remove_(it);
+    v->setZero();
   }
+}
 
-  int VariableVector::totalSize() const
+void VariableVector::computeMapping() const
+{
+  int size = 0;
+  for(const auto & v : variables_)
   {
-    return size_;
+    v->mappingHelper_.start = size;
+    v->mappingHelper_.stamp = stamp_;
+    size += v->size();
   }
+}
 
-  int VariableVector::numberOfVariables() const
+std::map<const Variable *, Range> VariableVector::computeMappingMap() const
+{
+  computeMapping();
+  std::map<const Variable *, Range> m;
+  for(const auto & v : variables_)
   {
-    return static_cast<int>(variables_.size());
+    m[v.get()] = {v->mappingHelper_.start, v->size()};
   }
 
-  const VariablePtr VariableVector::operator[](int i) const
+  return m;
+}
+
+bool VariableVector::contains(const Variable & v) const
+{
+  auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) { return (it.get() == &v); });
+  return it != variables_.end();
+}
+
+int VariableVector::indexOf(const Variable & v) const
+{
+  auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) { return (it.get() == &v); });
+  if(it == variables_.end())
   {
-    assert(i >= 0 && i < numberOfVariables());
-    return variables_[i];
+    return -1;
   }
-
-  const std::vector<VariablePtr>& VariableVector::variables() const
+  else
   {
-    return variables_;
+    return static_cast<int>(it - variables_.begin());
   }
+}
 
-  const Eigen::VectorXd& VariableVector::value() const
+int VariableVector::stamp() const { return stamp_; }
+
+void VariableVector::add_(VariablePtr v)
+{
+  variables_.push_back(v);
+  size_ += v->size();
+  getNewStamp();
+}
+
+void VariableVector::remove_(std::vector<VariablePtr>::const_iterator it)
+{
+  size_ -= (*it)->size();
+  variables_.erase(it);
+  getNewStamp();
+}
+
+void VariableVector::getNewStamp() const
+{
+  stamp_ = counter;
+  counter++;
+}
+
+VariableVector TVM_DLLAPI dot(const VariableVector & vars, int ndiff)
+{
+  VariableVector dv;
+  const auto & vv = vars.variables();
+  for(const auto & v : vv)
   {
-    value_.resize(size_);
-    int n = 0;
-    for (const auto& v : variables_)
-    {
-      int s = v->size();
-      value_.segment(n, s) = v->value();
-      n += s;
-    }
-    return value_;
+    dv.add(dot(v, ndiff));
   }
-
-  void VariableVector::value(const VectorConstRef& val)
-  {
-    assert(val.size() == totalSize());
-    int n = 0;
-    for (const auto& v : variables_)
-    {
-      int s = v->size();
-      v->value(val.segment(n, s));
-      n += s;
-    }
-  }
-
-  void VariableVector::setZero()
-  {
-    for (auto& v : variables_)
-    {
-      v->setZero();
-    }
-  }
-
-  void VariableVector::computeMapping() const
-  {
-    int size = 0;
-    for (const auto& v : variables_)
-    {
-      v->mappingHelper_.start = size;
-      v->mappingHelper_.stamp = stamp_;
-      size += v->size();
-    }
-  }
-
-  std::map<const Variable*, Range> VariableVector::computeMappingMap() const
-  {
-    computeMapping();
-    std::map<const Variable*, Range> m;
-    for (const auto& v : variables_)
-    {
-      m[v.get()] = { v->mappingHelper_.start, v->size() };
-    }
-
-    return m;
-  }
-
-  bool VariableVector::contains(const Variable& v) const
-  {
-    auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr& it) {return (it.get() == &v); });
-    return it != variables_.end();
-  }
-
-  int VariableVector::indexOf(const Variable & v) const
-  {
-    auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr& it) {return (it.get() == &v); });
-    if (it == variables_.end())
-    {
-      return -1;
-    }
-    else
-    {
-      return static_cast<int>(it - variables_.begin());
-    }
-  }
-
-  int VariableVector::stamp() const
-  {
-    return stamp_;
-  }
-
-  void VariableVector::add_(VariablePtr v)
-  {
-    variables_.push_back(v);
-    size_ += v->size();
-    getNewStamp();
-  }
-
-  void VariableVector::remove_(std::vector<VariablePtr>::const_iterator it)
-  {
-    size_ -= (*it)->size();
-    variables_.erase(it);
-    getNewStamp();
-  }
-
-  void VariableVector::getNewStamp() const
-  {
-    stamp_ = counter;
-    counter++;
-  }
-
-  VariableVector TVM_DLLAPI dot(const VariableVector& vars, int ndiff)
-  {
-    VariableVector dv;
-    const auto& vv = vars.variables();
-    for (const auto& v : vv)
-    {
-      dv.add(dot(v, ndiff));
-    }
-    return dv;
-  }
-}  // namespace tvm
+  return dv;
+}
+} // namespace tvm

--- a/src/VariableVector.cpp
+++ b/src/VariableVector.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/VariableVector.h>
 

--- a/src/constraint/BasicLinearConstraint.cpp
+++ b/src/constraint/BasicLinearConstraint.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/constraint/BasicLinearConstraint.h>
 
@@ -37,189 +37,212 @@ namespace tvm
 namespace constraint
 {
 
-  BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef& A, VariablePtr x, Type ct)
-    : BasicLinearConstraint(std::vector<MatrixConstRef>{ A }, { x }, ct)
+BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef & A, VariablePtr x, Type ct)
+: BasicLinearConstraint(std::vector<MatrixConstRef>{A}, {x}, ct)
+{
+}
+
+BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
+                                             const std::vector<VariablePtr> & x,
+                                             Type ct)
+: LinearConstraint(ct, RHS::ZERO, static_cast<int>(A.begin()->rows()))
+{
+  if(ct == Type::DOUBLE_SIDED)
+    throw std::runtime_error("This constructor is only for single-sided constraints.");
+  if(A.size() != x.size())
+    throw std::runtime_error("The number of matrices and variables is incoherent.");
+  auto v = x.begin();
+  for(const Eigen::MatrixXd & a : A)
   {
+    add(a, *v);
+    ++v;
+  }
+}
+
+BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef & A,
+                                             VariablePtr x,
+                                             const VectorConstRef & b,
+                                             Type ct,
+                                             RHS cr)
+: BasicLinearConstraint(std::vector<MatrixConstRef>{A}, {x}, b, ct, cr)
+{
+}
+
+BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
+                                             const std::vector<VariablePtr> & x,
+                                             const VectorConstRef & b,
+                                             Type ct,
+                                             RHS cr)
+: LinearConstraint(ct, cr, static_cast<int>(A.begin()->rows()))
+{
+  if(ct == Type::DOUBLE_SIDED)
+    throw std::runtime_error("This constructor is only for single-sided constraints.");
+  if(cr == RHS::ZERO)
+    throw std::runtime_error("RHS::ZERO is not a valid input for this constructor. Please use the constructor for "
+                             "Ax=0, Ax<=0 and Ax>=0 instead.");
+  if(A.size() != x.size())
+    throw std::runtime_error("The number of matrices and variables is incoherent.");
+  if(b.size() != size())
+    throw std::runtime_error("Vector b doesn't have the good size.");
+
+  auto v = x.begin();
+  for(const Eigen::MatrixXd & a : A)
+  {
+    add(a, *v);
+    ++v;
+  }
+  this->b(b);
+}
+
+BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef & A,
+                                             VariablePtr x,
+                                             const VectorConstRef & l,
+                                             const VectorConstRef & u,
+                                             RHS cr)
+: BasicLinearConstraint(std::vector<MatrixConstRef>{A}, {x}, l, u, cr)
+{
+}
+
+BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
+                                             const std::vector<VariablePtr> & x,
+                                             const VectorConstRef & l,
+                                             const VectorConstRef & u,
+                                             RHS cr)
+: LinearConstraint(Type::DOUBLE_SIDED, cr, static_cast<int>(A.begin()->rows()))
+{
+  if(cr == RHS::ZERO)
+    throw std::runtime_error("RHS::ZERO is not a valid input for this constructor. Please use the constructor for "
+                             "Ax=0, Ax<=0 and Ax>=0 instead.");
+  if(A.size() != x.size())
+    throw std::runtime_error("The number of matrices and variables is incoherent.");
+  if(l.size() != size())
+    throw std::runtime_error("Vector l doesn't have the good size.");
+  if(u.size() != size())
+    throw std::runtime_error("Vector u doesn't have the good size.");
+
+  auto v = x.begin();
+  for(const Eigen::MatrixXd & a : A)
+  {
+    add(a, *v);
+    ++v;
   }
 
-  BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x, Type ct)
-    : LinearConstraint(ct, RHS::ZERO, static_cast<int>(A.begin()->rows()))
+  this->l(l);
+  this->u(u);
+}
+
+BasicLinearConstraint::BasicLinearConstraint(int m, VariablePtr x, Type ct, RHS cr) : LinearConstraint(ct, cr, m)
+{
+  addVariable(x, true);
+}
+
+BasicLinearConstraint::BasicLinearConstraint(int m, std::vector<VariablePtr> & x, Type ct, RHS cr)
+: LinearConstraint(ct, cr, m)
+{
+  for(const auto & v : x)
   {
-    if (ct == Type::DOUBLE_SIDED)
-      throw std::runtime_error("This constructor is only for single-sided constraints.");
-    if (A.size() != x.size())
-      throw std::runtime_error("The number of matrices and variables is incoherent.");
-    auto v = x.begin();
-    for (const Eigen::MatrixXd& a : A)
+    addVariable(v, true);
+  }
+}
+
+void BasicLinearConstraint::A(const MatrixConstRef & A, const Variable & x, const tvm::internal::MatrixProperties & p)
+{
+  if(A.rows() == size() && A.cols() == x.size())
+  {
+    jacobian_.at(&x) = A;
+    jacobian_.at(&x).properties(p);
+  }
+  else
+    throw std::runtime_error("Matrix A doesn't have the good size.");
+}
+
+void BasicLinearConstraint::A(const MatrixConstRef & A, const tvm::internal::MatrixProperties & p)
+{
+  if(variables().numberOfVariables() == 1)
+  {
+    this->A(A, *variables()[0].get(), p);
+  }
+  else
+    throw std::runtime_error("You can use this method only for constraints with one variable.");
+}
+
+void BasicLinearConstraint::b(const VectorConstRef & b)
+{
+  if(type() != Type::DOUBLE_SIDED && rhs() != RHS::ZERO)
+  {
+    if(b.size() == size())
     {
-      add(a, *v);
-      ++v;
-    }
-  }
-
-  BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef& A, VariablePtr x, const VectorConstRef& b, Type ct, RHS cr)
-    : BasicLinearConstraint(std::vector<MatrixConstRef>{ A }, { x }, b, ct, cr)
-  {
-  }
-
-  BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x, const VectorConstRef& b, Type ct, RHS cr)
-    : LinearConstraint(ct, cr, static_cast<int>(A.begin()->rows()))
-  {
-    if (ct == Type::DOUBLE_SIDED)
-      throw std::runtime_error("This constructor is only for single-sided constraints.");
-    if (cr == RHS::ZERO)
-      throw std::runtime_error("RHS::ZERO is not a valid input for this constructor. Please use the constructor for Ax=0, Ax<=0 and Ax>=0 instead.");
-    if (A.size() != x.size())
-      throw std::runtime_error("The number of matrices and variables is incoherent.");
-    if (b.size() != size())
-      throw std::runtime_error("Vector b doesn't have the good size.");
-
-    auto v = x.begin();
-    for (const Eigen::MatrixXd& a : A)
-    {
-      add(a, *v);
-      ++v;
-    }
-    this->b(b);
-  }
-
-  BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef& A, VariablePtr x,
-                                               const VectorConstRef& l, const VectorConstRef& u, RHS cr)
-    :BasicLinearConstraint(std::vector<MatrixConstRef>{ A }, { x }, l, u, cr)
-  {
-  }
-
-  BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x,
-                                               const VectorConstRef& l, const VectorConstRef& u, RHS cr)
-    : LinearConstraint(Type::DOUBLE_SIDED, cr, static_cast<int>(A.begin()->rows()))
-  {
-    if (cr == RHS::ZERO)
-      throw std::runtime_error("RHS::ZERO is not a valid input for this constructor. Please use the constructor for Ax=0, Ax<=0 and Ax>=0 instead.");
-    if (A.size() != x.size())
-      throw std::runtime_error("The number of matrices and variables is incoherent.");
-    if (l.size() != size())
-      throw std::runtime_error("Vector l doesn't have the good size.");
-    if (u.size() != size())
-      throw std::runtime_error("Vector u doesn't have the good size.");
-
-    auto v = x.begin();
-    for (const Eigen::MatrixXd& a : A)
-    {
-      add(a, *v);
-      ++v;
-    }
-
-    this->l(l);
-    this->u(u);
-  }
-
-  BasicLinearConstraint::BasicLinearConstraint(int m, VariablePtr x, Type ct, RHS cr) 
-    : LinearConstraint(ct, cr, m)
-  {
-    addVariable(x, true);
-  }
-
-  BasicLinearConstraint::BasicLinearConstraint(int m, std::vector<VariablePtr>& x, Type ct, RHS cr)
-    : LinearConstraint(ct, cr, m)
-  {
-    for (const auto& v : x)
-    {
-      addVariable(v, true);
-    }
-  }
-
-  void BasicLinearConstraint::A(const MatrixConstRef& A, const Variable& x,
-                                const tvm::internal::MatrixProperties& p)
-  {
-    if (A.rows() == size() && A.cols() == x.size())
-    {
-      jacobian_.at(&x) = A;
-      jacobian_.at(&x).properties(p);
-    }
-    else
-      throw std::runtime_error("Matrix A doesn't have the good size.");
-  }
-
-  void BasicLinearConstraint::A(const MatrixConstRef& A, const tvm::internal::MatrixProperties& p)
-  {
-    if (variables().numberOfVariables() == 1)
-    {
-      this->A(A, *variables()[0].get(), p);
-    }
-    else
-      throw std::runtime_error("You can use this method only for constraints with one variable.");
-  }
-
-  void BasicLinearConstraint::b(const VectorConstRef& b)
-  {
-    if (type() != Type::DOUBLE_SIDED && rhs() != RHS::ZERO)
-    {
-      if (b.size() == size())
+      switch(type())
       {
-        switch (type())
-        {
-        case Type::EQUAL: eRef() = b; break;
-        case Type::GREATER_THAN: lRef() = b; break;
-        case Type::LOWER_THAN: uRef() = b; break;
-        default: break;
-        }
-      }
-      else
-        throw std::runtime_error("Vector b doesn't have the correct size.");
-    }
-    else
-      throw std::runtime_error("setb is not allowed for this constraint.");
-  }
-
-  void BasicLinearConstraint::l(const VectorConstRef& l)
-  {
-    if (type() == Type::DOUBLE_SIDED && rhs() != RHS::ZERO)
-    {
-      if (l.size() == size())
-      {
-        lRef() = l;
-      }
-      else
-      {
-        throw std::runtime_error("Vector l doesn't have the correct size.");
-      }
-    }
-    else
-    {
-      throw std::runtime_error("setl is not allowed for this constraint.");
-    }
-  }
-
-  void BasicLinearConstraint::u(const VectorConstRef& u)
-  {
-    if (type() == Type::DOUBLE_SIDED && rhs() != RHS::ZERO)
-    {
-      if (u.size() == size())
-      {
-        uRef() = u;
-      }
-      else
-      {
-        throw std::runtime_error("Vector u doesn't have the correct size.");
+        case Type::EQUAL:
+          eRef() = b;
+          break;
+        case Type::GREATER_THAN:
+          lRef() = b;
+          break;
+        case Type::LOWER_THAN:
+          uRef() = b;
+          break;
+        default:
+          break;
       }
     }
     else
-      throw std::runtime_error("setu is not allowed for this constraint.");
+      throw std::runtime_error("Vector b doesn't have the correct size.");
   }
+  else
+    throw std::runtime_error("setb is not allowed for this constraint.");
+}
 
-  void BasicLinearConstraint::add(const Eigen::MatrixXd& A, VariablePtr x)
+void BasicLinearConstraint::l(const VectorConstRef & l)
+{
+  if(type() == Type::DOUBLE_SIDED && rhs() != RHS::ZERO)
   {
-    if (!x->space().isEuclidean() && x->isBasePrimitive())
-      throw std::runtime_error("We allow linear constraint only on Euclidean variables.");
-    if (A.rows() != size())
-      throw std::runtime_error("Matrix A doesn't have coherent row size.");
-    if (A.cols() != x->size())
-      throw std::runtime_error("Matrix A doesn't have its column size coherent with its corresponding variable.");
-    addVariable(x, true);
-    jacobian_.at(x.get()) = A;
-    jacobian_.at(x.get()).properties({ tvm::internal::MatrixProperties::Constness(true) });
+    if(l.size() == size())
+    {
+      lRef() = l;
+    }
+    else
+    {
+      throw std::runtime_error("Vector l doesn't have the correct size.");
+    }
   }
+  else
+  {
+    throw std::runtime_error("setl is not allowed for this constraint.");
+  }
+}
 
-}  // namespace constraint
+void BasicLinearConstraint::u(const VectorConstRef & u)
+{
+  if(type() == Type::DOUBLE_SIDED && rhs() != RHS::ZERO)
+  {
+    if(u.size() == size())
+    {
+      uRef() = u;
+    }
+    else
+    {
+      throw std::runtime_error("Vector u doesn't have the correct size.");
+    }
+  }
+  else
+    throw std::runtime_error("setu is not allowed for this constraint.");
+}
 
-}  // namespace tvm
+void BasicLinearConstraint::add(const Eigen::MatrixXd & A, VariablePtr x)
+{
+  if(!x->space().isEuclidean() && x->isBasePrimitive())
+    throw std::runtime_error("We allow linear constraint only on Euclidean variables.");
+  if(A.rows() != size())
+    throw std::runtime_error("Matrix A doesn't have coherent row size.");
+  if(A.cols() != x->size())
+    throw std::runtime_error("Matrix A doesn't have its column size coherent with its corresponding variable.");
+  addVariable(x, true);
+  jacobian_.at(x.get()) = A;
+  jacobian_.at(x.get()).properties({tvm::internal::MatrixProperties::Constness(true)});
+}
+
+} // namespace constraint
+
+} // namespace tvm

--- a/src/constraint/BasicLinearConstraint.cpp
+++ b/src/constraint/BasicLinearConstraint.cpp
@@ -12,8 +12,7 @@ namespace constraint
 
 BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef & A, VariablePtr x, Type ct)
 : BasicLinearConstraint(std::vector<MatrixConstRef>{A}, {x}, ct)
-{
-}
+{}
 
 BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
                                              const std::vector<VariablePtr> & x,
@@ -38,8 +37,7 @@ BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef & A,
                                              Type ct,
                                              RHS cr)
 : BasicLinearConstraint(std::vector<MatrixConstRef>{A}, {x}, b, ct, cr)
-{
-}
+{}
 
 BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
                                              const std::vector<VariablePtr> & x,
@@ -73,8 +71,7 @@ BasicLinearConstraint::BasicLinearConstraint(const MatrixConstRef & A,
                                              const VectorConstRef & u,
                                              RHS cr)
 : BasicLinearConstraint(std::vector<MatrixConstRef>{A}, {x}, l, u, cr)
-{
-}
+{}
 
 BasicLinearConstraint::BasicLinearConstraint(const std::vector<MatrixConstRef> & A,
                                              const std::vector<VariablePtr> & x,

--- a/src/constraint/BasicLinearConstraint.cpp
+++ b/src/constraint/BasicLinearConstraint.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/constraint/BasicLinearConstraint.h>
 

--- a/src/constraint/Constraint.cpp
+++ b/src/constraint/Constraint.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/constraint/abstract/Constraint.h>
 
@@ -40,49 +40,39 @@ namespace constraint
 namespace abstract
 {
 
-  Constraint::Constraint(Type ct, RHS cr, int m)
-    : graph::abstract::OutputSelector<Constraint, tvm::internal::FirstOrderProvider>(m)
-    , vectors_(ct, cr)
-    , cstrType_(ct)
-    , constraintRhs_(cr)
-  {
-    if (ct == Type::DOUBLE_SIDED && cr == RHS::ZERO)
-      throw std::runtime_error("The combination (ConstraintType::DOUBLE_SIDED, ConstraintRHS::ZERO) is forbidden. Please use (ConstraintType::EQUAL, ConstraintRHS::ZERO) instead.");
-    //FIXME: we make the choice here to have no "rhs" output when the ConstraintRHS is zero.
-    //An alternative is to use and set to zero the relevant vectors, but then we need
-    //to prevent a derived class to change their value.
-    resizeCache();
-    if (!vectors_.use_l())
-      disableOutput(Output::L);
-    if (!vectors_.use_u())
-      disableOutput(Output::U);
-    if (!vectors_.use_e())
-      disableOutput(Output::E);
-  }
+Constraint::Constraint(Type ct, RHS cr, int m)
+: graph::abstract::OutputSelector<Constraint, tvm::internal::FirstOrderProvider>(m), vectors_(ct, cr), cstrType_(ct),
+  constraintRhs_(cr)
+{
+  if(ct == Type::DOUBLE_SIDED && cr == RHS::ZERO)
+    throw std::runtime_error("The combination (ConstraintType::DOUBLE_SIDED, ConstraintRHS::ZERO) is forbidden. Please "
+                             "use (ConstraintType::EQUAL, ConstraintRHS::ZERO) instead.");
+  // FIXME: we make the choice here to have no "rhs" output when the ConstraintRHS is zero.
+  // An alternative is to use and set to zero the relevant vectors, but then we need
+  // to prevent a derived class to change their value.
+  resizeCache();
+  if(!vectors_.use_l())
+    disableOutput(Output::L);
+  if(!vectors_.use_u())
+    disableOutput(Output::U);
+  if(!vectors_.use_e())
+    disableOutput(Output::E);
+}
 
-  void Constraint::resizeCache()
-  {
-    tvm::internal::FirstOrderProvider::resizeCache();
-    vectors_.resize(size());
-  }
+void Constraint::resizeCache()
+{
+  tvm::internal::FirstOrderProvider::resizeCache();
+  vectors_.resize(size());
+}
 
-  Type Constraint::type() const
-  {
-    return cstrType_;
-  }
+Type Constraint::type() const { return cstrType_; }
 
-  bool Constraint::isEquality() const
-  {
-    return cstrType_ == Type::EQUAL;
-  }
+bool Constraint::isEquality() const { return cstrType_ == Type::EQUAL; }
 
-  RHS Constraint::rhs() const
-  {
-    return constraintRhs_;
-  }
+RHS Constraint::rhs() const { return constraintRhs_; }
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace constraint
+} // namespace constraint
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/constraint/Constraint.cpp
+++ b/src/constraint/Constraint.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/constraint/abstract/Constraint.h>
 

--- a/src/constraint/LinearConstraint.cpp
+++ b/src/constraint/LinearConstraint.cpp
@@ -1,34 +1,34 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/constraint/abstract/LinearConstraint.h>
 #include <tvm/Variable.h>
+#include <tvm/constraint/abstract/LinearConstraint.h>
 
 namespace tvm
 {
@@ -39,24 +39,23 @@ namespace constraint
 namespace abstract
 {
 
-  LinearConstraint::LinearConstraint(Type ct, RHS cr, int m)
-    :Constraint(ct,cr,m)
+LinearConstraint::LinearConstraint(Type ct, RHS cr, int m) : Constraint(ct, cr, m)
+{
+  registerUpdates(LinearConstraint::Update::Value, &LinearConstraint::updateValue);
+  addOutputDependency<LinearConstraint>(FirstOrderProvider::Output::Value, LinearConstraint::Update::Value);
+}
+
+void LinearConstraint::updateValue()
+{
+  value_.setZero();
+  for(const auto & v : variables())
   {
-    registerUpdates(LinearConstraint::Update::Value,&LinearConstraint::updateValue);
-    addOutputDependency<LinearConstraint>(FirstOrderProvider::Output::Value, LinearConstraint::Update::Value);
+    value_ += jacobian(*v) * v->value();
   }
+}
 
-  void LinearConstraint::updateValue()
-  {
-    value_.setZero();
-    for (const auto & v : variables())
-    {
-      value_ += jacobian(*v) * v->value();
-    }
-  }
+} // namespace abstract
 
-}  // namespace abstract
+} // namespace constraint
 
-}  // namespace constraint
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/constraint/LinearConstraint.cpp
+++ b/src/constraint/LinearConstraint.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>

--- a/src/constraint/LinearizedTaskConstraint.cpp
+++ b/src/constraint/LinearizedTaskConstraint.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/constraint/internal/LinearizedTaskConstraint.h>
 
@@ -42,28 +42,27 @@ namespace constraint
 namespace internal
 {
 
-  LinearizedTaskConstraint::LinearizedTaskConstraint(const Task& task)
-    : LinearConstraint(task.type(), constraint::RHS::AS_GIVEN, task.function()->size())
-    , f_(task.function())
-    , td_(task.taskDynamics())
+LinearizedTaskConstraint::LinearizedTaskConstraint(const Task & task)
+: LinearConstraint(task.type(), constraint::RHS::AS_GIVEN, task.function()->size()), f_(task.function()),
+  td_(task.taskDynamics())
+{
+  assert(f_->imageSpace().isEuclidean());
+  if(type() == constraint::Type::DOUBLE_SIDED)
   {
-    assert(f_->imageSpace().isEuclidean());
-    if (type() == constraint::Type::DOUBLE_SIDED)
+    td2_ = task.secondBoundTaskDynamics();
+    if(td_->order() != td2_->order())
     {
-      td2_ = task.secondBoundTaskDynamics();
-      if (td_->order() != td2_->order())
-      {
-        throw std::runtime_error("For double-sided task, the dynamic of both sides must have the same order.");
-      }
+      throw std::runtime_error("For double-sided task, the dynamic of both sides must have the same order.");
     }
+  }
 
-    using LTC = LinearizedTaskConstraint;
-    Constraint::Output_ output;
-    void (LTC::*kin)();
-    void (LTC::*dyn)();
+  using LTC = LinearizedTaskConstraint;
+  Constraint::Output_ output;
+  void (LTC::*kin)();
+  void (LTC::*dyn)();
 
-    switch (task.type())
-    {
+  switch(task.type())
+  {
     case constraint::Type::GREATER_THAN:
       output = Constraint::Output::L;
       kin = &LTC::updateLKin;
@@ -87,15 +86,15 @@ namespace internal
     default:
       assert(false);
       break;
-    }
+  }
 
-    switch (td_->order())
-    {
+  switch(td_->order())
+  {
     case task_dynamics::Order::Zero:
     {
-      for (auto& v : f_->variables())
+      for(auto & v : f_->variables())
       {
-        if (!f_->linearIn(*v))
+        if(!f_->linearIn(*v))
           throw std::runtime_error("The function is not linear in " + v->name());
         addVariable(v, true);
       }
@@ -104,115 +103,97 @@ namespace internal
     break;
     case task_dynamics::Order::One:
     {
-      for (auto& v : f_->variables())
+      for(auto & v : f_->variables())
         addVariable(dot(v), true);
       registerUpdates(Update::UpdateRHS, kin);
     }
     break;
     case task_dynamics::Order::Two:
     {
-      for (auto& v : f_->variables())
+      for(auto & v : f_->variables())
         addVariable(dot(v, 2), true);
       registerUpdates(Update::UpdateRHS, dyn);
       addInputDependency<LTC>(Update::UpdateRHS, f_, function::abstract::Function::Output::NormalAcceleration);
     }
     break;
-    }
+  }
 
-    using BaseOutput = tvm::internal::FirstOrderProvider::Output;
-    addInputDependency<LTC>(Update::UpdateRHS, td_, task_dynamics::abstract::TaskDynamicsImpl::Output::Value);
-    addInputDependency<LinearConstraint>(LinearConstraint::Update::Value, f_, BaseOutput::Jacobian);
+  using BaseOutput = tvm::internal::FirstOrderProvider::Output;
+  addInputDependency<LTC>(Update::UpdateRHS, td_, task_dynamics::abstract::TaskDynamicsImpl::Output::Value);
+  addInputDependency<LinearConstraint>(LinearConstraint::Update::Value, f_, BaseOutput::Jacobian);
 #ifndef WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wpragmas"
-# pragma GCC diagnostic ignored "-Wunknown-warning-option"
-# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpragmas"
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
-    addOutputDependency<LTC>(output, Update::UpdateRHS);
+  addOutputDependency<LTC>(output, Update::UpdateRHS);
 #ifndef WIN32
-# pragma GCC diagnostic pop
+#  pragma GCC diagnostic pop
 #endif
-    addDirectDependency<LTC>(BaseOutput::Jacobian, f_, BaseOutput::Jacobian);
+  addDirectDependency<LTC>(BaseOutput::Jacobian, f_, BaseOutput::Jacobian);
 
-    if (type() == constraint::Type::DOUBLE_SIDED)
+  if(type() == constraint::Type::DOUBLE_SIDED)
+  {
+    if(td2_->order() == task_dynamics::Order::Two)
     {
-      if (td2_->order() == task_dynamics::Order::Two)
-      {
-        registerUpdates(Update::UpdateRHS2, &LTC::updateU2Dyn);
-        addInputDependency<LTC>(Update::UpdateRHS2, f_, function::abstract::Function::Output::NormalAcceleration);
-      }
-      else
-      {
-        registerUpdates(Update::UpdateRHS2, &LTC::updateU2Kin);
-      }
-      addInputDependency<LTC>(Update::UpdateRHS2, td2_, task_dynamics::abstract::TaskDynamicsImpl::Output::Value);
-#ifndef WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wpragmas"
-# pragma GCC diagnostic ignored "-Wunknown-warning-option"
-# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-      addOutputDependency<LTC>(Constraint::Output::U, Update::UpdateRHS2);
-#ifndef WIN32
-# pragma GCC diagnostic pop
-#endif
+      registerUpdates(Update::UpdateRHS2, &LTC::updateU2Dyn);
+      addInputDependency<LTC>(Update::UpdateRHS2, f_, function::abstract::Function::Output::NormalAcceleration);
     }
-  }
-
-  void LinearizedTaskConstraint::updateLKin()
-  {
-    lRef() = td_->value();
-  }
-
-  void LinearizedTaskConstraint::updateLDyn()
-  {
-    lRef() = td_->value() - f_->normalAcceleration();
-  }
-
-  void LinearizedTaskConstraint::updateUKin()
-  {
-    uRef() = td_->value();
-  }
-
-  void LinearizedTaskConstraint::updateUDyn()
-  {
-    uRef() = td_->value() - f_->normalAcceleration();
-  }
-
-  void LinearizedTaskConstraint::updateEKin()
-  {
-    eRef() = td_->value();
-  }
-
-  void LinearizedTaskConstraint::updateEDyn()
-  {
-    eRef() = td_->value() - f_->normalAcceleration();
-  }
-
-  void LinearizedTaskConstraint::updateU2Kin()
-  {
-    uRef() = td2_->value();
-  }
-
-  void LinearizedTaskConstraint::updateU2Dyn()
-  {
-    uRef() = td2_->value() - f_->normalAcceleration();
-  }
-
-  const tvm::internal::MatrixWithProperties& LinearizedTaskConstraint::jacobian(const Variable& x) const
-  {
-    switch (td_->order())
+    else
     {
-    case task_dynamics::Order::Zero: return f_->jacobian(x); break;
-    case task_dynamics::Order::One: return f_->jacobian(*x.primitive()); break;
-    case task_dynamics::Order::Two: return f_->jacobian(*x.primitive<2>()); break;
+      registerUpdates(Update::UpdateRHS2, &LTC::updateU2Kin);
+    }
+    addInputDependency<LTC>(Update::UpdateRHS2, td2_, task_dynamics::abstract::TaskDynamicsImpl::Output::Value);
+#ifndef WIN32
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpragmas"
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    addOutputDependency<LTC>(Constraint::Output::U, Update::UpdateRHS2);
+#ifndef WIN32
+#  pragma GCC diagnostic pop
+#endif
+  }
+}
+
+void LinearizedTaskConstraint::updateLKin() { lRef() = td_->value(); }
+
+void LinearizedTaskConstraint::updateLDyn() { lRef() = td_->value() - f_->normalAcceleration(); }
+
+void LinearizedTaskConstraint::updateUKin() { uRef() = td_->value(); }
+
+void LinearizedTaskConstraint::updateUDyn() { uRef() = td_->value() - f_->normalAcceleration(); }
+
+void LinearizedTaskConstraint::updateEKin() { eRef() = td_->value(); }
+
+void LinearizedTaskConstraint::updateEDyn() { eRef() = td_->value() - f_->normalAcceleration(); }
+
+void LinearizedTaskConstraint::updateU2Kin() { uRef() = td2_->value(); }
+
+void LinearizedTaskConstraint::updateU2Dyn() { uRef() = td2_->value() - f_->normalAcceleration(); }
+
+const tvm::internal::MatrixWithProperties & LinearizedTaskConstraint::jacobian(const Variable & x) const
+{
+  switch(td_->order())
+  {
+    case task_dynamics::Order::Zero:
+      return f_->jacobian(x);
+      break;
+    case task_dynamics::Order::One:
+      return f_->jacobian(*x.primitive());
+      break;
+    case task_dynamics::Order::Two:
+      return f_->jacobian(*x.primitive<2>());
+      break;
     default:
       throw std::runtime_error("Unimplemented case.");
-    }
   }
+}
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace constraint
+} // namespace constraint
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/constraint/LinearizedTaskConstraint.cpp
+++ b/src/constraint/LinearizedTaskConstraint.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/constraint/internal/LinearizedTaskConstraint.h>
 

--- a/src/constraint/LinearizedTaskConstraint.cpp
+++ b/src/constraint/LinearizedTaskConstraint.cpp
@@ -63,8 +63,7 @@ LinearizedTaskConstraint::LinearizedTaskConstraint(const Task & task)
 
   switch(td_->order())
   {
-    case task_dynamics::Order::Zero:
-    {
+    case task_dynamics::Order::Zero: {
       for(auto & v : f_->variables())
       {
         if(!f_->linearIn(*v))
@@ -74,15 +73,13 @@ LinearizedTaskConstraint::LinearizedTaskConstraint(const Task & task)
       registerUpdates(Update::UpdateRHS, kin);
     }
     break;
-    case task_dynamics::Order::One:
-    {
+    case task_dynamics::Order::One: {
       for(auto & v : f_->variables())
         addVariable(dot(v), true);
       registerUpdates(Update::UpdateRHS, kin);
     }
     break;
-    case task_dynamics::Order::Two:
-    {
+    case task_dynamics::Order::Two: {
       for(auto & v : f_->variables())
         addVariable(dot(v, 2), true);
       registerUpdates(Update::UpdateRHS, dyn);

--- a/src/constraint/RHSVectors.cpp
+++ b/src/constraint/RHSVectors.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/constraint/internal/RHSVectors.h>
 

--- a/src/constraint/RHSVectors.cpp
+++ b/src/constraint/RHSVectors.cpp
@@ -12,8 +12,7 @@ RHSVectors::RHSVectors(Type ct, RHS cr)
 : use_l_((ct == Type::GREATER_THAN || ct == Type::DOUBLE_SIDED) && cr != RHS::ZERO),
   use_u_((ct == Type::LOWER_THAN || ct == Type::DOUBLE_SIDED) && cr != RHS::ZERO),
   use_e_(ct == Type::EQUAL && cr != RHS::ZERO)
-{
-}
+{}
 
 void RHSVectors::resize(int n)
 {

--- a/src/constraint/RHSVectors.cpp
+++ b/src/constraint/RHSVectors.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/constraint/internal/RHSVectors.h>
 
@@ -35,25 +35,24 @@ namespace constraint
 {
 namespace internal
 {
-  RHSVectors::RHSVectors(Type ct, RHS cr)
-    : use_l_((ct == Type::GREATER_THAN || ct == Type::DOUBLE_SIDED) && cr != RHS::ZERO)
-    , use_u_((ct == Type::LOWER_THAN || ct == Type::DOUBLE_SIDED) && cr != RHS::ZERO)
-    , use_e_(ct == Type::EQUAL && cr != RHS::ZERO)
-  {
-
-  }
-
-  void RHSVectors::resize(int n)
-  {
-    if (use_l_)
-      l_.resize(n);
-
-    if (use_u_)
-      u_.resize(n);
-
-    if (use_e_)
-      e_.resize(n);
-  }
+RHSVectors::RHSVectors(Type ct, RHS cr)
+: use_l_((ct == Type::GREATER_THAN || ct == Type::DOUBLE_SIDED) && cr != RHS::ZERO),
+  use_u_((ct == Type::LOWER_THAN || ct == Type::DOUBLE_SIDED) && cr != RHS::ZERO),
+  use_e_(ct == Type::EQUAL && cr != RHS::ZERO)
+{
 }
+
+void RHSVectors::resize(int n)
+{
+  if(use_l_)
+    l_.resize(n);
+
+  if(use_u_)
+    u_.resize(n);
+
+  if(use_e_)
+    e_.resize(n);
 }
-}
+} // namespace internal
+} // namespace constraint
+} // namespace tvm

--- a/src/event/Listener.cpp
+++ b/src/event/Listener.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/event/Listener.h>
 
@@ -35,11 +35,8 @@ namespace tvm
 namespace event
 {
 
-  void Listener::receive(Type evt, const Source & notifier)
-  {
-    process(evt, notifier);
-  }
+void Listener::receive(Type evt, const Source & notifier) { process(evt, notifier); }
 
-}
+} // namespace event
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/event/Listener.cpp
+++ b/src/event/Listener.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/event/Listener.h>
 

--- a/src/event/Source.cpp
+++ b/src/event/Source.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/event/Source.h>
 

--- a/src/event/Source.cpp
+++ b/src/event/Source.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/event/Source.h>
 
@@ -37,18 +37,15 @@ namespace tvm
 namespace event
 {
 
-  void Source::regist(std::shared_ptr<Listener> user, Type evt)
-  {
-    registrations_[evt].push_back(user);
-  }
+void Source::regist(std::shared_ptr<Listener> user, Type evt) { registrations_[evt].push_back(user); }
 
-  void Source::notify(Type evt)
-  {
-    const auto & list = registrations_[evt];
-    for (const auto & u : list)
-      u.lock()->receive(evt, *this);
-  }
+void Source::notify(Type evt)
+{
+  const auto & list = registrations_[evt];
+  for(const auto & u : list)
+    u.lock()->receive(evt, *this);
+}
 
-}  // namespace event
+} // namespace event
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/function/BasicLinearFunction.cpp
+++ b/src/function/BasicLinearFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/function/BasicLinearFunction.h>
 
@@ -37,31 +37,32 @@ namespace tvm
 namespace function
 {
 
-BasicLinearFunction::BasicLinearFunction(const MatrixConstRef& A, VariablePtr x)
-  : BasicLinearFunction({A}, std::vector<VariablePtr>{x})
+BasicLinearFunction::BasicLinearFunction(const MatrixConstRef & A, VariablePtr x)
+: BasicLinearFunction({A}, std::vector<VariablePtr>{x})
 {
 }
 
-BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x)
-  : BasicLinearFunction(A, x, Eigen::VectorXd::Zero(A.begin()->rows()))
+BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef> & A, const std::vector<VariablePtr> & x)
+: BasicLinearFunction(A, x, Eigen::VectorXd::Zero(A.begin()->rows()))
 {
-  this->b_.properties({ tvm::internal::MatrixProperties::Constness(true),
-                       tvm::internal::MatrixProperties::ZERO });
+  this->b_.properties({tvm::internal::MatrixProperties::Constness(true), tvm::internal::MatrixProperties::ZERO});
 }
 
-BasicLinearFunction::BasicLinearFunction(const MatrixConstRef& A, VariablePtr x, const VectorConstRef& b)
-  : BasicLinearFunction({A}, std::vector<VariablePtr>{x}, b)
+BasicLinearFunction::BasicLinearFunction(const MatrixConstRef & A, VariablePtr x, const VectorConstRef & b)
+: BasicLinearFunction({A}, std::vector<VariablePtr>{x}, b)
 {
 }
 
-BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef>& A, const std::vector<VariablePtr>& x, const VectorConstRef& b)
-  : LinearFunction(static_cast<int>(A.begin()->rows()))
+BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef> & A,
+                                         const std::vector<VariablePtr> & x,
+                                         const VectorConstRef & b)
+: LinearFunction(static_cast<int>(A.begin()->rows()))
 {
-  if (A.size() != x.size())
+  if(A.size() != x.size())
     throw std::runtime_error("The number of matrices and variables is incoherent.");
 
   auto v = x.begin();
-  for (const Eigen::MatrixXd& a : A)
+  for(const Eigen::MatrixXd & a : A)
   {
     add(a, *v);
     ++v;
@@ -70,26 +71,21 @@ BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef>& A, c
   setDerivativesToZero();
 }
 
-BasicLinearFunction::BasicLinearFunction(int m, VariablePtr x)
-  : BasicLinearFunction(m, std::vector<VariablePtr>{x})
-{
-}
+BasicLinearFunction::BasicLinearFunction(int m, VariablePtr x) : BasicLinearFunction(m, std::vector<VariablePtr>{x}) {}
 
-BasicLinearFunction::BasicLinearFunction(int m, const std::vector<VariablePtr>& x)
-  : LinearFunction(m)
+BasicLinearFunction::BasicLinearFunction(int m, const std::vector<VariablePtr> & x) : LinearFunction(m)
 {
-  for (auto& v : x)
+  for(auto & v : x)
   {
     addVariable(v, true);
-    jacobian_.at(v.get()).properties({ tvm::internal::MatrixProperties::Constness(true) });
+    jacobian_.at(v.get()).properties({tvm::internal::MatrixProperties::Constness(true)});
   }
   setDerivativesToZero();
 }
 
-void BasicLinearFunction::A(const MatrixConstRef& A, const Variable& x,
-                            const tvm::internal::MatrixProperties& p)
+void BasicLinearFunction::A(const MatrixConstRef & A, const Variable & x, const tvm::internal::MatrixProperties & p)
 {
-  if (A.rows() == size() && A.cols() == x.size())
+  if(A.rows() == size() && A.cols() == x.size())
   {
     jacobian_.at(&x) = A;
     jacobian_.at(&x).properties(p);
@@ -98,17 +94,17 @@ void BasicLinearFunction::A(const MatrixConstRef& A, const Variable& x,
     throw std::runtime_error("Matrix A doesn't have the good size.");
 }
 
-void BasicLinearFunction::A(const MatrixConstRef& A, const tvm::internal::MatrixProperties& p)
+void BasicLinearFunction::A(const MatrixConstRef & A, const tvm::internal::MatrixProperties & p)
 {
-  if (variables().numberOfVariables() == 1)
+  if(variables().numberOfVariables() == 1)
     this->A(A, *variables()[0].get(), p);
   else
     throw std::runtime_error("You can use this method only for constraints with one variable.");
 }
 
-void BasicLinearFunction::b(const VectorConstRef& b, const internal::MatrixProperties& p)
+void BasicLinearFunction::b(const VectorConstRef & b, const internal::MatrixProperties & p)
 {
-  if (b.size() == size())
+  if(b.size() == size())
   {
     this->b_ = b;
     this->b_.properties(p);
@@ -117,6 +113,6 @@ void BasicLinearFunction::b(const VectorConstRef& b, const internal::MatrixPrope
     throw std::runtime_error("Vector b doesn't have the correct size.");
 }
 
-}  // namespace function
+} // namespace function
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/function/BasicLinearFunction.cpp
+++ b/src/function/BasicLinearFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/function/BasicLinearFunction.h>
 

--- a/src/function/BasicLinearFunction.cpp
+++ b/src/function/BasicLinearFunction.cpp
@@ -12,8 +12,7 @@ namespace function
 
 BasicLinearFunction::BasicLinearFunction(const MatrixConstRef & A, VariablePtr x)
 : BasicLinearFunction({A}, std::vector<VariablePtr>{x})
-{
-}
+{}
 
 BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef> & A, const std::vector<VariablePtr> & x)
 : BasicLinearFunction(A, x, Eigen::VectorXd::Zero(A.begin()->rows()))
@@ -23,8 +22,7 @@ BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef> & A, 
 
 BasicLinearFunction::BasicLinearFunction(const MatrixConstRef & A, VariablePtr x, const VectorConstRef & b)
 : BasicLinearFunction({A}, std::vector<VariablePtr>{x}, b)
-{
-}
+{}
 
 BasicLinearFunction::BasicLinearFunction(const std::vector<MatrixConstRef> & A,
                                          const std::vector<VariablePtr> & x,

--- a/src/function/Function.cpp
+++ b/src/function/Function.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/function/abstract/Function.h>
 
@@ -40,65 +40,62 @@ namespace function
 namespace abstract
 {
 
-  Function::Function(int m)
-    : Function(Space(m))
+Function::Function(int m) : Function(Space(m)) {}
+
+Function::Function(Space image) : FirstOrderProvider(std::move(image))
+{
+  resizeVelocityCache();
+  resizeNormalAccelerationCache();
+  resizeJDotCache();
+}
+
+void Function::resizeCache()
+{
+  FirstOrderProvider::resizeCache();
+  resizeVelocityCache();
+  resizeNormalAccelerationCache();
+  resizeJDotCache();
+}
+
+void Function::resizeVelocityCache()
+{
+  if(isOutputEnabled((int)Output::Velocity))
+    velocity_.resize(tSize());
+}
+
+void Function::resizeNormalAccelerationCache()
+{
+  if(isOutputEnabled((int)Output::NormalAcceleration))
+    normalAcceleration_.resize(tSize());
+}
+
+void Function::resizeJDotCache()
+{
+  if(isOutputEnabled((int)Output::JDot))
   {
+    for(auto v : variables())
+      JDot_[v.get()].resize(tSize(), v->space().tSize());
   }
+}
 
-  Function::Function(Space image)
-    : FirstOrderProvider(std::move(image))
-  {
-    resizeVelocityCache();
-    resizeNormalAccelerationCache();
-    resizeJDotCache();
-  }
+void Function::addVariable_(VariablePtr v)
+{
+  JDot_[v.get()].resize(tSize(), v->space().tSize());
+  variablesDot_.push_back(dot(v));
+}
 
-  void Function::resizeCache()
-  {
-    FirstOrderProvider::resizeCache();
-    resizeVelocityCache();
-    resizeNormalAccelerationCache();
-    resizeJDotCache();
-  }
+void Function::removeVariable_(VariablePtr v)
+{
+  JDot_.erase(v.get());
+  auto it = std::find(variablesDot_.begin(), variablesDot_.end(), dot(v));
+  assert(it != variablesDot_.end()
+         && "This should not happen: FirstOrderProvider::removeVariable would raise an exception first if the variable "
+            "was not there.");
+  variablesDot_.erase(it);
+}
 
-  void Function::resizeVelocityCache()
-  {
-    if (isOutputEnabled((int)Output::Velocity))
-      velocity_.resize(tSize());
-  }
+} // namespace abstract
 
-  void Function::resizeNormalAccelerationCache()
-  {
-    if (isOutputEnabled((int)Output::NormalAcceleration))
-      normalAcceleration_.resize(tSize());
-  }
+} // namespace function
 
-  void Function::resizeJDotCache()
-  {
-    if (isOutputEnabled((int)Output::JDot))
-    {
-      for (auto v : variables())
-        JDot_[v.get()].resize(tSize(), v->space().tSize());
-    }
-  }
-
-  void Function::addVariable_(VariablePtr v)
-  {
-    JDot_[v.get()].resize(tSize(), v->space().tSize());
-    variablesDot_.push_back(dot(v));
-  }
-
-  void Function::removeVariable_(VariablePtr v)
-  {
-    JDot_.erase(v.get());
-    auto it = std::find(variablesDot_.begin(), variablesDot_.end(), dot(v));
-    assert(it != variablesDot_.end()
-      && "This should not happen: FirstOrderProvider::removeVariable would raise an exception first if the variable was not there.");
-    variablesDot_.erase(it);
-  }
-
-}  // namespace abstract
-
-}  // namespace function
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/function/Function.cpp
+++ b/src/function/Function.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/function/abstract/Function.h>
 

--- a/src/function/IdentityFunction.cpp
+++ b/src/function/IdentityFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/function/IdentityFunction.h>
 
@@ -38,38 +38,30 @@ namespace function
 {
 
 IdentityFunction::IdentityFunction(VariablePtr x)
-  : BasicLinearFunction(Eigen::MatrixXd::Identity(x->size(), x->size()), x)
+: BasicLinearFunction(Eigen::MatrixXd::Identity(x->size(), x->size()), x)
 {
-  jacobian_.begin()->second.properties({ tvm::internal::MatrixProperties::Shape::IDENTITY });
+  jacobian_.begin()->second.properties({tvm::internal::MatrixProperties::Shape::IDENTITY});
 }
 
-void IdentityFunction::A(const MatrixConstRef&, const Variable&, 
-                         const tvm::internal::MatrixProperties&)
-{
-  throw std::runtime_error("You can not change the A matrix on a identity function");
-}
-
-void IdentityFunction::A(const MatrixConstRef&, const tvm::internal::MatrixProperties&)
+void IdentityFunction::A(const MatrixConstRef &, const Variable &, const tvm::internal::MatrixProperties &)
 {
   throw std::runtime_error("You can not change the A matrix on a identity function");
 }
 
-void IdentityFunction::b(const VectorConstRef&, const tvm::internal::MatrixProperties&)
+void IdentityFunction::A(const MatrixConstRef &, const tvm::internal::MatrixProperties &)
+{
+  throw std::runtime_error("You can not change the A matrix on a identity function");
+}
+
+void IdentityFunction::b(const VectorConstRef &, const tvm::internal::MatrixProperties &)
 {
   throw std::runtime_error("You can not change the b vector on a identity function");
 }
 
-void IdentityFunction::updateValue_()
-{
-  value_ = variables()[0]->value();
-}
+void IdentityFunction::updateValue_() { value_ = variables()[0]->value(); }
 
-void IdentityFunction::updateVelocity_()
-{
-  velocity_ = dot(variables()[0])->value();
-}
+void IdentityFunction::updateVelocity_() { velocity_ = dot(variables()[0])->value(); }
 
+} // namespace function
 
-}  // namespace function
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/function/IdentityFunction.cpp
+++ b/src/function/IdentityFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/function/IdentityFunction.h>
 

--- a/src/function/LinearFunction.cpp
+++ b/src/function/LinearFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/function/abstract/LinearFunction.h>
 
@@ -40,58 +40,51 @@ namespace function
 namespace abstract
 {
 
-  LinearFunction::LinearFunction(int m)
-    :Function(m), b_(m)
-  {
-    registerUpdates(Update::Value, &LinearFunction::updateValue);
-    registerUpdates(Update::Velocity, &LinearFunction::updateVelocity);
-    addInputDependency<LinearFunction>(Update::Value, *this, Output::Jacobian);
-    addInputDependency<LinearFunction>(Update::Value, *this, Output::B);
-    addInputDependency<LinearFunction>(Update::Velocity, *this, Output::Jacobian);
-    addOutputDependency<LinearFunction>(Output::Value, Update::Value);
-    addOutputDependency<LinearFunction>(Output::Velocity, Update::Velocity);
-  }
+LinearFunction::LinearFunction(int m) : Function(m), b_(m)
+{
+  registerUpdates(Update::Value, &LinearFunction::updateValue);
+  registerUpdates(Update::Velocity, &LinearFunction::updateVelocity);
+  addInputDependency<LinearFunction>(Update::Value, *this, Output::Jacobian);
+  addInputDependency<LinearFunction>(Update::Value, *this, Output::B);
+  addInputDependency<LinearFunction>(Update::Velocity, *this, Output::Jacobian);
+  addOutputDependency<LinearFunction>(Output::Value, Update::Value);
+  addOutputDependency<LinearFunction>(Output::Velocity, Update::Velocity);
+}
 
-  void LinearFunction::updateValue()
-  {
-    updateValue_();
-  }
+void LinearFunction::updateValue() { updateValue_(); }
 
-  void LinearFunction::updateVelocity()
-  {
-    updateVelocity_();
-  }
+void LinearFunction::updateVelocity() { updateVelocity_(); }
 
-  void LinearFunction::resizeCache()
-  {
-    Function::resizeCache();
-    b_.resize(size());
-    setDerivativesToZero();
-  }
+void LinearFunction::resizeCache()
+{
+  Function::resizeCache();
+  b_.resize(size());
+  setDerivativesToZero();
+}
 
-  void LinearFunction::updateValue_()
-  {
-    value_ = b_;
-    for (auto v : variables())
-      value_ += jacobian(*v) * v->value();
-  }
+void LinearFunction::updateValue_()
+{
+  value_ = b_;
+  for(auto v : variables())
+    value_ += jacobian(*v) * v->value();
+}
 
-  void LinearFunction::updateVelocity_()
-  {
-    velocity_.setZero();
-    for (auto v : variables())
-      velocity_ += jacobian(*v) * dot(v)->value();
-  }
+void LinearFunction::updateVelocity_()
+{
+  velocity_.setZero();
+  for(auto v : variables())
+    velocity_ += jacobian(*v) * dot(v)->value();
+}
 
-  void LinearFunction::setDerivativesToZero()
-  {
-    normalAcceleration_.setZero();
-    for (const auto& v : variables())
-      JDot_[v.get()].setZero();
-  }
+void LinearFunction::setDerivativesToZero()
+{
+  normalAcceleration_.setZero();
+  for(const auto & v : variables())
+    JDot_[v.get()].setZero();
+}
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace function
+} // namespace function
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/function/LinearFunction.cpp
+++ b/src/function/LinearFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/function/abstract/LinearFunction.h>
 

--- a/src/geometry/Plane.cpp
+++ b/src/geometry/Plane.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/geometry/Plane.h>
 
@@ -35,15 +35,9 @@ namespace tvm
 namespace geometry
 {
 
-Plane::Plane(const Eigen::Vector3d & normal, double offset)
-{
-  position(normal, offset);
-}
+Plane::Plane(const Eigen::Vector3d & normal, double offset) { position(normal, offset); }
 
-Plane::Plane(const Eigen::Vector3d & normal, const Eigen::Vector3d & point)
-{
-  position(normal, point);
-}
+Plane::Plane(const Eigen::Vector3d & normal, const Eigen::Vector3d & point) { position(normal, point); }
 
 void Plane::position(const Eigen::Vector3d & normal, double offset)
 {
@@ -55,7 +49,7 @@ void Plane::position(const Eigen::Vector3d & normal, const Eigen::Vector3d & poi
 {
   normal_ = normal;
   point_ = point;
-  offset_ = - normal_.dot(point_);
+  offset_ = -normal_.dot(point_);
 }
 
 void Plane::velocity(const Eigen::Vector3d & nDot, const Eigen::Vector3d & sp)

--- a/src/geometry/Plane.cpp
+++ b/src/geometry/Plane.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/geometry/Plane.h>
 

--- a/src/graph/CallGraph.cpp
+++ b/src/graph/CallGraph.cpp
@@ -1,37 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/graph/CallGraph.h>
 #include <tvm/graph/internal/Logger.h>
 
-#define TVM_GRAPH_LOG_ADD_GRAPH_OUTPUTS(graph, inputs) \
-  internal::Logger::logger().addGraphOutput(graph, inputs.get());
+#define TVM_GRAPH_LOG_ADD_GRAPH_OUTPUTS(graph, inputs) internal::Logger::logger().addGraphOutput(graph, inputs.get());
 
 namespace tvm
 {
@@ -54,10 +53,7 @@ void CallGraph::add(std::shared_ptr<internal::Inputs> inputs)
   TVM_GRAPH_LOG_ADD_GRAPH_OUTPUTS(this, inputs)
 }
 
-void CallGraph::update()
-{
-  plan_.build(*this);
-}
+void CallGraph::update() { plan_.build(*this); }
 
 void CallGraph::clear()
 {
@@ -68,8 +64,7 @@ void CallGraph::clear()
   plan_.clear();
 }
 
-std::vector<int> CallGraph::addOutput(abstract::Outputs * source,
-                                      int output)
+std::vector<int> CallGraph::addOutput(abstract::Outputs * source, int output)
 {
   std::intptr_t ptr = reinterpret_cast<std::intptr_t>(source);
   if(visited_.count(ptr) && visited_[ptr].count(output))
@@ -79,7 +74,7 @@ std::vector<int> CallGraph::addOutput(abstract::Outputs * source,
   std::vector<int> callId = {};
   if(source->is_node_)
   {
-    auto node = static_cast<internal::AbstractNode*>(source);
+    auto node = static_cast<internal::AbstractNode *>(source);
     if(node->outputDependencies_.count(output))
     {
       for(const auto & u : node->outputDependencies_[output])
@@ -87,9 +82,9 @@ std::vector<int> CallGraph::addOutput(abstract::Outputs * source,
         callId.push_back(addCall({node, u}));
       }
     }
-    else if (node->directDependencies_.count(output))
+    else if(node->directDependencies_.count(output))
     {
-      const auto& p = node->directDependencies_[output];
+      const auto & p = node->directDependencies_[output];
       callId = addOutput(p.first, p.second);
     }
   }
@@ -138,18 +133,15 @@ int CallGraph::addCall(Call c)
 void CallGraph::Plan::build(const CallGraph & graph)
 {
   plan_.clear();
-  const auto& order = graph.dependencyGraph_.order();
+  const auto & order = graph.dependencyGraph_.order();
 
-  for (auto i : order)
+  for(auto i : order)
   {
     plan_.push_back(graph.calls_[i]);
   }
 }
 
-void CallGraph::Plan::clear()
-{
-  plan_.clear();
-}
+void CallGraph::Plan::clear() { plan_.clear(); }
 
 } // namespace graph
 

--- a/src/graph/CallGraph.cpp
+++ b/src/graph/CallGraph.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/graph/CallGraph.h>
 #include <tvm/graph/internal/Logger.h>

--- a/src/graph/DependencyGraph.cpp
+++ b/src/graph/DependencyGraph.cpp
@@ -1,6 +1,5 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
-
 #include <tvm/graph/internal/DependencyGraph.h>
 
 #include <algorithm>
@@ -10,294 +9,290 @@
 
 namespace tvm::graph::internal
 {
-  DependencyGraph::DisjointSet::DisjointSet(size_t n)
-    : parent_(n)
-    , rank_(n, 0)
-  {
-    // fill parents with elements from 0 to n-1, i.e. each element is its own parent
-    // (all elements are in different sets)
-    std::iota(parent_.begin(), parent_.end(), 0);
-  }
+DependencyGraph::DisjointSet::DisjointSet(size_t n) : parent_(n), rank_(n, 0)
+{
+  // fill parents with elements from 0 to n-1, i.e. each element is its own parent
+  // (all elements are in different sets)
+  std::iota(parent_.begin(), parent_.end(), 0);
+}
 
-  void DependencyGraph::DisjointSet::resize(size_t n)
-  {
-    parent_.resize(n);
-    std::iota(parent_.begin(), parent_.end(), 0);
-    rank_.resize(n);
-    std::fill_n(rank_.begin(), n, 0);
-  }
+void DependencyGraph::DisjointSet::resize(size_t n)
+{
+  parent_.resize(n);
+  std::iota(parent_.begin(), parent_.end(), 0);
+  rank_.resize(n);
+  std::fill_n(rank_.begin(), n, 0);
+}
 
-  size_t DependencyGraph::DisjointSet::root(size_t node) const
+size_t DependencyGraph::DisjointSet::root(size_t node) const
+{
+  assert(node < parent_.size());
+  if(node != parent_[node])
   {
-    assert(node < parent_.size());
-    if (node != parent_[node])
+    return root(parent_[node]);
+  }
+  return parent_[node];
+}
+
+size_t DependencyGraph::DisjointSet::rootCompr(size_t node)
+{
+  assert(node < parent_.size());
+  if(node != parent_[node])
+  {
+    parent_[node] = rootCompr(parent_[node]);
+  }
+  return parent_[node];
+}
+
+void DependencyGraph::DisjointSet::unify(size_t node1, size_t node2)
+{
+  assert(node1 < parent_.size());
+  assert(node2 < parent_.size());
+  auto root1 = rootCompr(node1);
+  auto root2 = rootCompr(node2);
+
+  if(root1 == root2)
+    return;
+
+  if(rank_[root1] < rank_[root2])
+  {
+    parent_[root1] = root2;
+  }
+  else if(rank_[root1] > rank_[root2])
+  {
+    parent_[root2] = root1;
+  }
+  else
+  {
+    parent_[root2] = root1;
+    rank_[root1]++;
+  }
+}
+
+bool DependencyGraph::DisjointSet::isRoot(size_t i) const
+{
+  assert(i < parent_.size());
+  return parent_[i] == i;
+}
+
+size_t DependencyGraph::addNode()
+{
+  roots_.push_back(true);
+  children_.push_back({});
+  return roots_.size() - 1;
+}
+
+bool DependencyGraph::addEdge(size_t from, size_t to)
+{
+  assert(from < roots_.size());
+  assert(to < roots_.size());
+
+  auto p = edges_.insert({from, to});
+
+  if(p.second)
+  {
+    children_[from].push_back(to);
+    roots_[to] = false;
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+std::vector<size_t> DependencyGraph::order() const { return order_().first; }
+
+std::vector<std::vector<size_t>> DependencyGraph::groupedOrder() const
+{
+  size_t n = roots_.size();
+  const auto & [order, components] = order_();
+
+  // At this point, we have all the nodes ordered in order, but without the notion
+  // of components. On the other hand, parent describes a collection of trees,
+  // each one corresponding to a component. We need to merge those data.
+  std::vector<std::vector<size_t>> orderedGroups;
+
+  // First, we create a map associating a group number to a root.
+  std::vector<size_t> map(n);
+  for(size_t i = 0; i < n; ++i)
+  {
+    if(components.isRoot(i))
     {
-      return root(parent_[node]);
+      map[i] = orderedGroups.size();
+      orderedGroups.push_back({});
     }
-    return parent_[node];
   }
 
-  size_t DependencyGraph::DisjointSet::rootCompr(size_t node)
+  // Second, we populate the groups in an ordered way
+  for(auto i : order)
   {
-    assert(node < parent_.size());
-    if (node != parent_[node])
-    {
-      parent_[node] = rootCompr(parent_[node]);
-    }
-    return parent_[node];
+    orderedGroups[map[components.root(i)]].push_back(i);
   }
 
-  void DependencyGraph::DisjointSet::unify(size_t node1, size_t node2)
+  return orderedGroups;
+}
+
+size_t DependencyGraph::size() const { return roots_.size(); }
+
+const std::set<std::pair<size_t, size_t>> & DependencyGraph::edges() const { return edges_; }
+
+void DependencyGraph::clear()
+{
+  roots_.clear();
+  children_.clear();
+  edges_.clear();
+}
+
+std::pair<std::vector<std::vector<size_t>>, DependencyGraph> DependencyGraph::reduce() const
+{
+  size_t n = roots_.size();
+  std::vector<int> disc(n, -1);
+  std::vector<int> low(n, -1);
+  std::vector<uint8_t> stackMember(n, false);
+  std::stack<size_t> st;
+  int time = 0;
+
+  std::vector<std::vector<size_t>> ret;
+
+  // Call the recursive helper function to find SCC.
+  for(size_t i = 0; i < n; i++)
+    if(disc[i] == -1)
+      SCCUtil(ret, i, disc, low, st, stackMember, time);
+
+  // Now we need to build the reduced graph.
+  DependencyGraph g;
+
+  //  First, we build a map between a vertex and its SCC.
+  //  For each SCC we add a node in the reduced graph.
+  std::vector<size_t> vert2SCC(n);
+  for(size_t i = 0; i < ret.size(); ++i)
   {
-    assert(node1 < parent_.size());
-    assert(node2 < parent_.size());
-    auto root1 = rootCompr(node1);
-    auto root2 = rootCompr(node2);
-
-    if (root1 == root2) return;
-
-    if (rank_[root1] < rank_[root2])
+    for(auto j : ret[i])
     {
-      parent_[root1] = root2;
+      vert2SCC[j] = i;
     }
-    else if (rank_[root1] > rank_[root2])
-    {
-      parent_[root2] = root1;
-    }
-    else
-    {
-      parent_[root2] = root1;
-      rank_[root1]++;
-    }
+    g.addNode();
   }
 
-  bool DependencyGraph::DisjointSet::isRoot(size_t i) const
+  //  Second, we add the edges
+  for(const auto & p : edges_)
   {
-    assert(i < parent_.size());
-    return parent_[i] == i;
-  }
-
-  size_t DependencyGraph::addNode()
-  {
-    roots_.push_back(true);
-    children_.push_back({});
-    return roots_.size() - 1;
-  }
-
-  bool DependencyGraph::addEdge(size_t from, size_t to)
-  {
-    assert(from < roots_.size());
-    assert(to < roots_.size());
-
-    auto p = edges_.insert({ from, to });
-
-    if (p.second)
+    auto f = vert2SCC[p.first];
+    auto t = vert2SCC[p.second];
+    if(f != t) // we ignore edges between elements of a same SCC
     {
-      children_[from].push_back(to);
-      roots_[to] = false;
-      return true;
-    }
-    else
-    {
-      return false;
+      g.addEdge(f, t);
     }
   }
 
-  std::vector<size_t> DependencyGraph::order() const
+  return {ret, g};
+}
+
+void DependencyGraph::SCCUtil(std::vector<std::vector<size_t>> & ret,
+                              size_t u,
+                              std::vector<int> & disc,
+                              std::vector<int> & low,
+                              std::stack<size_t> & st,
+                              std::vector<uint8_t> & stackMember,
+                              int & time) const
+{
+  assert(time >= 0);
+
+  // Initialize discovery time and low value
+  disc[u] = low[u] = ++time;
+  st.push(u);
+  stackMember[u] = true;
+
+  // Go through all vertices adjacent to this
+  for(auto v : children_[u])
   {
-    return order_().first;
-  }
-
-  std::vector<std::vector<size_t>> DependencyGraph::groupedOrder() const
-  {
-    size_t n = roots_.size();
-    const auto& [order, components] = order_();
-
-    //At this point, we have all the nodes ordered in order, but without the notion
-    //of components. On the other hand, parent describes a collection of trees,
-    //each one corresponding to a component. We need to merge those data.
-    std::vector<std::vector<size_t>> orderedGroups;
-
-    //First, we create a map associating a group number to a root.
-    std::vector<size_t> map(n);
-    for (size_t i = 0; i < n; ++i)
+    // If v is not visited yet, then recur for it
+    if(disc[v] == -1)
     {
-      if (components.isRoot(i))
-      {
-        map[i] = orderedGroups.size();
-        orderedGroups.push_back({});
-      }
+      SCCUtil(ret, v, disc, low, st, stackMember, time);
+
+      // Check if the subtree rooted with 'v' has a
+      // connection to one of the ancestors of 'u'
+      low[u] = std::min(low[u], low[v]);
     }
-
-    //Second, we populate the groups in an ordered way
-    for (auto i : order)
+    else if(stackMember[v])
     {
-      orderedGroups[map[components.root(i)]].push_back(i);
+      // Update low value of 'u' only if 'v' is still in stack
+      // (i.e. it's a back edge, not cross edge).
+      low[u] = std::min(low[u], disc[v]);
     }
-
-    return orderedGroups;
   }
 
-  size_t DependencyGraph::size() const
+  // head node found, pop the stack and push an SCC
+  if(low[u] == disc[u])
   {
-    return roots_.size();
-  }
-
-  const std::set<std::pair<size_t, size_t>>& DependencyGraph::edges() const
-  {
-    return edges_;
-  }
-
-  void DependencyGraph::clear()
-  {
-    roots_.clear();
-    children_.clear();
-    edges_.clear();
-  }
-
-
-  std::pair<std::vector<std::vector<size_t>>, DependencyGraph>  DependencyGraph::reduce() const
-  {
-    size_t n = roots_.size();
-    std::vector<int> disc(n, -1);
-    std::vector<int> low(n, -1);
-    std::vector<uint8_t> stackMember(n, false);
-    std::stack<size_t> st;
-    int time = 0;
-
-    std::vector<std::vector<size_t>> ret;
-
-    //Call the recursive helper function to find SCC.
-    for (size_t i = 0; i < n; i++)
-      if (disc[i] == -1)
-        SCCUtil(ret, i, disc, low, st, stackMember, time);
-
-    //Now we need to build the reduced graph.
-    DependencyGraph g;
-
-    //  First, we build a map between a vertex and its SCC.
-    //  For each SCC we add a node in the reduced graph.
-    std::vector<size_t> vert2SCC(n);
-    for (size_t i = 0; i < ret.size(); ++i)
+    ret.push_back({});
+    while(st.top() != u)
     {
-      for (auto j : ret[i])
-      {
-        vert2SCC[j] = i;
-      }
-      g.addNode();
-    }
-
-    //  Second, we add the edges
-    for (const auto& p : edges_)
-    {
-      auto f = vert2SCC[p.first];
-      auto t = vert2SCC[p.second];
-      if (f != t)  // we ignore edges between elements of a same SCC
-      {
-        g.addEdge(f, t);
-      }
-    }
-
-    return { ret, g };
-  }
-
-  void DependencyGraph::SCCUtil(std::vector<std::vector<size_t>>& ret,
-    size_t u, std::vector<int>& disc, std::vector<int>& low,
-    std::stack<size_t>& st, std::vector<uint8_t>& stackMember, int& time) const
-  {
-    assert(time >= 0);
-
-    // Initialize discovery time and low value
-    disc[u] = low[u] = ++time;
-    st.push(u);
-    stackMember[u] = true;
-
-    // Go through all vertices adjacent to this
-    for (auto v : children_[u])
-    {
-      // If v is not visited yet, then recur for it
-      if (disc[v] == -1)
-      {
-        SCCUtil(ret, v, disc, low, st, stackMember, time);
-
-        // Check if the subtree rooted with 'v' has a
-        // connection to one of the ancestors of 'u'
-        low[u] = std::min(low[u], low[v]);
-      }
-      else if (stackMember[v])
-      {
-        // Update low value of 'u' only if 'v' is still in stack
-        // (i.e. it's a back edge, not cross edge).
-        low[u] = std::min(low[u], disc[v]);
-      }
-    }
-
-    // head node found, pop the stack and push an SCC
-    if (low[u] == disc[u])
-    {
-      ret.push_back({});
-      while (st.top() != u)
-      {
-        ret.back().push_back(st.top());
-        stackMember[st.top()] = false;
-        st.pop();
-      }
       ret.back().push_back(st.top());
       stackMember[st.top()] = false;
       st.pop();
     }
-  }
-
-  std::pair<std::vector<size_t>, DependencyGraph::DisjointSet> DependencyGraph::order_() const
-  {
-    size_t n = roots_.size();
-    std::pair<std::vector<size_t>, DependencyGraph::DisjointSet> ret;
-    ret.first.reserve(n);
-    ret.second.resize(n);
-    std::vector<uint8_t> visited(n, false);
-    std::vector<uint8_t> stack(n, false);
-
-    bool has_root = false;
-    for (size_t i = 0; i < visited.size(); ++i)
-    {
-      if (roots_[i])
-      {
-        orderUtil(i, ret.first, visited, stack, ret.second);
-        has_root = true;
-      }
-    }
-
-    if (!has_root && visited.size() != 0)
-    {
-      throw std::logic_error("[DependencyGraph::Order] Try to order a non-empty graph with no root. It contains at least one cycle.");
-    }
-
-    return ret;
-  }
-
-  void DependencyGraph::orderUtil(size_t v, std::vector<size_t>& order,
-    std::vector<uint8_t>& visited, std::vector<uint8_t>& stack,
-    DisjointSet& components) const
-  {
-    if (!visited[v])
-    {
-      visited[v] = true;
-      stack[v] = true;
-
-      for (auto i : children_[v])
-      {
-        components.unify(v, i);
-        if (!visited[i])
-        {
-          orderUtil(i, order, visited, stack, components);
-        }
-        else if (stack[i])
-        {
-          throw std::logic_error("[DependencyGraph::orderUtil] The graph contains a cycle");
-        }
-      }
-    }
-    stack[v] = false;
-    order.push_back(v);
+    ret.back().push_back(st.top());
+    stackMember[st.top()] = false;
+    st.pop();
   }
 }
+
+std::pair<std::vector<size_t>, DependencyGraph::DisjointSet> DependencyGraph::order_() const
+{
+  size_t n = roots_.size();
+  std::pair<std::vector<size_t>, DependencyGraph::DisjointSet> ret;
+  ret.first.reserve(n);
+  ret.second.resize(n);
+  std::vector<uint8_t> visited(n, false);
+  std::vector<uint8_t> stack(n, false);
+
+  bool has_root = false;
+  for(size_t i = 0; i < visited.size(); ++i)
+  {
+    if(roots_[i])
+    {
+      orderUtil(i, ret.first, visited, stack, ret.second);
+      has_root = true;
+    }
+  }
+
+  if(!has_root && visited.size() != 0)
+  {
+    throw std::logic_error(
+        "[DependencyGraph::Order] Try to order a non-empty graph with no root. It contains at least one cycle.");
+  }
+
+  return ret;
+}
+
+void DependencyGraph::orderUtil(size_t v,
+                                std::vector<size_t> & order,
+                                std::vector<uint8_t> & visited,
+                                std::vector<uint8_t> & stack,
+                                DisjointSet & components) const
+{
+  if(!visited[v])
+  {
+    visited[v] = true;
+    stack[v] = true;
+
+    for(auto i : children_[v])
+    {
+      components.unify(v, i);
+      if(!visited[i])
+      {
+        orderUtil(i, order, visited, stack, components);
+      }
+      else if(stack[i])
+      {
+        throw std::logic_error("[DependencyGraph::orderUtil] The graph contains a cycle");
+      }
+    }
+  }
+  stack[v] = false;
+  order.push_back(v);
+}
+} // namespace tvm::graph::internal

--- a/src/graph/Inputs.cpp
+++ b/src/graph/Inputs.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/graph/internal/Inputs.h>
 
@@ -38,33 +38,23 @@ namespace graph
 namespace internal
 {
 
-Inputs::Iterator::Iterator(inputs_t::iterator it, inputs_t::iterator end)
-: Inputs::inputs_t::iterator(it),
-  end_(end)
-{
-}
+Inputs::Iterator::Iterator(inputs_t::iterator it, inputs_t::iterator end) : Inputs::inputs_t::iterator(it), end_(end) {}
 
-Inputs::Iterator::operator bool()
-{
-  return *this != end_;
-}
+Inputs::Iterator::operator bool() { return *this != end_; }
 
 void Inputs::removeInput(Iterator it, abstract::Outputs * source)
 {
   inputs_.erase(it);
   auto sourceIt = std::find_if(store_.begin(), store_.end(),
-                         [source](const std::shared_ptr<abstract::Outputs> & o)
-                         {
-                           return o.get() == source;
-                         });
+                               [source](const std::shared_ptr<abstract::Outputs> & o) { return o.get() == source; });
   if(sourceIt != store_.end())
   {
     store_.erase(sourceIt);
   }
 }
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace graph
+} // namespace graph
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/graph/Inputs.cpp
+++ b/src/graph/Inputs.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/graph/internal/Inputs.h>
 

--- a/src/graph/Log.cpp
+++ b/src/graph/Log.cpp
@@ -1,285 +1,281 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/graph/internal/Log.h>
 #include <tvm/graph/CallGraph.h>
+#include <tvm/graph/internal/Log.h>
 
 #include <algorithm>
 #include <map>
 #include <sstream>
 
 #ifdef __GNUG__
-#include <cstdlib>
-#include <memory>
-#include <cxxabi.h>
+#  include <cstdlib>
+#  include <cxxabi.h>
+#  include <memory>
 #endif
 
 namespace
 {
-  using namespace tvm::graph::internal;
+using namespace tvm::graph::internal;
 
-  /** Replace the spaces in name by underscores*/
-  std::string replaceSpaces(std::string name)
+/** Replace the spaces in name by underscores*/
+std::string replaceSpaces(std::string name)
+{
+  for(size_t i = 0; i < name.length(); i++)
   {
-    for (size_t i = 0; i < name.length(); i++)
-    {
-      if (name[i] == ' ')
-        name[i] = '_';
-    }
-    return name;
+    if(name[i] == ' ')
+      name[i] = '_';
   }
+  return name;
+}
 
-  /** Replace the colons in name by underscores*/
-  std::string replaceColons(std::string name)
+/** Replace the colons in name by underscores*/
+std::string replaceColons(std::string name)
+{
+  for(size_t i = 0; i < name.length(); i++)
   {
-    for (size_t i = 0; i < name.length(); i++)
-    {
-      if (name[i] == ':')
-        name[i] = '_';
-    }
-    return name;
+    if(name[i] == ':')
+      name[i] = '_';
   }
+  return name;
+}
 
-  /** Remove from the name the namespace names specified in the static vector below*/
-  std::string removeNamespace(const std::string& name)
+/** Remove from the name the namespace names specified in the static vector below*/
+std::string removeNamespace(const std::string & name)
+{
+  static std::vector<std::string> namespaces = {"tvm",           "constraint", "function", "graph",   "scheme",
+                                                "task_dynamics", "utils",      "abstract", "internal"};
+  std::string res = name;
+  for(const auto & s : namespaces)
   {
-    static std::vector<std::string> namespaces = { "tvm", "constraint", "function", "graph", "scheme", "task_dynamics", "utils", "abstract", "internal" };
-    std::string res = name;
-    for (const auto& s : namespaces)
+    auto i = res.find(s + "::");
+    if(i != std::string::npos)
     {
-      auto i = res.find(s + "::");
-      if (i != std::string::npos)
-      {
-        res = res.substr(0, i) + res.substr(i + s.size() + 2);
-      }
+      res = res.substr(0, i) + res.substr(i + s.size() + 2);
     }
-    return res;
   }
+  return res;
+}
 
-  /** Demangle the typeid name*/
-  std::string demangle(const std::string& name, bool removeNamespace_ = false)
-  {
+/** Demangle the typeid name*/
+std::string demangle(const std::string & name, bool removeNamespace_ = false)
+{
 #if defined(_MSC_VER)
-    auto i = name.find("class ");
-    if (i != std::string::npos)
+  auto i = name.find("class ");
+  if(i != std::string::npos)
+  {
+    if(removeNamespace_)
     {
-      if (removeNamespace_)
-      {
-        return removeNamespace(name.substr(i + 6));
-      }
-      else
-      {
-        return name.substr(i + 6);
-      }
-    }
-
-    i = name.find("enum ");
-    if (i != std::string::npos)
-    {
-      if (removeNamespace_)
-      {
-        return removeNamespace(name.substr(i + 5));
-      }
-      else
-      {
-        return name.substr(i + 5);
-      }
-    }
-
-#elif defined(__GNUG__)
-    //adapted from https://stackoverflow.com/a/4541470
-    int status = -4; // some arbitrary value to eliminate the compiler warning
-    std::unique_ptr<char, void(*)(void*)> res{
-      abi::__cxa_demangle(name.c_str(), NULL, NULL, &status),
-      std::free
-    };
-    if (status == 0)
-    {
-      std::string resName = res.get();
-      if (removeNamespace_)
-      {
-        return removeNamespace(resName);
-      }
-      else
-      {
-        return resName;
-      }
+      return removeNamespace(name.substr(i + 6));
     }
     else
     {
-      return name;
+      return name.substr(i + 6);
     }
+  }
+
+  i = name.find("enum ");
+  if(i != std::string::npos)
+  {
+    if(removeNamespace_)
+    {
+      return removeNamespace(name.substr(i + 5));
+    }
+    else
+    {
+      return name.substr(i + 5);
+    }
+  }
+
+#elif defined(__GNUG__)
+  // adapted from https://stackoverflow.com/a/4541470
+  int status = -4; // some arbitrary value to eliminate the compiler warning
+  std::unique_ptr<char, void (*)(void *)> res{abi::__cxa_demangle(name.c_str(), NULL, NULL, &status), std::free};
+  if(status == 0)
+  {
+    std::string resName = res.get();
+    if(removeNamespace_)
+    {
+      return removeNamespace(resName);
+    }
+    else
+    {
+      return resName;
+    }
+  }
+  else
+  {
+    return name;
+  }
 #else
 
 #endif
-    return name;
-  }
+  return name;
+}
 
-  /** Return a clean name from typeid by demangling it, replacing spaces and
-    * optionaly replacing colons.
-    */
-  std::string clean(const std::string& name, bool replaceColons_ = true)
+/** Return a clean name from typeid by demangling it, replacing spaces and
+ * optionaly replacing colons.
+ */
+std::string clean(const std::string & name, bool replaceColons_ = true)
+{
+  if(replaceColons_)
   {
-    if (replaceColons_)
-    {
-      return replaceColons(replaceSpaces(demangle(name, true)));
-    }
-    else
-    {
-      return replaceSpaces(demangle(name, true));
-    }
+    return replaceColons(replaceSpaces(demangle(name, true)));
   }
+  else
+  {
+    return replaceSpaces(demangle(name, true));
+  }
+}
 
-  //find the input corresponding to the input dependency
-  template<typename InputContainer>
-  const Log::Input& findInput(const InputContainer& s, const Log::InputDependency& d)
+// find the input corresponding to the input dependency
+template<typename InputContainer>
+const Log::Input & findInput(const InputContainer & s, const Log::InputDependency & d)
+{
+  for(const auto & i : s)
   {
-    for (const auto& i : s)
+    if(i.owner == d.owner && i.id == d.input && i.source == d.source)
     {
-      if (i.owner == d.owner && i.id == d.input && i.source == d.source)
-      {
-        return i;
-      }
+      return i;
     }
-    throw std::runtime_error("Input not found");
   }
+  throw std::runtime_error("Input not found");
+}
 
-  //find the input corresponding to the direct dependency
-  template<typename InputContainer>
-  const Log::Input& findInput(const InputContainer& s, const Log::DirectDependency& d)
+// find the input corresponding to the direct dependency
+template<typename InputContainer>
+const Log::Input & findInput(const InputContainer & s, const Log::DirectDependency & d)
+{
+  for(const auto & i : s)
   {
-    for (const auto& i : s)
+    if(i.owner == d.owner && i.id == d.input && i.source == d.source)
     {
-      if (i.owner == d.owner && i.id == d.input && i.source == d.source)
-      {
-        return i;
-      }
+      return i;
     }
-    throw std::runtime_error("Input not found");
   }
+  throw std::runtime_error("Input not found");
+}
 
-  //find the update corresponding to the input dependency
-  const Log::Update& findUpdate(const std::set<Log::Update>& s, const Log::InputDependency& d)
+// find the update corresponding to the input dependency
+const Log::Update & findUpdate(const std::set<Log::Update> & s, const Log::InputDependency & d)
+{
+  for(const auto & u : s)
   {
-    for (const auto& u : s)
+    if(u.owner == d.owner && u.id == d.update)
     {
-      if (u.owner == d.owner && u.id == d.update)
-      {
-        return u;
-      }
+      return u;
     }
-    throw std::runtime_error("Update not found");
   }
+  throw std::runtime_error("Update not found");
+}
 
-  //find the update corresponding to the output dependency
-  template<typename UpdateContainer>
-  const Log::Update& findUpdate(const UpdateContainer& s, const Log::OutputDependency& d)
+// find the update corresponding to the output dependency
+template<typename UpdateContainer>
+const Log::Update & findUpdate(const UpdateContainer & s, const Log::OutputDependency & d)
+{
+  for(const auto & u : s)
   {
-    for (const auto& u : s)
+    if(u.owner == d.owner && u.id == d.update)
     {
-      if (u.owner == d.owner && u.id == d.update)
-      {
-        return u;
-      }
+      return u;
     }
-    throw std::runtime_error("Update not found");
   }
+  throw std::runtime_error("Update not found");
+}
 
-  //find the update that is the origin of an internal dependency
-  template<typename UpdateContainer>
-  const Log::Update& findFromUpdate(const UpdateContainer& s, const Log::InternalDependency& d)
+// find the update that is the origin of an internal dependency
+template<typename UpdateContainer>
+const Log::Update & findFromUpdate(const UpdateContainer & s, const Log::InternalDependency & d)
+{
+  for(const auto & u : s)
   {
-    for (const auto& u : s)
+    if(u.owner == d.owner && u.id == d.from)
     {
-      if (u.owner == d.owner && u.id == d.from)
-      {
-        return u;
-      }
+      return u;
     }
-    throw std::runtime_error("Update not found");
   }
+  throw std::runtime_error("Update not found");
+}
 
-  //find the update that is the destination of an internal dependency
-  const Log::Update& findToUpdate(const std::set<Log::Update>& s, const Log::InternalDependency& d)
+// find the update that is the destination of an internal dependency
+const Log::Update & findToUpdate(const std::set<Log::Update> & s, const Log::InternalDependency & d)
+{
+  for(const auto & u : s)
   {
-    for (const auto& u : s)
+    if(u.owner == d.owner && u.id == d.to)
     {
-      if (u.owner == d.owner && u.id == d.to)
-      {
-        return u;
-      }
+      return u;
     }
-    throw std::runtime_error("Update not found");
   }
+  throw std::runtime_error("Update not found");
+}
 
-  //find the output corresponding to the output dependency
-  const Log::Output& findOutput(const std::set<Log::Output>& s, const Log::OutputDependency& d)
+// find the output corresponding to the output dependency
+const Log::Output & findOutput(const std::set<Log::Output> & s, const Log::OutputDependency & d)
+{
+  for(const auto & o : s)
   {
-    for (const auto& o : s)
+    if(o.owner == d.owner && o.id == d.output)
     {
-      if (o.owner == d.owner && o.id == d.output)
-      {
-        return o;
-      }
+      return o;
     }
-    throw std::runtime_error("Output not found");
   }
+  throw std::runtime_error("Output not found");
+}
 
-  //find the output corresponding to the output dependency
-  const Log::Output& findOutput(const std::set<Log::Output>& s, const Log::DirectDependency& d)
+// find the output corresponding to the output dependency
+const Log::Output & findOutput(const std::set<Log::Output> & s, const Log::DirectDependency & d)
+{
+  for(const auto & o : s)
   {
-    for (const auto& o : s)
+    if(o.owner == d.owner && o.id == d.output)
     {
-      if (o.owner == d.owner && o.id == d.output)
-      {
-        return o;
-      }
+      return o;
     }
-    throw std::runtime_error("Output not found");
   }
+  throw std::runtime_error("Output not found");
+}
 
-  //find the output corresponding to an intput
-  const Log::Output& findOutput(const std::vector<Log::Output>& v, const Log::Input& i)
+// find the output corresponding to an intput
+const Log::Output & findOutput(const std::vector<Log::Output> & v, const Log::Input & i)
+{
+  for(const auto & o : v)
   {
-    for (const auto& o : v)
+    if(o.owner == i.source && o.id == i.id)
     {
-      if (o.owner == i.source && o.id == i.id)
-      {
-        return o;
-      }
+      return o;
     }
-    throw std::runtime_error("Output not found");
   }
+  throw std::runtime_error("Output not found");
+}
 
 } // anonymous namespace
-
-
 
 namespace tvm
 {
@@ -289,405 +285,410 @@ namespace graph
 
 namespace internal
 {
-  std::ostream& operator<<(std::ostream& os, const std::type_index& t)
+std::ostream & operator<<(std::ostream & os, const std::type_index & t)
+{
+  os << "[" << t.hash_code() << " " << t.name() << "]";
+  return os;
+}
+
+std::string Log::generateDot(const Pointer & p) const
+{
+  std::set<Output> outputs;
+  std::set<Update> updates;
+  std::map<Pointer, std::set<Input>> inputs;
+
+  // List of outputs
+  for(const auto & o : outputs_)
   {
-    os << "[" << t.hash_code() << " " << t.name() << "]";
-    return os;
+    if(o.owner == p)
+    {
+      outputs.insert(o);
+    }
+  }
+  // Ouputs may not be refered by an update, but by the input of another node
+  for(const auto & i : inputs_)
+  {
+    if(i.source == p)
+    {
+      outputs.insert({i.id, i.name, p});
+    }
   }
 
-
-  std::string Log::generateDot(const Pointer& p) const
+  // List of updates
+  for(const auto & u : updates_)
   {
-    std::set<Output> outputs;
-    std::set<Update> updates;
-    std::map<Pointer, std::set<Input>> inputs;
-
-    //List of outputs
-    for (const auto& o : outputs_)
+    if(u.owner == p)
     {
-      if (o.owner == p)
-      {
-        outputs.insert(o);
-      }
+      updates.insert(u);
     }
-    //Ouputs may not be refered by an update, but by the input of another node
-    for (const auto& i : inputs_)
+  }
+
+  // List of inputs
+  for(const auto & i : inputs_)
+  {
+    if(i.owner == p)
     {
-      if (i.source == p)
-      {
-        outputs.insert({ i.id, i.name, p });
-      }
+      inputs[i.source].insert(i);
     }
+  }
 
-    //List of updates
-    for (const auto& u : updates_)
+  std::stringstream dot;
+  dot << "digraph \"" << clean(p.type.name()) << "\"\n{\n";
+  dot << "  rankdir=\"LR\";\n";
+
+  // inputs
+  int c = 0;
+  for(const auto & source : inputs)
+  {
+    dot << "  subgraph cluster" << c++ << " {\n";
+    dot << "    label=\"" << clean(source.first.type.name(), false) << "\";\n";
+    dot << "    node [shape=diamond];\n";
+    for(const auto & s : source.second)
     {
-      if (u.owner == p)
-      {
-        updates.insert(u);
-      }
-    }
-
-    //List of inputs
-    for (const auto& i : inputs_)
-    {
-      if (i.owner == p)
-      {
-        inputs[i.source].insert(i);
-      }
-    }
-
-    std::stringstream dot;
-    dot << "digraph \"" << clean(p.type.name()) << "\"\n{\n";
-    dot << "  rankdir=\"LR\";\n";
-
-    //inputs
-    int c = 0;
-    for (const auto& source : inputs)
-    {
-      dot << "  subgraph cluster" << c++ << " {\n";
-      dot << "    label=\"" << clean(source.first.type.name(), false) << "\";\n";
-      dot << "    node [shape=diamond];\n";
-      for (const auto& s : source.second)
-      {
-        dot << "    " << nodeName(s) << " [label=\"" << clean(s.name) << "\"];\n";
-      }
-      dot << "  }\n";
-    }
-
-    //updates
-    dot << "  {\n";
-    for (const auto& u : updates)
-    {
-      dot << "    " << nodeName(u) << " [label=\"" << clean(u.name) << "\"];\n";
+      dot << "    " << nodeName(s) << " [label=\"" << clean(s.name) << "\"];\n";
     }
     dot << "  }\n";
-
-    //outputs
-    dot << "  {\n";
-    dot << "    rank=same;\n";
-    dot << "    node [shape=octagon];\n";
-    for (const auto& o : outputs)
-    {
-      dot << "    " << nodeName(o) << " [label=\"" << clean(o.name) << "\"];\n";
-    }
-    dot << "  }\n";
-
-    //input - update links
-    for (const auto& d : inputDependencies_)
-    {
-      if (d.owner.value == p.value)
-      {
-        auto i = findInput(inputs[d.source], d);
-        auto u = findUpdate(updates, d);
-        dot << nodeName(i) << "->" << nodeName(u) << ";\n";
-      }
-    }
-
-    //update - output links
-    for (const auto& d : outputDependencies_)
-    {
-      if (d.owner.value == p.value)
-      {
-        auto u = findUpdate(updates, d);
-        auto o = findOutput(outputs, d);
-        dot << nodeName(u) << "->" << nodeName(o) << ";\n";
-      }
-    }
-
-    //update - update links
-    for (const auto& d : internalDependencies_)
-    {
-      if (d.owner.value == p.value)
-      {
-        auto f = findFromUpdate(updates, d);
-        auto t = findToUpdate(updates, d);
-        dot << nodeName(f) << "->" << nodeName(t) << ";\n";
-      }
-    }
-
-    //input - output links
-    for (const auto& d : directDependencies_)
-    {
-      if (d.owner.value == p.value)
-      {
-        auto i = findInput(inputs[d.source], d);
-        auto o = findOutput(outputs, d);
-        dot << nodeName(i) << "->" << nodeName(o) << ";\n";
-      }
-    }
-
-    dot << "}";
-    return dot.str();
   }
 
-  std::string Log::generateDot(const CallGraph* const g) const
+  // updates
+  dot << "  {\n";
+  for(const auto & u : updates)
   {
-    std::vector<Output> outputs = outputs_;
-    //Adding outputs refered only as source
-    for (const auto& i : inputs_)
+    dot << "    " << nodeName(u) << " [label=\"" << clean(u.name) << "\"];\n";
+  }
+  dot << "  }\n";
+
+  // outputs
+  dot << "  {\n";
+  dot << "    rank=same;\n";
+  dot << "    node [shape=octagon];\n";
+  for(const auto & o : outputs)
+  {
+    dot << "    " << nodeName(o) << " [label=\"" << clean(o.name) << "\"];\n";
+  }
+  dot << "  }\n";
+
+  // input - update links
+  for(const auto & d : inputDependencies_)
+  {
+    if(d.owner.value == p.value)
     {
-      outputs.push_back({ i.id, i.name, i.source });
+      auto i = findInput(inputs[d.source], d);
+      auto u = findUpdate(updates, d);
+      dot << nodeName(i) << "->" << nodeName(u) << ";\n";
+    }
+  }
+
+  // update - output links
+  for(const auto & d : outputDependencies_)
+  {
+    if(d.owner.value == p.value)
+    {
+      auto u = findUpdate(updates, d);
+      auto o = findOutput(outputs, d);
+      dot << nodeName(u) << "->" << nodeName(o) << ";\n";
+    }
+  }
+
+  // update - update links
+  for(const auto & d : internalDependencies_)
+  {
+    if(d.owner.value == p.value)
+    {
+      auto f = findFromUpdate(updates, d);
+      auto t = findToUpdate(updates, d);
+      dot << nodeName(f) << "->" << nodeName(t) << ";\n";
+    }
+  }
+
+  // input - output links
+  for(const auto & d : directDependencies_)
+  {
+    if(d.owner.value == p.value)
+    {
+      auto i = findInput(inputs[d.source], d);
+      auto o = findOutput(outputs, d);
+      dot << nodeName(i) << "->" << nodeName(o) << ";\n";
+    }
+  }
+
+  dot << "}";
+  return dot.str();
+}
+
+std::string Log::generateDot(const CallGraph * const g) const
+{
+  std::vector<Output> outputs = outputs_;
+  // Adding outputs refered only as source
+  for(const auto & i : inputs_)
+  {
+    outputs.push_back({i.id, i.name, i.source});
+  }
+
+  auto it = graphOutputs_.find(g);
+  if(it != graphOutputs_.end())
+  {
+    // We want to populate the following vectors with the updates and outputs in the call graph
+    std::vector<Output> outputsInGraph;
+    std::vector<Update> updatesInGraph;
+
+    std::map<Output, bool> processedOutputs;
+    std::map<Update, bool> processedUpdates;
+    std::vector<Output> outputStack;
+    std::vector<Update> updateStack;
+
+    // first we retrieve the outputs of the call graph
+    for(const auto & p : it->second)
+    {
+      for(const auto & i : inputs_)
+      {
+        if(i.owner == p)
+        {
+          outputStack.push_back(findOutput(outputs, i));
+        }
+      }
     }
 
-    auto it = graphOutputs_.find(g);
-    if (it != graphOutputs_.end())
+    // now we follow the dependency backward
+    while(!outputStack.empty() || !updateStack.empty())
     {
-      //We want to populate the following vectors with the updates and outputs in the call graph
-      std::vector<Output> outputsInGraph;
-      std::vector<Update> updatesInGraph;
-     
-      std::map<Output, bool> processedOutputs;
-      std::map<Update, bool> processedUpdates;
-      std::vector<Output> outputStack;
-      std::vector<Update> updateStack;
-
-      //first we retrieve the outputs of the call graph
-      for (const auto& p : it->second)
+      if(!outputStack.empty())
       {
-        for (const auto& i : inputs_)
+        auto o = outputStack.back();
+        outputStack.pop_back();
+        if(!processedOutputs[o])
         {
-          if (i.owner == p)
+          outputsInGraph.push_back(o);
+          for(const auto & d : outputDependencies_)
           {
-            outputStack.push_back(findOutput(outputs, i));
+            if(d.owner == o.owner && d.output == o.id)
+            {
+              updateStack.push_back(findUpdate(updates_, d));
+            }
           }
-        }
-      }
-
-      //now we follow the dependency backward
-      while (!outputStack.empty() || !updateStack.empty())
-      {
-        if (!outputStack.empty())
-        {
-          auto o = outputStack.back();
-          outputStack.pop_back();
-          if (!processedOutputs[o])
+          for(const auto & d : directDependencies_)
           {
-            outputsInGraph.push_back(o);
-            for (const auto& d : outputDependencies_)
+            if(d.owner == o.owner && d.output == o.id)
             {
-              if (d.owner == o.owner && d.output == o.id)
-              {
-                updateStack.push_back(findUpdate(updates_, d));
-              }
+              auto i = findInput(inputs_, d);
+              outputStack.push_back(findOutput(outputs, i));
             }
-            for (const auto& d : directDependencies_)
-            {
-              if (d.owner == o.owner && d.output == o.id)
-              {
-                auto i = findInput(inputs_, d);
-                outputStack.push_back(findOutput(outputs, i));
-              }
-            }
-            processedOutputs[o] = true;
           }
+          processedOutputs[o] = true;
         }
+      }
 
-        if (!updateStack.empty())
+      if(!updateStack.empty())
+      {
+        auto u = updateStack.back();
+        updateStack.pop_back();
+        if(!processedUpdates[u])
         {
-          auto u = updateStack.back();
-          updateStack.pop_back();
-          if (!processedUpdates[u])
+          updatesInGraph.push_back(u);
+          for(const auto & d : inputDependencies_)
           {
-            updatesInGraph.push_back(u);
-            for (const auto& d : inputDependencies_)
+            if(d.owner == u.owner && d.update == u.id)
             {
-              if (d.owner == u.owner && d.update == u.id)
-              {
-                auto i = findInput(inputs_, d);
-                outputStack.push_back(findOutput(outputs, i));
-              }
+              auto i = findInput(inputs_, d);
+              outputStack.push_back(findOutput(outputs, i));
             }
-            for (const auto& d : internalDependencies_)
-            {
-              if (d.owner == u.owner && d.to == u.id)
-              {
-                updateStack.push_back(findFromUpdate(updates_, d));
-              }
-            }
-            processedUpdates[u] = true;
           }
+          for(const auto & d : internalDependencies_)
+          {
+            if(d.owner == u.owner && d.to == u.id)
+            {
+              updateStack.push_back(findFromUpdate(updates_, d));
+            }
+          }
+          processedUpdates[u] = true;
         }
       }
-      return generateDot(outputsInGraph, updatesInGraph);
     }
-    else
-    {
-      return "";
-    }
+    return generateDot(outputsInGraph, updatesInGraph);
   }
-
-  std::string Log::generateDot(const std::vector<Log::Output>& outHighlight, const std::vector<Log::Update>& upHighlight) const
+  else
   {
-    std::map<std::uintptr_t, std::set<Output>> outputs;
-    std::map<std::uintptr_t, std::set<Update>> updates;
-    std::map<std::uintptr_t, std::set<Input>> inputs;
-    std::map<Output, bool> isAlsoInput;
-    std::map<Output, bool> oh;
-    std::map<Update, bool> uh;
-
-    //Sort outputs by owner
-    for (const auto& o : outputs_)
-    {
-      auto p = outputs[o.owner.value].insert(o);
-      if (p.second)
-      {
-        isAlsoInput[o] = false;
-      }
-    }
-
-    //Sort input by source and process the corresponding output
-    for (const auto& i : inputs_)
-    {
-      inputs[i.source.value].insert(i);
-      //Ouputs may not be refered by an update, but by the input of another node
-      auto p = outputs[i.source.value].insert({ i.id, i.name, i.source });
-      isAlsoInput[*p.first] = true;
-    }
-
-    //Sort updates by owner
-    for (const auto& u : updates_)
-    {
-      updates[u.owner.value].insert(u);
-    }
-
-    //process the highlights
-    for (auto& o : outHighlight)
-    {
-      oh[o] = true;
-    }
-    for (auto& u : upHighlight)
-    {
-      uh[u] = true;
-    }
-
-    //generate the dot code
-    std::stringstream dot;
-    dot << "digraph \"" << "Update graph" << "\"\n{\n";
-    dot << "  rankdir=\"LR\";\n";
-
-    //Process each node
-    int c = 0;
-    for (const auto& p : types_)
-    {
-      dot << " subgraph cluster" << ++c << " {\n";
-      dot << "    label=\"" << clean(p.second.back().name(), false) << "\";\n";
-      //updates
-      dot << "    {\n";
-      dot << "      rank=same;\n";
-      for (const auto& u : updates[p.first])
-      {
-        dot << "      " << nodeName(u) << " [label=\"" << clean(u.name) << "\"";
-        if (uh[u])
-        {
-          dot << ",color=orange";
-        }
-        dot << "];\n";
-      }
-      dot << "    }\n";
-      //outputs
-      dot << "    {\n";
-      dot << "      rank=same;\n";
-      for (const auto& o : outputs[p.first])
-      {
-        dot << "      " << nodeName(o) << " [label=\"" << clean(o.name) << "\",";
-        if (isAlsoInput[o])
-        {
-          dot << "shape=Mdiamond";
-        }
-        else
-        {
-          dot << "shape=octagon";
-        }
-        if (oh[o])
-        {
-          dot << ",color=orange";
-        }
-        dot << "]; \n";
-      }
-      dot << "    }\n";
-      dot << " }\n";
-    }
-
-    //input - update links
-    for (const auto& d : inputDependencies_)
-    {
-      auto i = findInput(inputs[d.source.value], d);
-      auto u = findUpdate(updates[d.owner.value], d);
-      Output o{ i.id, i.name, i.source };
-      dot << nodeName(o) << "->" << nodeName(u);
-      if (oh[o] && uh[u])
-      {
-        dot << " " << "[color=orange]";
-      }
-      dot << ";\n";
-    }
-
-    //update - output links
-    for (const auto& d : outputDependencies_)
-    {
-      auto u = findUpdate(updates[d.owner.value], d);
-      auto o = findOutput(outputs[d.owner.value], d);
-      dot << nodeName(u) << "->" << nodeName(o);
-      if (oh[o] && uh[u])
-      {
-        dot << " " << "[color=orange]";
-      }
-      dot << ";\n";
-    }
-
-    //update - update links
-    for (const auto& d : internalDependencies_)
-    {
-      auto from = findFromUpdate(updates[d.owner.value], d);
-      auto to = findToUpdate(updates[d.owner.value], d);
-      dot << nodeName(from) << "->" << nodeName(to);
-      if (uh[from] && uh[to])
-      {
-        dot << " " << "[color=orange]";
-      }
-      dot << ";\n";
-    }
-
-    //input - output links
-    for (const auto& d : directDependencies_)
-    {
-      auto i = findInput(inputs[d.source.value], d);
-      auto to = findOutput(outputs[d.owner.value], d);
-      Output from{ i.id, i.name, i.source };
-      dot << nodeName(from) << "->" << nodeName(to);
-      if (oh[from] && oh[to])
-      {
-        dot << " " << "[color=orange]";
-      }
-      dot << ";\n";
-    }
-
-    dot << "}";
-    return dot.str();
+    return "";
   }
+}
 
+std::string Log::generateDot(const std::vector<Log::Output> & outHighlight,
+                             const std::vector<Log::Update> & upHighlight) const
+{
+  std::map<std::uintptr_t, std::set<Output>> outputs;
+  std::map<std::uintptr_t, std::set<Update>> updates;
+  std::map<std::uintptr_t, std::set<Input>> inputs;
+  std::map<Output, bool> isAlsoInput;
+  std::map<Output, bool> oh;
+  std::map<Update, bool> uh;
 
-  std::string Log::nodeName(const Log::Output& output) const
+  // Sort outputs by owner
+  for(const auto & o : outputs_)
   {
-    std::stringstream ss;
-    ss << clean(types_.at(output.owner.value).back().name()) << output.owner.value << "_out" << clean(output.name);
-    return ss.str();
+    auto p = outputs[o.owner.value].insert(o);
+    if(p.second)
+    {
+      isAlsoInput[o] = false;
+    }
   }
 
-  std::string Log::nodeName(const Log::Input& input) const
+  // Sort input by source and process the corresponding output
+  for(const auto & i : inputs_)
   {
-    std::stringstream ss;
-    ss << clean(types_.at(input.source.value).back().name()) << input.source.value << "_in" << clean(input.name);
-    return ss.str();
+    inputs[i.source.value].insert(i);
+    // Ouputs may not be refered by an update, but by the input of another node
+    auto p = outputs[i.source.value].insert({i.id, i.name, i.source});
+    isAlsoInput[*p.first] = true;
   }
 
-  std::string Log::nodeName(const Log::Update& update) const
+  // Sort updates by owner
+  for(const auto & u : updates_)
   {
-    std::stringstream ss;
-    ss << clean(types_.at(update.owner.value).back().name()) << update.owner.value << "_up" << clean(update.name);
-    return ss.str();
+    updates[u.owner.value].insert(u);
   }
+
+  // process the highlights
+  for(auto & o : outHighlight)
+  {
+    oh[o] = true;
+  }
+  for(auto & u : upHighlight)
+  {
+    uh[u] = true;
+  }
+
+  // generate the dot code
+  std::stringstream dot;
+  dot << "digraph \""
+      << "Update graph"
+      << "\"\n{\n";
+  dot << "  rankdir=\"LR\";\n";
+
+  // Process each node
+  int c = 0;
+  for(const auto & p : types_)
+  {
+    dot << " subgraph cluster" << ++c << " {\n";
+    dot << "    label=\"" << clean(p.second.back().name(), false) << "\";\n";
+    // updates
+    dot << "    {\n";
+    dot << "      rank=same;\n";
+    for(const auto & u : updates[p.first])
+    {
+      dot << "      " << nodeName(u) << " [label=\"" << clean(u.name) << "\"";
+      if(uh[u])
+      {
+        dot << ",color=orange";
+      }
+      dot << "];\n";
+    }
+    dot << "    }\n";
+    // outputs
+    dot << "    {\n";
+    dot << "      rank=same;\n";
+    for(const auto & o : outputs[p.first])
+    {
+      dot << "      " << nodeName(o) << " [label=\"" << clean(o.name) << "\",";
+      if(isAlsoInput[o])
+      {
+        dot << "shape=Mdiamond";
+      }
+      else
+      {
+        dot << "shape=octagon";
+      }
+      if(oh[o])
+      {
+        dot << ",color=orange";
+      }
+      dot << "]; \n";
+    }
+    dot << "    }\n";
+    dot << " }\n";
+  }
+
+  // input - update links
+  for(const auto & d : inputDependencies_)
+  {
+    auto i = findInput(inputs[d.source.value], d);
+    auto u = findUpdate(updates[d.owner.value], d);
+    Output o{i.id, i.name, i.source};
+    dot << nodeName(o) << "->" << nodeName(u);
+    if(oh[o] && uh[u])
+    {
+      dot << " "
+          << "[color=orange]";
+    }
+    dot << ";\n";
+  }
+
+  // update - output links
+  for(const auto & d : outputDependencies_)
+  {
+    auto u = findUpdate(updates[d.owner.value], d);
+    auto o = findOutput(outputs[d.owner.value], d);
+    dot << nodeName(u) << "->" << nodeName(o);
+    if(oh[o] && uh[u])
+    {
+      dot << " "
+          << "[color=orange]";
+    }
+    dot << ";\n";
+  }
+
+  // update - update links
+  for(const auto & d : internalDependencies_)
+  {
+    auto from = findFromUpdate(updates[d.owner.value], d);
+    auto to = findToUpdate(updates[d.owner.value], d);
+    dot << nodeName(from) << "->" << nodeName(to);
+    if(uh[from] && uh[to])
+    {
+      dot << " "
+          << "[color=orange]";
+    }
+    dot << ";\n";
+  }
+
+  // input - output links
+  for(const auto & d : directDependencies_)
+  {
+    auto i = findInput(inputs[d.source.value], d);
+    auto to = findOutput(outputs[d.owner.value], d);
+    Output from{i.id, i.name, i.source};
+    dot << nodeName(from) << "->" << nodeName(to);
+    if(oh[from] && oh[to])
+    {
+      dot << " "
+          << "[color=orange]";
+    }
+    dot << ";\n";
+  }
+
+  dot << "}";
+  return dot.str();
+}
+
+std::string Log::nodeName(const Log::Output & output) const
+{
+  std::stringstream ss;
+  ss << clean(types_.at(output.owner.value).back().name()) << output.owner.value << "_out" << clean(output.name);
+  return ss.str();
+}
+
+std::string Log::nodeName(const Log::Input & input) const
+{
+  std::stringstream ss;
+  ss << clean(types_.at(input.source.value).back().name()) << input.source.value << "_in" << clean(input.name);
+  return ss.str();
+}
+
+std::string Log::nodeName(const Log::Update & update) const
+{
+  std::stringstream ss;
+  ss << clean(types_.at(update.owner.value).back().name()) << update.owner.value << "_up" << clean(update.name);
+  return ss.str();
+}
 
 } // namespace internal
 

--- a/src/graph/Log.cpp
+++ b/src/graph/Log.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/graph/CallGraph.h>
 #include <tvm/graph/internal/Log.h>

--- a/src/graph/Logger.cpp
+++ b/src/graph/Logger.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/graph/internal/Logger.h>
 
@@ -40,29 +40,23 @@ namespace graph
 namespace internal
 {
 
-  Logger& Logger::logger()
-  {
-    static std::unique_ptr<Logger> logger_{ new Logger() };
-    return *logger_;
-  }
+Logger & Logger::logger()
+{
+  static std::unique_ptr<Logger> logger_{new Logger()};
+  return *logger_;
+}
 
-  void Logger::disable()
-  {
-    disabled_ = true;
-  }
+void Logger::disable() { disabled_ = true; }
 
-  void Logger::enable()
-  {
-    disabled_ = false;
-  }
+void Logger::enable() { disabled_ = false; }
 
-  void Logger::addGraphOutput(CallGraph* g, Inputs* node)
-  {
-    if (disabled_) return;
+void Logger::addGraphOutput(CallGraph * g, Inputs * node)
+{
+  if(disabled_)
+    return;
 
-    log_.graphOutputs_[g].push_back(node);
-  }
-
+  log_.graphOutputs_[g].push_back(node);
+}
 
 } // namespace internal
 

--- a/src/graph/Logger.cpp
+++ b/src/graph/Logger.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/graph/internal/Logger.h>
 

--- a/src/hint/AutoCalculator.cpp
+++ b/src/hint/AutoCalculator.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/constraint/abstract/LinearConstraint.h>
 #include <tvm/hint/internal/AutoCalculator.h>

--- a/src/hint/AutoCalculator.cpp
+++ b/src/hint/AutoCalculator.cpp
@@ -1,34 +1,34 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/hint/internal/AutoCalculator.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
+#include <tvm/hint/internal/AutoCalculator.h>
 #include <tvm/hint/internal/DiagonalCalculator.h>
 #include <tvm/hint/internal/GenericCalculator.h>
 
@@ -41,25 +41,28 @@ namespace hint
 namespace internal
 {
 
-  std::unique_ptr<abstract::SubstitutionCalculatorImpl> AutoCalculator::impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const
+std::unique_ptr<abstract::SubstitutionCalculatorImpl> AutoCalculator::impl_(
+    const std::vector<LinearConstraintPtr> & cstr,
+    const std::vector<VariablePtr> & x,
+    int rank) const
+{
+  if(cstr.size() > 1 || x.size() > 1)
   {
-    if (cstr.size() > 1 || x.size() > 1)
-    {
-      return GenericCalculator().impl(cstr, x, rank);
-    }
-    else
-    {
-      const auto& p = cstr[0]->jacobian(*x[0]).properties();
-      if (p.isDiagonal() && p.isInvertible())
-      {
-        return DiagonalCalculator().impl(cstr, x, rank);
-      }
-      return GenericCalculator().impl(cstr, x, rank);
-    }
+    return GenericCalculator().impl(cstr, x, rank);
   }
-
+  else
+  {
+    const auto & p = cstr[0]->jacobian(*x[0]).properties();
+    if(p.isDiagonal() && p.isInvertible())
+    {
+      return DiagonalCalculator().impl(cstr, x, rank);
+    }
+    return GenericCalculator().impl(cstr, x, rank);
+  }
 }
 
-}
+} // namespace internal
 
-}
+} // namespace hint
+
+} // namespace tvm

--- a/src/hint/DiagonalCalculator.cpp
+++ b/src/hint/DiagonalCalculator.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>

--- a/src/hint/DiagonalCalculator.cpp
+++ b/src/hint/DiagonalCalculator.cpp
@@ -1,35 +1,35 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/hint/internal/DiagonalCalculator.h>
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
+#include <tvm/hint/internal/DiagonalCalculator.h>
 
 #include <algorithm>
 
@@ -37,20 +37,20 @@ using namespace Eigen;
 
 namespace
 {
-  /** max value of two sorted vectors, where the second one can be empty*/
-  DenseIndex optionalMax(const std::vector<DenseIndex>& v1, const std::vector<DenseIndex>& v2)
+/** max value of two sorted vectors, where the second one can be empty*/
+DenseIndex optionalMax(const std::vector<DenseIndex> & v1, const std::vector<DenseIndex> & v2)
+{
+  assert(v1.size() > 0);
+  if(v2.empty())
   {
-    assert(v1.size() > 0);
-    if (v2.empty())
-    {
-      return v1.back();
-    }
-    else
-    {
-      return std::max(v1.back(), v2.back());
-    }
+    return v1.back();
+  }
+  else
+  {
+    return std::max(v1.back(), v2.back());
   }
 }
+} // namespace
 
 namespace tvm
 {
@@ -60,246 +60,254 @@ namespace hint
 
 namespace internal
 {
-  DiagonalCalculator::DiagonalCalculator(DenseIndex first, DenseIndex size)
-    : first_(first), size_(size)
+DiagonalCalculator::DiagonalCalculator(DenseIndex first, DenseIndex size) : first_(first), size_(size)
+{
+  if(first < 0)
   {
-    if (first < 0)
-    {
-      throw std::runtime_error("first must be non-negative.");
-    }
-    if (size < -1)
-    {
-      throw std::runtime_error("Invalid size.");
-    }
+    throw std::runtime_error("first must be non-negative.");
+  }
+  if(size < -1)
+  {
+    throw std::runtime_error("Invalid size.");
+  }
+}
+
+DiagonalCalculator::DiagonalCalculator(const std::vector<DenseIndex> & nnzRows,
+                                       const std::vector<DenseIndex> & zeroRows)
+: first_(-1), size_(-1), nnz_(nnzRows), zeros_(zeroRows)
+{
+  if(nnz_.empty())
+  {
+    throw std::runtime_error("There should be at least one non-zero row.");
   }
 
-  DiagonalCalculator::DiagonalCalculator(const std::vector<DenseIndex>& nnzRows, const std::vector<DenseIndex>& zeroRows)
-    : first_(-1), size_(-1), nnz_(nnzRows), zeros_(zeroRows)
+  std::sort(nnz_.begin(), nnz_.end());
+  std::sort(zeros_.begin(), zeros_.end());
+
+  std::vector<bool> appear(optionalMax(nnz_, zeros_) + 1, false);
+
+  for(auto i : nnz_)
   {
-    if (nnz_.empty())
+    if(i < 0)
     {
-      throw std::runtime_error("There should be at least one non-zero row.");
+      throw std::runtime_error("Indices must be non-negative.");
     }
-
-    std::sort(nnz_.begin(), nnz_.end());
-    std::sort(zeros_.begin(), zeros_.end());
-
-    std::vector<bool> appear(optionalMax(nnz_, zeros_) + 1, false);
-
-    for (auto i : nnz_)
+    if(appear[static_cast<size_t>(i)])
     {
-      if (i < 0)
-      {
-        throw std::runtime_error("Indices must be non-negative.");
-      }
-      if (appear[static_cast<size_t>(i)])
-      {
-        throw std::runtime_error("Each index must be unique.");
-      }
-      else
-      {
-        appear[i] = true;
-      }
-    }
-
-    for (auto i : zeros_)
-    {
-      if (i < 0)
-      {
-        throw std::runtime_error("Indices must be non-negative.");
-      }
-      if (appear[static_cast<size_t>(i)])
-      {
-        throw std::runtime_error("Each index of nnzRows and zeroRows must be unique.");
-      }
-      else
-      {
-        appear[i] = true;
-      }
-    }
-  }
-
-  std::unique_ptr<abstract::SubstitutionCalculatorImpl> DiagonalCalculator::impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const
-  {
-    if (first_ >= 0)
-    {
-      return std::unique_ptr<abstract::SubstitutionCalculatorImpl>(new Impl(cstr, x, rank, first_, size_));
+      throw std::runtime_error("Each index must be unique.");
     }
     else
     {
-      return std::unique_ptr<abstract::SubstitutionCalculatorImpl>(new Impl(cstr, x, rank, nnz_, zeros_));
+      appear[i] = true;
     }
   }
 
-  DiagonalCalculator::Impl::Impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank, DenseIndex first, DenseIndex size)
-    : SubstitutionCalculatorImpl(cstr, x, rank)
-    , first_(first)
-    , size_(size)
+  for(auto i : zeros_)
   {
-    if (!isSimple())
+    if(i < 0)
     {
-      throw std::runtime_error("This calculator is only for the substitution of a single variable through a single constraint.");
+      throw std::runtime_error("Indices must be non-negative.");
     }
-    if (size == -1)
+    if(appear[static_cast<size_t>(i)])
     {
-      size_ = x.front()->size() - first;
-    }
-    if (size_ != rank)
-    {
-      throw std::runtime_error("The number of non-zero rows is not consistent with the rank.");
-    }
-
-    DenseIndex i = 0;
-    for (; i < first; ++i)
-    {
-      cnnz_.push_back(i);
-    }
-    for (DenseIndex j = 0; j < size_; ++i, ++j)
-    {
-      nnz_.push_back(i);
-    }
-    for (; i < n(); ++i)
-    {
-      cnnz_.push_back(i);
-    }
-
-
-    build();
-  }
-
-  DiagonalCalculator::Impl::Impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank, const std::vector<DenseIndex>& nnzRows, const std::vector<DenseIndex>& zeroRows)
-    : SubstitutionCalculatorImpl(cstr, x, rank)
-    , first_(-1)
-    , size_(0)
-    , nnz_(nnzRows)
-    , cnnz_()
-    , zeros_(zeroRows)
-  {
-    if (!isSimple())
-    {
-      throw std::runtime_error("This calculator is only for the substitution of a single variable through a single constraint.");
-    }
-    if (static_cast<int>(optionalMax(nnzRows, zeroRows)) >= n())
-    {
-      throw std::runtime_error("Some indices are too large for the substitution considered");
-    }
-    if (static_cast<int>(nnzRows.size()) != rank)
-    {
-      throw std::runtime_error("The number of non-zero rows is not consistent with the rank.");
-    }
-
-    // build cnnz_
-    for (DenseIndex i = 0; i < nnz_.front(); ++i)
-    {
-      cnnz_.push_back(i);
-    }
-    for (size_t j = 0; j < nnz_.size()-1; ++j)
-    {
-      for (auto i = nnz_[j] + 1; i < nnz_[j + 1]; ++i)
-      {
-        cnnz_.push_back(i);
-      }
-    }
-    for (auto i = nnz_.back() + 1; i < n(); ++i)
-    {
-      cnnz_.push_back(i);
-    }
-
-    build();
-  }
-
-  void DiagonalCalculator::Impl::update_()
-  {
-    const auto& A = constraints_[0]->jacobian(*variables_[0]);
-    for (size_t i = 0; i < nnz_.size(); ++i)
-    {
-      inverse_[static_cast<DenseIndex>(i)] = 1. / A(innz_[i], nnz_[i]);
-    }
-  }
-
-  void DiagonalCalculator::Impl::premultiplyByASharpAndSTranspose_(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const
-  {
-    //FIXME: optimized version for identity/minus identity
-
-    // multiplying by A^#
-    if (minus)
-    {
-      for (size_t i = 0; i < nnz_.size(); ++i)
-      {
-        outA.row(nnz_[i]) = -inverse_[static_cast<DenseIndex>(i)] * in.row(innz_[i]);
-      }
+      throw std::runtime_error("Each index of nnzRows and zeroRows must be unique.");
     }
     else
     {
-      for (size_t i = 0; i < nnz_.size(); ++i)
-      {
-        outA.row(nnz_[i]) = inverse_[static_cast<DenseIndex>(i)] * in.row(innz_[i]);
-      }
-    }
-    for (auto i : cnnz_)
-    {
-      outA.row(i).setZero();
-    }
-
-    //multiplying by S^T
-    for (size_t i = 0; i < zeros_.size(); ++i)
-    {
-      outS.row(static_cast<DenseIndex>(i)) = in.row(zeros_[i]);
+      appear[i] = true;
     }
   }
+}
 
-  void DiagonalCalculator::Impl::postMultiplyByN_(MatrixRef out, const MatrixConstRef& in, bool add) const
+std::unique_ptr<abstract::SubstitutionCalculatorImpl> DiagonalCalculator::impl_(
+    const std::vector<LinearConstraintPtr> & cstr,
+    const std::vector<VariablePtr> & x,
+    int rank) const
+{
+  if(first_ >= 0)
   {
-    if (add)
-    {
-      for (size_t i = 0; i < cnnz_.size(); ++i)
-      {
-        out.col(static_cast<DenseIndex>(i)) += in.col(cnnz_[i]);
-      }
-    }
-    else
-    {
-      for (size_t i = 0; i < cnnz_.size(); ++i)
-      {
-        out.col(static_cast<DenseIndex>(i)) = in.col(cnnz_[i]);
-      }
-    }
+    return std::unique_ptr<abstract::SubstitutionCalculatorImpl>(new Impl(cstr, x, rank, first_, size_));
   }
-
-  void DiagonalCalculator::Impl::build()
+  else
   {
-    N_.setZero();
-    for (size_t i = 0; i < cnnz_.size(); ++i)
-    {
-      N_(cnnz_[i], static_cast<DenseIndex>(i)) = 1;
-    }
-
-    std::vector<bool> appearnnz(static_cast<size_t>(n()), false);
-    std::vector<bool> appearZero(static_cast<size_t>(n()), false);
-    for (auto i : nnz_)
-    {
-      appearnnz[i] = true;
-    }
-    for (auto i : zeros_)
-    {
-      appearZero[i] = true;
-    }
-    DenseIndex k = 0;
-    for (size_t i = 0; i < static_cast<size_t>(n()); ++i)
-    {
-      if (appearnnz[i])
-      {
-        innz_.push_back(k);
-        ++k;
-      }
-      else if (appearZero[i])
-      {
-        ++k;
-      }
-    }
-
-    inverse_.resize(static_cast<DenseIndex>(nnz_.size()));
+    return std::unique_ptr<abstract::SubstitutionCalculatorImpl>(new Impl(cstr, x, rank, nnz_, zeros_));
   }
 }
+
+DiagonalCalculator::Impl::Impl(const std::vector<LinearConstraintPtr> & cstr,
+                               const std::vector<VariablePtr> & x,
+                               int rank,
+                               DenseIndex first,
+                               DenseIndex size)
+: SubstitutionCalculatorImpl(cstr, x, rank), first_(first), size_(size)
+{
+  if(!isSimple())
+  {
+    throw std::runtime_error(
+        "This calculator is only for the substitution of a single variable through a single constraint.");
+  }
+  if(size == -1)
+  {
+    size_ = x.front()->size() - first;
+  }
+  if(size_ != rank)
+  {
+    throw std::runtime_error("The number of non-zero rows is not consistent with the rank.");
+  }
+
+  DenseIndex i = 0;
+  for(; i < first; ++i)
+  {
+    cnnz_.push_back(i);
+  }
+  for(DenseIndex j = 0; j < size_; ++i, ++j)
+  {
+    nnz_.push_back(i);
+  }
+  for(; i < n(); ++i)
+  {
+    cnnz_.push_back(i);
+  }
+
+  build();
 }
+
+DiagonalCalculator::Impl::Impl(const std::vector<LinearConstraintPtr> & cstr,
+                               const std::vector<VariablePtr> & x,
+                               int rank,
+                               const std::vector<DenseIndex> & nnzRows,
+                               const std::vector<DenseIndex> & zeroRows)
+: SubstitutionCalculatorImpl(cstr, x, rank), first_(-1), size_(0), nnz_(nnzRows), cnnz_(), zeros_(zeroRows)
+{
+  if(!isSimple())
+  {
+    throw std::runtime_error(
+        "This calculator is only for the substitution of a single variable through a single constraint.");
+  }
+  if(static_cast<int>(optionalMax(nnzRows, zeroRows)) >= n())
+  {
+    throw std::runtime_error("Some indices are too large for the substitution considered");
+  }
+  if(static_cast<int>(nnzRows.size()) != rank)
+  {
+    throw std::runtime_error("The number of non-zero rows is not consistent with the rank.");
+  }
+
+  // build cnnz_
+  for(DenseIndex i = 0; i < nnz_.front(); ++i)
+  {
+    cnnz_.push_back(i);
+  }
+  for(size_t j = 0; j < nnz_.size() - 1; ++j)
+  {
+    for(auto i = nnz_[j] + 1; i < nnz_[j + 1]; ++i)
+    {
+      cnnz_.push_back(i);
+    }
+  }
+  for(auto i = nnz_.back() + 1; i < n(); ++i)
+  {
+    cnnz_.push_back(i);
+  }
+
+  build();
 }
+
+void DiagonalCalculator::Impl::update_()
+{
+  const auto & A = constraints_[0]->jacobian(*variables_[0]);
+  for(size_t i = 0; i < nnz_.size(); ++i)
+  {
+    inverse_[static_cast<DenseIndex>(i)] = 1. / A(innz_[i], nnz_[i]);
+  }
+}
+
+void DiagonalCalculator::Impl::premultiplyByASharpAndSTranspose_(MatrixRef outA,
+                                                                 MatrixRef outS,
+                                                                 const MatrixConstRef & in,
+                                                                 bool minus) const
+{
+  // FIXME: optimized version for identity/minus identity
+
+  // multiplying by A^#
+  if(minus)
+  {
+    for(size_t i = 0; i < nnz_.size(); ++i)
+    {
+      outA.row(nnz_[i]) = -inverse_[static_cast<DenseIndex>(i)] * in.row(innz_[i]);
+    }
+  }
+  else
+  {
+    for(size_t i = 0; i < nnz_.size(); ++i)
+    {
+      outA.row(nnz_[i]) = inverse_[static_cast<DenseIndex>(i)] * in.row(innz_[i]);
+    }
+  }
+  for(auto i : cnnz_)
+  {
+    outA.row(i).setZero();
+  }
+
+  // multiplying by S^T
+  for(size_t i = 0; i < zeros_.size(); ++i)
+  {
+    outS.row(static_cast<DenseIndex>(i)) = in.row(zeros_[i]);
+  }
+}
+
+void DiagonalCalculator::Impl::postMultiplyByN_(MatrixRef out, const MatrixConstRef & in, bool add) const
+{
+  if(add)
+  {
+    for(size_t i = 0; i < cnnz_.size(); ++i)
+    {
+      out.col(static_cast<DenseIndex>(i)) += in.col(cnnz_[i]);
+    }
+  }
+  else
+  {
+    for(size_t i = 0; i < cnnz_.size(); ++i)
+    {
+      out.col(static_cast<DenseIndex>(i)) = in.col(cnnz_[i]);
+    }
+  }
+}
+
+void DiagonalCalculator::Impl::build()
+{
+  N_.setZero();
+  for(size_t i = 0; i < cnnz_.size(); ++i)
+  {
+    N_(cnnz_[i], static_cast<DenseIndex>(i)) = 1;
+  }
+
+  std::vector<bool> appearnnz(static_cast<size_t>(n()), false);
+  std::vector<bool> appearZero(static_cast<size_t>(n()), false);
+  for(auto i : nnz_)
+  {
+    appearnnz[i] = true;
+  }
+  for(auto i : zeros_)
+  {
+    appearZero[i] = true;
+  }
+  DenseIndex k = 0;
+  for(size_t i = 0; i < static_cast<size_t>(n()); ++i)
+  {
+    if(appearnnz[i])
+    {
+      innz_.push_back(k);
+      ++k;
+    }
+    else if(appearZero[i])
+    {
+      ++k;
+    }
+  }
+
+  inverse_.resize(static_cast<DenseIndex>(nnz_.size()));
+}
+} // namespace internal
+} // namespace hint
+} // namespace tvm

--- a/src/hint/GenericCalculator.cpp
+++ b/src/hint/GenericCalculator.cpp
@@ -28,8 +28,7 @@ GenericCalculator::Impl::Impl(const std::vector<LinearConstraintPtr> & cstr,
                               const std::vector<VariablePtr> & x,
                               int rank)
 : SubstitutionCalculatorImpl(cstr, x, rank), qr_(m(), n()), invR1R2_(r(), n() - r()), tmp_(m(), 2 * n())
-{
-}
+{}
 
 void GenericCalculator::Impl::update_()
 {

--- a/src/hint/GenericCalculator.cpp
+++ b/src/hint/GenericCalculator.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>

--- a/src/hint/GenericCalculator.cpp
+++ b/src/hint/GenericCalculator.cpp
@@ -1,35 +1,35 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/hint/internal/GenericCalculator.h>
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
+#include <tvm/hint/internal/GenericCalculator.h>
 
 #include <sstream>
 
@@ -40,120 +40,125 @@ namespace tvm
 
 namespace hint
 {
-    
+
 namespace internal
 {
-  std::unique_ptr<abstract::SubstitutionCalculatorImpl> GenericCalculator::impl_(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const
+std::unique_ptr<abstract::SubstitutionCalculatorImpl> GenericCalculator::impl_(
+    const std::vector<LinearConstraintPtr> & cstr,
+    const std::vector<VariablePtr> & x,
+    int rank) const
+{
+  return std::unique_ptr<abstract::SubstitutionCalculatorImpl>(new GenericCalculator::Impl(cstr, x, rank));
+}
+
+GenericCalculator::Impl::Impl(const std::vector<LinearConstraintPtr> & cstr,
+                              const std::vector<VariablePtr> & x,
+                              int rank)
+: SubstitutionCalculatorImpl(cstr, x, rank), qr_(m(), n()), invR1R2_(r(), n() - r()), tmp_(m(), 2 * n())
+{
+}
+
+void GenericCalculator::Impl::update_()
+{
+  if(isSimple())
   {
-    return std::unique_ptr<abstract::SubstitutionCalculatorImpl>(new GenericCalculator::Impl(cstr, x, rank));
+    qr_.compute(constraints_.front()->jacobian(*variables_[0]));
+  }
+  else
+  {
+    fillA();
+    qr_.compute(A());
   }
 
-  GenericCalculator::Impl::Impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank)
-    : SubstitutionCalculatorImpl(cstr, x, rank)
-    , qr_(m(),n())
-    , invR1R2_(r(), n()-r())
-    , tmp_(m(), 2*n())
+  if(qr_.rank() != r())
   {
-  }
-
-  void GenericCalculator::Impl::update_()
-  {
-    if (isSimple())
+    std::stringstream ss;
+    const auto & vars = variables_.variables();
+    ss << "During the substitution of the ";
+    if(variables_.variables().size() == 1)
     {
-      qr_.compute(constraints_.front()->jacobian(*variables_[0]));
+      ss << "variable " << vars.front()->name();
     }
     else
     {
-      fillA();
-      qr_.compute(A());
-    }
-
-    if (qr_.rank() != r())
-    {
-      std::stringstream ss;
-      const auto& vars = variables_.variables();
-      ss << "During the substitution of the ";
-      if (variables_.variables().size() == 1)
+      ss << "variables (";
+      for(size_t i = 0; i < vars.size() - 1; ++i)
       {
-        ss << "variable " << vars.front()->name();
+        ss << vars[i]->name() << ", ";
       }
-      else
-      {
-        ss << "variables (";
-        for (size_t i = 0; i < vars.size() - 1; ++i)
-        {
-          ss << vars[i]->name() << ", ";
-        }
-        ss << vars.back()->name() << ")";
-      }
-      ss << ": the rank of the matrix (" << qr_.rank();
-      ss << ") is not the one that was specified (" << r() << ").";
-      throw std::runtime_error(ss.str());
+      ss << vars.back()->name() << ")";
     }
-      
-    //Set shortcuts
-    const auto& R1 = qr_.matrixR().topLeftCorner(r(), r()).template triangularView<Eigen::Upper>();
-    auto& R2 = qr_.matrixR().topRightCorner(r(), n() - r());
-    const auto& P = qr_.colsPermutation().indices();
-
-    //Compute inv(R1) * R2
-    invR1R2_ = R1.solve(R2);
-
-    // N = P_2 - P_1 * inv(R1) * R2
-    for (Eigen::DenseIndex i = 0; i < r(); ++i)
-    {
-      N_.row(P.coeff(i)) = -invR1R2_.row(i);
-    }
-    for (auto i = r(); i < n(); ++i)
-    {
-      N_.row(P.coeff(i)).setZero();
-      N_(P.coeff(i), i - r()) = 1;
-    }
+    ss << ": the rank of the matrix (" << qr_.rank();
+    ss << ") is not the one that was specified (" << r() << ").";
+    throw std::runtime_error(ss.str());
   }
 
-  void GenericCalculator::Impl::premultiplyByASharpAndSTranspose_(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const
+  // Set shortcuts
+  const auto & R1 = qr_.matrixR().topLeftCorner(r(), r()).template triangularView<Eigen::Upper>();
+  auto & R2 = qr_.matrixR().topRightCorner(r(), n() - r());
+  const auto & P = qr_.colsPermutation().indices();
+
+  // Compute inv(R1) * R2
+  invR1R2_ = R1.solve(R2);
+
+  // N = P_2 - P_1 * inv(R1) * R2
+  for(Eigen::DenseIndex i = 0; i < r(); ++i)
   {
-    //For M = in, and A = | Q1   Q2 | | R1  R2 | | P1^T | 
-    //                                |  0   0 | | P2^T |
-    // we compute | P1 R1^-1   0 | | Q1^T | M
-    //            |    0       I | | Q2^T |     
-    tmp_.resize(m(), in.cols());
-    auto T = tmp_.get();
-    
-    // T = Q^T M
-    T = qr_.matrixQ().setLength(qr_.nonzeroPivots()).transpose() * in;
+    N_.row(P.coeff(i)) = -invR1R2_.row(i);
+  }
+  for(auto i = r(); i < n(); ++i)
+  {
+    N_.row(P.coeff(i)).setZero();
+    N_(P.coeff(i), i - r()) = 1;
+  }
+}
 
-    // T(1:r,:) = R1^-1 T(1:r,:)
-    const auto& R1 = qr_.matrixR().topLeftCorner(r(), r()).template triangularView<Eigen::Upper>();
-    R1.solveInPlace(T.topRows(r()));
+void GenericCalculator::Impl::premultiplyByASharpAndSTranspose_(MatrixRef outA,
+                                                                MatrixRef outS,
+                                                                const MatrixConstRef & in,
+                                                                bool minus) const
+{
+  // For M = in, and A = | Q1   Q2 | | R1  R2 | | P1^T |
+  //                                |  0   0 | | P2^T |
+  // we compute | P1 R1^-1   0 | | Q1^T | M
+  //            |    0       I | | Q2^T |
+  tmp_.resize(m(), in.cols());
+  auto T = tmp_.get();
 
-    // outA = - P1 * T(1:r,:)
-    if (minus)
-    {
-      for (DenseIndex i = 0; i < r(); ++i)
-      {
-        outA.row(qr_.colsPermutation().indices().coeff(i)) = -T.row(i);
-      }
-    }
-    else
-    {
-      for (DenseIndex i = 0; i < r(); ++i)
-      {
-        outA.row(qr_.colsPermutation().indices().coeff(i)) = T.row(i);
-      }
-    }
-    
-    for (DenseIndex i = r(); i < n(); ++i)
-    {
-      outA.row(qr_.colsPermutation().indices().coeff(i)).setZero();
-    }
+  // T = Q^T M
+  T = qr_.matrixQ().setLength(qr_.nonzeroPivots()).transpose() * in;
 
-    // outS
-    outS = T.bottomRows(m() - r());
+  // T(1:r,:) = R1^-1 T(1:r,:)
+  const auto & R1 = qr_.matrixR().topLeftCorner(r(), r()).template triangularView<Eigen::Upper>();
+  R1.solveInPlace(T.topRows(r()));
+
+  // outA = - P1 * T(1:r,:)
+  if(minus)
+  {
+    for(DenseIndex i = 0; i < r(); ++i)
+    {
+      outA.row(qr_.colsPermutation().indices().coeff(i)) = -T.row(i);
+    }
+  }
+  else
+  {
+    for(DenseIndex i = 0; i < r(); ++i)
+    {
+      outA.row(qr_.colsPermutation().indices().coeff(i)) = T.row(i);
+    }
   }
 
+  for(DenseIndex i = r(); i < n(); ++i)
+  {
+    outA.row(qr_.colsPermutation().indices().coeff(i)).setZero();
+  }
+
+  // outS
+  outS = T.bottomRows(m() - r());
 }
 
-}
+} // namespace internal
 
-}
+} // namespace hint
+
+} // namespace tvm

--- a/src/hint/Substitution.cpp
+++ b/src/hint/Substitution.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/hint/Substitution.h>
 
@@ -40,141 +40,132 @@ namespace tvm
 namespace hint
 {
 
-  Substitution::Substitution(LinearConstraintPtr cstr, VariablePtr x, int rank,
-                             const abstract::SubstitutionCalculator& calc)
-    : Substitution(std::vector<LinearConstraintPtr>{ cstr }, std::vector<VariablePtr>{ x }, rank, calc)
-  {
-  }
-
-  Substitution::Substitution(const std::vector<LinearConstraintPtr>& cstr, VariablePtr x, int rank,
-                             const abstract::SubstitutionCalculator& calc)
-    : Substitution(cstr, std::vector<VariablePtr>{ x }, rank, calc)
-  {
-  }
-
-  Substitution::Substitution(LinearConstraintPtr cstr, std::vector<VariablePtr>& x, int rank,
-                             const abstract::SubstitutionCalculator& calc)
-    : Substitution(std::vector<LinearConstraintPtr>{ cstr }, x, rank, calc)
-  {
-  }
-
-  Substitution::Substitution(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank,
-                             const abstract::SubstitutionCalculator& calc)
-    : rank_(rank), m_(0), constraints_(cstr), x_(x)
-  {
-    if (rank == constant::fullRank)
-    {
-      int r = 0;
-      for (const auto& c : cstr)
-      {
-        r += c->size();
-      }
-      rank_ = r;
-    }
-    for (const auto& c : constraints_)
-    {
-      m_ += c->size();
-    }
-    check();
-    calculator_ = calc.impl(cstr, x, rank_);
-  }
-
-  int Substitution::rank() const
-  {
-    return rank_;
-  }
-
-  int Substitution::m() const
-  {
-    return m_;
-  }
-
-  const std::vector<LinearConstraintPtr>& Substitution::constraints() const
-  {
-    return constraints_;
-  }
-
-  const std::vector<VariablePtr>& Substitution::variables() const
-  {
-    return x_;
-  }
-
-  bool Substitution::isSimple() const
-  {
-    return constraints_.size() == 1 && x_.size() == 1;
-  }
-
-  std::shared_ptr<abstract::SubstitutionCalculatorImpl> Substitution::calculator() const
-  {
-    return calculator_;
-  }
-
-  void Substitution::check() const
-  {
-    //all constraints need to be equality
-    for (const auto& c : constraints_)
-    {
-      // It could be possible to accept double sided inequality constraints with both bounds equal
-      // but in this case we would need to assert that the bounds are and stay equals (the latter
-      // requiring some form of annotation).
-      // If the bounds are known to be always equal, the user should simply use an equality.
-      // If only some of the bounds are equal but not all, we would need an annotation giving the
-      // pattern, and handling it would add a lot of complexity for a not so common case.
-      if (c->type() != constraint::Type::EQUAL)
-      {
-        throw std::runtime_error("Substitution can only be done using equality constraints.");
-      }
-    }
-
-    std::vector<bool> varIsInOneConstr(x_.size(), false);
-    std::vector<bool> constrHasOneVar(constraints_.size(), false);
-
-    for (size_t i = 0; i < constraints_.size(); ++i)
-    {
-      for (size_t j = 0; j < x_.size(); ++j)
-      {
-        if (constraints_[i]->variables().contains(*x_[j]))
-        {
-          varIsInOneConstr[j] = true;
-          constrHasOneVar[i] = true;
-        }
-      }
-    }
-
-    //all variables need to appear in at least one constraints
-    for (size_t j = 0; j < x_.size(); ++j)
-    {
-      if (!varIsInOneConstr[j])
-      {
-        std::stringstream ss;
-        ss << "The variable " << x_[j] << " cannot be used for substitution: it does not appear in any of the given constraints.";
-        throw std::runtime_error(ss.str());
-      }
-    }
-
-    //all constraints need to contain at least one of the listed variables
-    for (size_t i = 0; i < constraints_.size(); ++i)
-    {
-      if (!constrHasOneVar[i])
-      {
-        std::stringstream ss;
-        ss << "The " << (i + 1) << "-th constraint (index " << i << ") does not contains any of the specified variables.";
-        throw std::runtime_error(ss.str());
-      }
-    }
-
-    //rank of the substitution cannot be greater than the size of the variables
-    int s = 0;
-    for (const auto& xi : x_)
-    {
-      s += xi->size();
-    }
-    if (rank_ > s)
-    {
-      throw std::runtime_error("Substitution is not feasible: too many equations.");
-    }
-  }
-
+Substitution::Substitution(LinearConstraintPtr cstr,
+                           VariablePtr x,
+                           int rank,
+                           const abstract::SubstitutionCalculator & calc)
+: Substitution(std::vector<LinearConstraintPtr>{cstr}, std::vector<VariablePtr>{x}, rank, calc)
+{
 }
 
+Substitution::Substitution(const std::vector<LinearConstraintPtr> & cstr,
+                           VariablePtr x,
+                           int rank,
+                           const abstract::SubstitutionCalculator & calc)
+: Substitution(cstr, std::vector<VariablePtr>{x}, rank, calc)
+{
 }
+
+Substitution::Substitution(LinearConstraintPtr cstr,
+                           std::vector<VariablePtr> & x,
+                           int rank,
+                           const abstract::SubstitutionCalculator & calc)
+: Substitution(std::vector<LinearConstraintPtr>{cstr}, x, rank, calc)
+{
+}
+
+Substitution::Substitution(const std::vector<LinearConstraintPtr> & cstr,
+                           const std::vector<VariablePtr> & x,
+                           int rank,
+                           const abstract::SubstitutionCalculator & calc)
+: rank_(rank), m_(0), constraints_(cstr), x_(x)
+{
+  if(rank == constant::fullRank)
+  {
+    int r = 0;
+    for(const auto & c : cstr)
+    {
+      r += c->size();
+    }
+    rank_ = r;
+  }
+  for(const auto & c : constraints_)
+  {
+    m_ += c->size();
+  }
+  check();
+  calculator_ = calc.impl(cstr, x, rank_);
+}
+
+int Substitution::rank() const { return rank_; }
+
+int Substitution::m() const { return m_; }
+
+const std::vector<LinearConstraintPtr> & Substitution::constraints() const { return constraints_; }
+
+const std::vector<VariablePtr> & Substitution::variables() const { return x_; }
+
+bool Substitution::isSimple() const { return constraints_.size() == 1 && x_.size() == 1; }
+
+std::shared_ptr<abstract::SubstitutionCalculatorImpl> Substitution::calculator() const { return calculator_; }
+
+void Substitution::check() const
+{
+  // all constraints need to be equality
+  for(const auto & c : constraints_)
+  {
+    // It could be possible to accept double sided inequality constraints with both bounds equal
+    // but in this case we would need to assert that the bounds are and stay equals (the latter
+    // requiring some form of annotation).
+    // If the bounds are known to be always equal, the user should simply use an equality.
+    // If only some of the bounds are equal but not all, we would need an annotation giving the
+    // pattern, and handling it would add a lot of complexity for a not so common case.
+    if(c->type() != constraint::Type::EQUAL)
+    {
+      throw std::runtime_error("Substitution can only be done using equality constraints.");
+    }
+  }
+
+  std::vector<bool> varIsInOneConstr(x_.size(), false);
+  std::vector<bool> constrHasOneVar(constraints_.size(), false);
+
+  for(size_t i = 0; i < constraints_.size(); ++i)
+  {
+    for(size_t j = 0; j < x_.size(); ++j)
+    {
+      if(constraints_[i]->variables().contains(*x_[j]))
+      {
+        varIsInOneConstr[j] = true;
+        constrHasOneVar[i] = true;
+      }
+    }
+  }
+
+  // all variables need to appear in at least one constraints
+  for(size_t j = 0; j < x_.size(); ++j)
+  {
+    if(!varIsInOneConstr[j])
+    {
+      std::stringstream ss;
+      ss << "The variable " << x_[j]
+         << " cannot be used for substitution: it does not appear in any of the given constraints.";
+      throw std::runtime_error(ss.str());
+    }
+  }
+
+  // all constraints need to contain at least one of the listed variables
+  for(size_t i = 0; i < constraints_.size(); ++i)
+  {
+    if(!constrHasOneVar[i])
+    {
+      std::stringstream ss;
+      ss << "The " << (i + 1) << "-th constraint (index " << i << ") does not contains any of the specified variables.";
+      throw std::runtime_error(ss.str());
+    }
+  }
+
+  // rank of the substitution cannot be greater than the size of the variables
+  int s = 0;
+  for(const auto & xi : x_)
+  {
+    s += xi->size();
+  }
+  if(rank_ > s)
+  {
+    throw std::runtime_error("Substitution is not feasible: too many equations.");
+  }
+}
+
+} // namespace hint
+
+} // namespace tvm

--- a/src/hint/Substitution.cpp
+++ b/src/hint/Substitution.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/hint/Substitution.h>
 

--- a/src/hint/Substitution.cpp
+++ b/src/hint/Substitution.cpp
@@ -18,24 +18,21 @@ Substitution::Substitution(LinearConstraintPtr cstr,
                            int rank,
                            const abstract::SubstitutionCalculator & calc)
 : Substitution(std::vector<LinearConstraintPtr>{cstr}, std::vector<VariablePtr>{x}, rank, calc)
-{
-}
+{}
 
 Substitution::Substitution(const std::vector<LinearConstraintPtr> & cstr,
                            VariablePtr x,
                            int rank,
                            const abstract::SubstitutionCalculator & calc)
 : Substitution(cstr, std::vector<VariablePtr>{x}, rank, calc)
-{
-}
+{}
 
 Substitution::Substitution(LinearConstraintPtr cstr,
                            std::vector<VariablePtr> & x,
                            int rank,
                            const abstract::SubstitutionCalculator & calc)
 : Substitution(std::vector<LinearConstraintPtr>{cstr}, x, rank, calc)
-{
-}
+{}
 
 Substitution::Substitution(const std::vector<LinearConstraintPtr> & cstr,
                            const std::vector<VariablePtr> & x,

--- a/src/hint/SubstitutionCalculator.cpp
+++ b/src/hint/SubstitutionCalculator.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/hint/abstract/SubstitutionCalculator.h>
 
@@ -38,13 +38,15 @@ namespace hint
 namespace abstract
 {
 
-std::unique_ptr<SubstitutionCalculatorImpl> SubstitutionCalculator::impl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank) const
+std::unique_ptr<SubstitutionCalculatorImpl> SubstitutionCalculator::impl(const std::vector<LinearConstraintPtr> & cstr,
+                                                                         const std::vector<VariablePtr> & x,
+                                                                         int rank) const
 {
   return impl_(cstr, x, rank);
 }
 
-}
+} // namespace abstract
 
-}
+} // namespace hint
 
-}
+} // namespace tvm

--- a/src/hint/SubstitutionCalculator.cpp
+++ b/src/hint/SubstitutionCalculator.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/hint/abstract/SubstitutionCalculator.h>
 

--- a/src/hint/SubstitutionCalculatorImpl.cpp
+++ b/src/hint/SubstitutionCalculatorImpl.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/hint/abstract/SubstitutionCalculatorImpl.h>
 
@@ -34,12 +34,12 @@
 
 namespace
 {
-  // return true if the buffers for M1 and M2 are disjoint
-  bool noAliasing(const tvm::MatrixConstRef& M1, const tvm::MatrixConstRef& M2)
-  {
-    return M1.data() >= M2.data() + M2.size() || M2.data() >= M1.data() + M1.size();
-  }
+// return true if the buffers for M1 and M2 are disjoint
+bool noAliasing(const tvm::MatrixConstRef & M1, const tvm::MatrixConstRef & M2)
+{
+  return M1.data() >= M2.data() + M2.size() || M2.data() >= M1.data() + M1.size();
 }
+} // namespace
 
 namespace tvm
 {
@@ -52,19 +52,23 @@ namespace abstract
 
 void SubstitutionCalculatorImpl::update()
 {
-  if (!constant_ || init_)
+  if(!constant_ || init_)
   {
     update_();
     assert(N_.rows() == n_);
-    if (N_.cols() != n_ - r_)
+    if(N_.cols() != n_ - r_)
     {
-      throw std::runtime_error("N_ does not have the correct size. Did you specify a correct rank for the substitution, or did the rank change (which is not allowed)?");
+      throw std::runtime_error("N_ does not have the correct size. Did you specify a correct rank for the "
+                               "substitution, or did the rank change (which is not allowed)?");
     }
     init_ = false;
   }
 }
 
-void SubstitutionCalculatorImpl::premultiplyByASharpAndSTranspose(MatrixRef outA, MatrixRef outS, const MatrixConstRef& in, bool minus) const
+void SubstitutionCalculatorImpl::premultiplyByASharpAndSTranspose(MatrixRef outA,
+                                                                  MatrixRef outS,
+                                                                  const MatrixConstRef & in,
+                                                                  bool minus) const
 {
   assert(noAliasing(outA, in));
   assert(noAliasing(outS, in));
@@ -82,7 +86,7 @@ void SubstitutionCalculatorImpl::premultiplyByASharpAndSTranspose(MatrixRef outA
   assert(outS.cols() == in.cols());
 }
 
-void SubstitutionCalculatorImpl::postMultiplyByN(MatrixRef out, const MatrixConstRef& in, bool add) const
+void SubstitutionCalculatorImpl::postMultiplyByN(MatrixRef out, const MatrixConstRef & in, bool add) const
 {
   assert(noAliasing(out, in));
   assert(out.cols() == n_ - r_);
@@ -102,7 +106,7 @@ void SubstitutionCalculatorImpl::postMultiplyByN(MatrixRef out, const MatrixCons
   assert(in.cols() == r.dim);
   assert(out.rows() == in.rows());
 
-  if (r.start == 0 && r.dim == n_)
+  if(r.start == 0 && r.dim == n_)
   {
     postMultiplyByN_(out, in, add);
   }
@@ -117,7 +121,7 @@ void SubstitutionCalculatorImpl::postMultiplyByN(MatrixRef out, const MatrixCons
 
 void SubstitutionCalculatorImpl::postMultiplyByN_(MatrixRef out, const MatrixConstRef & in, bool add) const
 {
-  if (add)
+  if(add)
   {
     out.noalias() += in * N();
   }
@@ -129,9 +133,9 @@ void SubstitutionCalculatorImpl::postMultiplyByN_(MatrixRef out, const MatrixCon
 
 void SubstitutionCalculatorImpl::postMultiplyByN_(MatrixRef out, const MatrixConstRef & in, Range r, bool add) const
 {
-  if (add)
+  if(add)
   {
-    out.noalias() += in * N().middleRows(r.start,r.dim);
+    out.noalias() += in * N().middleRows(r.start, r.dim);
   }
   else
   {
@@ -141,35 +145,28 @@ void SubstitutionCalculatorImpl::postMultiplyByN_(MatrixRef out, const MatrixCon
 
 void SubstitutionCalculatorImpl::fillA()
 {
-  for (auto& f : fillData_)
+  for(auto & f : fillData_)
   {
     f.block = f.cstr->jacobian(*f.x);
   }
 }
 
-const Eigen::MatrixXd& SubstitutionCalculatorImpl::N() const
-{
-  return N_;
-}
+const Eigen::MatrixXd & SubstitutionCalculatorImpl::N() const { return N_; }
 
-SubstitutionCalculatorImpl::SubstitutionCalculatorImpl(const std::vector<LinearConstraintPtr>& cstr, const std::vector<VariablePtr>& x, int rank)
-  : constraints_(cstr)
-  , variables_(x)
-  , m_(0)
-  , n_(0)
-  , r_(rank)
-  , constant_(false)
-  , init_(true)
-  , simple_(cstr.size()==1 && x.size()==1)
+SubstitutionCalculatorImpl::SubstitutionCalculatorImpl(const std::vector<LinearConstraintPtr> & cstr,
+                                                       const std::vector<VariablePtr> & x,
+                                                       int rank)
+: constraints_(cstr), variables_(x), m_(0), n_(0), r_(rank), constant_(false), init_(true),
+  simple_(cstr.size() == 1 && x.size() == 1)
 {
   assert(rank >= 0);
 
-  for (const auto& c : cstr)
+  for(const auto & c : cstr)
   {
     m_ += c->size();
   }
 
-  for (const auto& v : x)
+  for(const auto & v : x)
   {
     n_ += v->size();
   }
@@ -177,35 +174,35 @@ SubstitutionCalculatorImpl::SubstitutionCalculatorImpl(const std::vector<LinearC
   assert(m_ <= n_);
   assert(r_ <= m_);
 
-  if (!isSimple())
+  if(!isSimple())
   {
     A_.resize(m_, n_);
     A_.setZero();
 
-    //build fillData
+    // build fillData
     int m = 0;
-    for (auto c : cstr)
+    for(auto c : cstr)
     {
       int mi = c->size();
-      for (auto v : variables_.variables())
+      for(auto v : variables_.variables())
       {
-        if (c->variables().contains(*v))
+        if(c->variables().contains(*v))
         {
           auto cols = v->getMappingIn(variables_);
-          fillData_.push_back({ v, c, A_.block(m,cols.start,mi,cols.dim) });
+          fillData_.push_back({v, c, A_.block(m, cols.start, mi, cols.dim)});
         }
       }
       m += mi;
     }
   }
 
-  //check constness
+  // check constness
   constant_ = true;
-  for (const auto& c : constraints_)
+  for(const auto & c : constraints_)
   {
-    for (const auto& v : variables_.variables())
+    for(const auto & v : variables_.variables())
     {
-      if (c->variables().contains(*v))
+      if(c->variables().contains(*v))
       {
         constant_ &= c->jacobian(*v).properties().isConstant();
       }
@@ -215,19 +212,13 @@ SubstitutionCalculatorImpl::SubstitutionCalculatorImpl(const std::vector<LinearC
   N_.resize(n_, n_ - r_);
 }
 
-void SubstitutionCalculatorImpl::constant(bool c)
-{
-  constant_ = c;
-}
+void SubstitutionCalculatorImpl::constant(bool c) { constant_ = c; }
 
-bool SubstitutionCalculatorImpl::constant() const
-{
-  return constant_;
-}
+bool SubstitutionCalculatorImpl::constant() const { return constant_; }
 
 const Eigen::MatrixXd & SubstitutionCalculatorImpl::A() const
 {
-  if (isSimple())
+  if(isSimple())
   {
     return constraints_[0]->jacobian(*variables_[0]);
   }
@@ -237,8 +228,8 @@ const Eigen::MatrixXd & SubstitutionCalculatorImpl::A() const
   }
 }
 
-}
+} // namespace abstract
 
-}
+} // namespace hint
 
-}
+} // namespace tvm

--- a/src/hint/SubstitutionCalculatorImpl.cpp
+++ b/src/hint/SubstitutionCalculatorImpl.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/hint/abstract/SubstitutionCalculatorImpl.h>
 

--- a/src/hint/SubstitutionUnit.cpp
+++ b/src/hint/SubstitutionUnit.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Variable.h>
 #include <tvm/hint/internal/GenericCalculator.h>

--- a/src/hint/SubstitutionUnit.cpp
+++ b/src/hint/SubstitutionUnit.cpp
@@ -1,101 +1,100 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/hint/internal/SubstitutionUnit.h>
 #include <tvm/Variable.h>
 #include <tvm/hint/internal/GenericCalculator.h>
+#include <tvm/hint/internal/SubstitutionUnit.h>
 
 #include <algorithm>
 #include <set>
 
 namespace
 {
-  using namespace tvm;
-  using namespace tvm::hint;
+using namespace tvm;
+using namespace tvm::hint;
 
-  /** Return a single substitution grouping the substitutions from \p substitutionPool
-    * specified by \p group.
-    */
-  Substitution group(const std::vector<Substitution>& substitutionPool,
-                     const std::vector<size_t>& group)
+/** Return a single substitution grouping the substitutions from \p substitutionPool
+ * specified by \p group.
+ */
+Substitution group(const std::vector<Substitution> & substitutionPool, const std::vector<size_t> & group)
+{
+  std::set<LinearConstraintPtr> subs;
+  std::set<VariablePtr> vars;
+
+  for(auto i : group)
   {
-    std::set<LinearConstraintPtr> subs;
-    std::set<VariablePtr> vars;
+    const auto & c = substitutionPool[i].constraints();
+    subs.insert(c.begin(), c.end());
 
-    for (auto i : group)
-    {
-      const auto& c = substitutionPool[i].constraints();
-      subs.insert(c.begin(), c.end());
-
-      const auto& v = substitutionPool[i].variables();
-      vars.insert(v.begin(), v.end());
-    }
-
-    //determine the rank.
-    //We make two suppositions:
-    // - the substitutions are independent
-    // - if x1,...,xk are the variables susbtituted by a substitution, and
-    //   xk+1,... are the variables substituted by other substitutions, the
-    //   matrices in front of xk+1,... are independent of the matrix in front
-    //   of x1,...,xk.
-    //  If this is not the case, an exception will be raised later in the
-    //  calculator.
-    int rank = 0;
-    for (auto i : group)
-    {
-      const auto& s = substitutionPool[i];
-      const auto& v = s.variables();
-      int ranki = s.rank(); //this is the declared rank of the matrix in front
-                            //of x1,...,xk
-      for (const auto& xi : vars)
-      {
-        int mi = 0;
-        // xi is one of the substituted variables. If it is not one
-        // substituted by s...
-        if (std::find(v.begin(), v.end(), xi) == v.end())
-        {
-          for (const auto& c : s.constraints())
-          {
-            if (c->variables().contains(*xi))
-              mi += c->size();
-          }
-          // it can help to increase the rank
-          ranki += std::min(mi, xi->size());
-        }
-      }
-      rank += std::min(ranki, s.m());
-    }
-
-    return Substitution(std::vector<LinearConstraintPtr>(subs.begin(), subs.end()),
-                        std::vector<VariablePtr>(vars.begin(), vars.end()), rank);
+    const auto & v = substitutionPool[i].variables();
+    vars.insert(v.begin(), v.end());
   }
+
+  // determine the rank.
+  // We make two suppositions:
+  // - the substitutions are independent
+  // - if x1,...,xk are the variables susbtituted by a substitution, and
+  //   xk+1,... are the variables substituted by other substitutions, the
+  //   matrices in front of xk+1,... are independent of the matrix in front
+  //   of x1,...,xk.
+  //  If this is not the case, an exception will be raised later in the
+  //  calculator.
+  int rank = 0;
+  for(auto i : group)
+  {
+    const auto & s = substitutionPool[i];
+    const auto & v = s.variables();
+    int ranki = s.rank(); // this is the declared rank of the matrix in front
+                          // of x1,...,xk
+    for(const auto & xi : vars)
+    {
+      int mi = 0;
+      // xi is one of the substituted variables. If it is not one
+      // substituted by s...
+      if(std::find(v.begin(), v.end(), xi) == v.end())
+      {
+        for(const auto & c : s.constraints())
+        {
+          if(c->variables().contains(*xi))
+            mi += c->size();
+        }
+        // it can help to increase the rank
+        ranki += std::min(mi, xi->size());
+      }
+    }
+    rank += std::min(ranki, s.m());
+  }
+
+  return Substitution(std::vector<LinearConstraintPtr>(subs.begin(), subs.end()),
+                      std::vector<VariablePtr>(vars.begin(), vars.end()), rank);
 }
+} // namespace
 
 namespace tvm
 {
@@ -103,387 +102,386 @@ namespace hint
 {
 namespace internal
 {
-  SubstitutionUnit::SubstitutionUnit(const std::vector<Substitution>& substitutionPool, const std::vector<std::vector<size_t>>& groups, const std::vector<size_t> order)
+SubstitutionUnit::SubstitutionUnit(const std::vector<Substitution> & substitutionPool,
+                                   const std::vector<std::vector<size_t>> & groups,
+                                   const std::vector<size_t> order)
+{
+  extractSubstitutions(substitutionPool, groups, order);
+  scanSubstitutions();
+  computeDependencies();
+  initializeMatrices();
+  createFunctions();
+}
+
+void SubstitutionUnit::update()
+{
+  for(const auto & c : calculators_)
   {
-    extractSubstitutions(substitutionPool, groups, order);
-    scanSubstitutions();
-    computeDependencies();
-    initializeMatrices();
-    createFunctions();
+    c->update();
   }
-
-  void SubstitutionUnit::update()
+  int m = 0;
+  // Knowing that the substitutions are ordered we process as follows, we process
+  // one substitution at a time, in order.
+  // For each constraint sum A_{ij} x_j + sum B_{ij} y_j = c of substitution k,
+  // we first fill the matrices B_{ij}.
+  // We then substitutes the variable x_l that are not the ones substituted by
+  // this substitution by x_l = sum M_{lj} y_j + sum AsZ_{lj} z_j + u_l. Since the
+  // substitutions are ordered, we know that the values M_{lj}, AsZ_{lj} and u_l
+  // have been computed at a previous iteration k.
+  // Once this has been done for every constraints in the substitution, we compute
+  // M, AsZ, u, S^T B, S^T Z and S^T c corresponding to the concatenation of the
+  // variables substituted by the substitution.
+  for(size_t k = 0; k < substitutions_.size(); ++k)
   {
-    for (const auto& c : calculators_)
+    int mk = 0;
+    bool cZero = true; // true if cIsZero_[i] for all i in sub2cstr_[k]
+    for(auto i : sub2cstr_[k])
     {
-      c->update();
-    }
-    int m = 0;
-    //Knowing that the substitutions are ordered we process as follows, we process
-    //one substitution at a time, in order.
-    //For each constraint sum A_{ij} x_j + sum B_{ij} y_j = c of substitution k,
-    //we first fill the matrices B_{ij}.
-    //We then substitutes the variable x_l that are not the ones substituted by
-    //this substitution by x_l = sum M_{lj} y_j + sum AsZ_{lj} z_j + u_l. Since the
-    //substitutions are ordered, we know that the values M_{lj}, AsZ_{lj} and u_l
-    //have been computed at a previous iteration k.
-    //Once this has been done for every constraints in the substitution, we compute
-    //M, AsZ, u, S^T B, S^T Z and S^T c corresponding to the concatenation of the
-    //variables substituted by the substitution.
-    for (size_t k=0; k<substitutions_.size(); ++k)
-    {
-      int mk = 0;
-      bool cZero = true; //true if cIsZero_[i] for all i in sub2cstr_[k]
-      for (auto i : sub2cstr_[k])
+      std::fill(firstY_.begin(), firstY_.end(), true);
+      std::fill(firstZ_.begin(), firstZ_.end(), true);
+      const auto & c = constraints_[i];
+      auto mki = c->size();
+      for(auto j : constraintsY_[i])
       {
-        std::fill(firstY_.begin(), firstY_.end(), true);
-        std::fill(firstZ_.begin(), firstZ_.end(), true);
-        const auto& c = constraints_[i];
-        auto mki = c->size();
-        for (auto j : constraintsY_[i])
-        {
-          auto r = y_[j]->getMappingIn(y_);
-          B_.block(m + mk, r.start, mki, r.dim) = c->jacobian(*y_[j]);
-          firstY_[j] = false;
-        }
-        switch (c->rhs())
-        {
-        case constraint::RHS::ZERO: c_.segment(m + mk, mki).setZero(); cIsZero_[i] = true; break;
-        case constraint::RHS::AS_GIVEN: c_.segment(m + mk, mki) = c->e(); cIsZero_[i] = false; break;
-        case constraint::RHS::OPPOSITE: c_.segment(m + mk, mki) = -c->e(); cIsZero_[i] = false; break;
-        }
-        for (auto l : CXdependencies_[i])
-        {
-          auto rx = x_[l]->getMappingIn(x_);
-          const auto& A = c->jacobian(*x_[l]);
-          // B_{ij} += A_{il}*M_{lj} for each y_j on which x_l depends.
-          for (auto j : XYdependencies_[l])
-          {
-            auto ry = y_[j]->getMappingIn(y_);
-            if (firstY_[j])
-            {
-              B_.block(m + mk, ry.start, mki, ry.dim).noalias() = 
-                A*M_.block(rx.start, ry.start, rx.dim, ry.dim);
-              firstY_[j] = false;
-            }
-            else
-            {
-              B_.block(m + mk, ry.start, mki, ry.dim).noalias() +=
-                A*M_.block(rx.start, ry.start, rx.dim, ry.dim);
-            }
-          }
-          // Z_{ij} += A_{il}*AsZ_{lj} for each z_j on which x_l depends.
-          for (auto j : XZdependencies_[l])
-          {
-            auto rz = z_[j]->getMappingIn(z_);
-            if (j == static_cast<int>(x2sub_[l]))
-            {
-              // we handles this dependency in z separately, as it involves N
-              calculators_[j]->postMultiplyByN(Z_.block(m + mk, rz.start, mki, rz.dim), A, xRange_[l],!firstZ_[j]);
-              firstZ_[j] = false;
-            }
-            else if (firstZ_[j])
-            {
-              Z_.block(m + mk, rz.start, mki, rz.dim).noalias() =
-                A*AsZ_.block(rx.start, rz.start, rx.dim, rz.dim);
-              firstZ_[j] = false;
-            }
-            else
-            {
-              Z_.block(m + mk, rz.start, mki, rz.dim).noalias() +=
-                A*AsZ_.block(rx.start, rz.start, rx.dim, rz.dim);
-            }
-          }
-          
-          // c_i -= A{il}*u_l
-          c_.segment(m + mk, mki).noalias() -= A*u_.segment(rx.start, rx.dim);
-          cIsZero_[i] = cIsZero_[i] && uIsZero_[l];
-        }
-        cZero = cZero && cIsZero_[i];
-        mk += mki;
+        auto r = y_[j]->getMappingIn(y_);
+        B_.block(m + mk, r.start, mki, r.dim) = c->jacobian(*y_[j]);
+        firstY_[j] = false;
       }
-      auto rn = substitutionNRanges_[k];
-      //Compute M_{kj} and S_k^T B_{k,j} for y_[j] on which substitutions_[k] depends.
-      for (auto j : SYdependencies_[k])
+      switch(c->rhs())
       {
-        auto ry = y_[j]->getMappingIn(y_);
-        calculators_[k]->premultiplyByASharpAndSTranspose(
-          M_.block(rn.start, ry.start, rn.dim, ry.dim),
-          StB_[k].middleCols(ry.start, ry.dim),
-          B_.block(m, ry.start, mk, ry.dim),
-          true);
+        case constraint::RHS::ZERO:
+          c_.segment(m + mk, mki).setZero();
+          cIsZero_[i] = true;
+          break;
+        case constraint::RHS::AS_GIVEN:
+          c_.segment(m + mk, mki) = c->e();
+          cIsZero_[i] = false;
+          break;
+        case constraint::RHS::OPPOSITE:
+          c_.segment(m + mk, mki) = -c->e();
+          cIsZero_[i] = false;
+          break;
       }
-      //Compute AsZ_{kj} and S_k^T Z_{k,j} for z_[j] on which substitutions_[k] depends.
-      for (auto j : SZdependencies_[k])
+      for(auto l : CXdependencies_[i])
       {
-        auto rz = z_[j]->getMappingIn(z_);
-        calculators_[k]->premultiplyByASharpAndSTranspose(
-          AsZ_.block(rn.start, rz.start, rn.dim, rz.dim),
-          StZ_[k].middleCols(rz.start, rz.dim),
-          Z_.block(m, rz.start, mk, rz.dim),
-          true);
-      }
-      //Compute u_k and S_k^T c_k
-      calculators_[k]->premultiplyByASharpAndSTranspose(
-        u_.segment(rn.start, rn.dim), Stc_[k], c_.segment(m, mk), false);
-      uIsZero_[k] = cZero;
-      m += mk;
-    }
-
-    //update values in varSubstitution and remaining_
-    for (size_t k = 0; k < substitutions_.size(); ++k)
-    {
-      for (auto i : sub2x_[k])
-      {
-        auto rx = x_[static_cast<int>(i)]->getMappingIn(x_);
-        for (auto j : SYdependencies_[k])
+        auto rx = x_[l]->getMappingIn(x_);
+        const auto & A = c->jacobian(*x_[l]);
+        // B_{ij} += A_{il}*M_{lj} for each y_j on which x_l depends.
+        for(auto j : XYdependencies_[l])
         {
           auto ry = y_[j]->getMappingIn(y_);
-          varSubstitutions_[i]->A(M_.block(rx.start, ry.start, rx.dim, ry.dim), *y_[j]);
+          if(firstY_[j])
+          {
+            B_.block(m + mk, ry.start, mki, ry.dim).noalias() = A * M_.block(rx.start, ry.start, rx.dim, ry.dim);
+            firstY_[j] = false;
+          }
+          else
+          {
+            B_.block(m + mk, ry.start, mki, ry.dim).noalias() += A * M_.block(rx.start, ry.start, rx.dim, ry.dim);
+          }
         }
-        for (auto j : SZdependencies_[k])
+        // Z_{ij} += A_{il}*AsZ_{lj} for each z_j on which x_l depends.
+        for(auto j : XZdependencies_[l])
         {
-          if (j == static_cast<int>(k)) continue;
           auto rz = z_[j]->getMappingIn(z_);
-          varSubstitutions_[i]->A(AsZ_.block(rx.start, rz.start, rx.dim, rz.dim), *z_[j]);
+          if(j == static_cast<int>(x2sub_[l]))
+          {
+            // we handles this dependency in z separately, as it involves N
+            calculators_[j]->postMultiplyByN(Z_.block(m + mk, rz.start, mki, rz.dim), A, xRange_[l], !firstZ_[j]);
+            firstZ_[j] = false;
+          }
+          else if(firstZ_[j])
+          {
+            Z_.block(m + mk, rz.start, mki, rz.dim).noalias() = A * AsZ_.block(rx.start, rz.start, rx.dim, rz.dim);
+            firstZ_[j] = false;
+          }
+          else
+          {
+            Z_.block(m + mk, rz.start, mki, rz.dim).noalias() += A * AsZ_.block(rx.start, rz.start, rx.dim, rz.dim);
+          }
         }
-        // copy N
-        if (z_[static_cast<int>(k)]->size() > 0)
-        {
-          varSubstitutions_[i]->A(calculators_[k]->N().middleRows(xRange_[i].start, xRange_[i].dim), *z_[static_cast<int>(k)]);
-        }
-        using tvm::internal::MatrixProperties;
-        MatrixProperties p;
-        if (uIsZero_[k])
-        {
-          p = { MatrixProperties::Constness(true), MatrixProperties::ZERO };
-        }
-        varSubstitutions_[i]->b(u_.segment(rx.start, rx.dim), p);
-      }
 
-      for (auto j : SYdependencies_[k])
+        // c_i -= A{il}*u_l
+        c_.segment(m + mk, mki).noalias() -= A * u_.segment(rx.start, rx.dim);
+        cIsZero_[i] = cIsZero_[i] && uIsZero_[l];
+      }
+      cZero = cZero && cIsZero_[i];
+      mk += mki;
+    }
+    auto rn = substitutionNRanges_[k];
+    // Compute M_{kj} and S_k^T B_{k,j} for y_[j] on which substitutions_[k] depends.
+    for(auto j : SYdependencies_[k])
+    {
+      auto ry = y_[j]->getMappingIn(y_);
+      calculators_[k]->premultiplyByASharpAndSTranspose(M_.block(rn.start, ry.start, rn.dim, ry.dim),
+                                                        StB_[k].middleCols(ry.start, ry.dim),
+                                                        B_.block(m, ry.start, mk, ry.dim), true);
+    }
+    // Compute AsZ_{kj} and S_k^T Z_{k,j} for z_[j] on which substitutions_[k] depends.
+    for(auto j : SZdependencies_[k])
+    {
+      auto rz = z_[j]->getMappingIn(z_);
+      calculators_[k]->premultiplyByASharpAndSTranspose(AsZ_.block(rn.start, rz.start, rn.dim, rz.dim),
+                                                        StZ_[k].middleCols(rz.start, rz.dim),
+                                                        Z_.block(m, rz.start, mk, rz.dim), true);
+    }
+    // Compute u_k and S_k^T c_k
+    calculators_[k]->premultiplyByASharpAndSTranspose(u_.segment(rn.start, rn.dim), Stc_[k], c_.segment(m, mk), false);
+    uIsZero_[k] = cZero;
+    m += mk;
+  }
+
+  // update values in varSubstitution and remaining_
+  for(size_t k = 0; k < substitutions_.size(); ++k)
+  {
+    for(auto i : sub2x_[k])
+    {
+      auto rx = x_[static_cast<int>(i)]->getMappingIn(x_);
+      for(auto j : SYdependencies_[k])
       {
         auto ry = y_[j]->getMappingIn(y_);
-        remaining_[k]->A(StB_[k].middleCols(ry.start, ry.dim), *y_[j]);
+        varSubstitutions_[i]->A(M_.block(rx.start, ry.start, rx.dim, ry.dim), *y_[j]);
       }
-      for (auto j : SZdependencies_[k])
+      for(auto j : SZdependencies_[k])
       {
+        if(j == static_cast<int>(k))
+          continue;
         auto rz = z_[j]->getMappingIn(z_);
-        remaining_[k]->A(StZ_[k].middleCols(rz.start, rz.dim), *z_[j]);
+        varSubstitutions_[i]->A(AsZ_.block(rx.start, rz.start, rx.dim, rz.dim), *z_[j]);
       }
-      remaining_[k]->b(Stc_[k]);
+      // copy N
+      if(z_[static_cast<int>(k)]->size() > 0)
+      {
+        varSubstitutions_[i]->A(calculators_[k]->N().middleRows(xRange_[i].start, xRange_[i].dim),
+                                *z_[static_cast<int>(k)]);
+      }
+      using tvm::internal::MatrixProperties;
+      MatrixProperties p;
+      if(uIsZero_[k])
+      {
+        p = {MatrixProperties::Constness(true), MatrixProperties::ZERO};
+      }
+      varSubstitutions_[i]->b(u_.segment(rx.start, rx.dim), p);
+    }
+
+    for(auto j : SYdependencies_[k])
+    {
+      auto ry = y_[j]->getMappingIn(y_);
+      remaining_[k]->A(StB_[k].middleCols(ry.start, ry.dim), *y_[j]);
+    }
+    for(auto j : SZdependencies_[k])
+    {
+      auto rz = z_[j]->getMappingIn(z_);
+      remaining_[k]->A(StZ_[k].middleCols(rz.start, rz.dim), *z_[j]);
+    }
+    remaining_[k]->b(Stc_[k]);
+  }
+}
+
+const std::vector<VariablePtr> & SubstitutionUnit::variables() const { return x_.variables(); }
+
+const std::vector<std::shared_ptr<function::BasicLinearFunction>> & SubstitutionUnit::variableSubstitutions() const
+{
+  return varSubstitutions_;
+}
+
+const std::vector<VariablePtr> & SubstitutionUnit::additionalVariables() const { return z_.variables(); }
+
+const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> & SubstitutionUnit::additionalConstraints() const
+{
+  return remaining_;
+}
+
+const std::vector<VariablePtr> & SubstitutionUnit::otherVariables() const { return y_.variables(); }
+
+void SubstitutionUnit::extractSubstitutions(const std::vector<Substitution> & substitutionPool,
+                                            const std::vector<std::vector<size_t>> & groups,
+                                            const std::vector<size_t> order)
+{
+  for(auto i : order)
+  {
+    assert(groups[i].size() > 0);
+    if(groups[i].size() == 1)
+    {
+      substitutions_.push_back(substitutionPool[groups[i].front()]);
+    }
+    else
+    {
+      substitutions_.push_back(group(substitutionPool, groups[i]));
     }
   }
+}
 
-  const std::vector<VariablePtr>& SubstitutionUnit::variables() const
+void SubstitutionUnit::scanSubstitutions()
+{
+  m_ = 0;
+  int n = 0;
+  for(size_t i = 0; i < substitutions_.size(); ++i)
   {
-    return x_.variables();
-  }
-
-  const std::vector<std::shared_ptr<function::BasicLinearFunction>>& SubstitutionUnit::variableSubstitutions() const
-  {
-    return varSubstitutions_;
-  }
-
-  const std::vector<VariablePtr>& SubstitutionUnit::additionalVariables() const
-  {
-    return z_.variables();
-  }
-
-  const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>>& SubstitutionUnit::additionalConstraints() const
-  {
-    return remaining_;
-  }
-
-  const std::vector<VariablePtr>& SubstitutionUnit::otherVariables() const
-  {
-    return y_.variables();
-  }
-
-  void SubstitutionUnit::extractSubstitutions(const std::vector<Substitution>& substitutionPool, const std::vector<std::vector<size_t>>& groups, const std::vector<size_t> order)
-  {
-    for (auto i : order)
+    const auto & s = substitutions_[i];
+    calculators_.push_back(s.calculator());
+    sub2cstr_.push_back({});
+    sub2x_.push_back({});
+    SYdependencies_.push_back({});
+    SZdependencies_.push_back({});
+    uIsZero_.push_back(false);
+    int ni = 0;
+    for(const auto & v : s.variables())
     {
-      assert(groups[i].size() > 0);
-      if (groups[i].size() == 1)
-      {
-        substitutions_.push_back(substitutionPool[groups[i].front()]);
-      }
-      else
-      {
-        substitutions_.push_back(group(substitutionPool, groups[i]));
-      }
+      sub2x_[i].push_back(x_.variables().size());
+      x2sub_.push_back(i);
+      x_.add(v);
+      xRange_.push_back({ni, v->size()});
+      ni += v->size();
+      XYdependencies_.push_back({});
+      XZdependencies_.push_back({});
+      cIsZero_.push_back(false);
     }
-  }
-
-  void SubstitutionUnit::scanSubstitutions()
-  {
-    m_ = 0;
-    int n = 0;
-    for (size_t i = 0; i< substitutions_.size(); ++i)
+    int mi = 0;
+    for(const auto c : s.constraints())
     {
-      const auto& s = substitutions_[i];
-      calculators_.push_back(s.calculator());
-      sub2cstr_.push_back({});
-      sub2x_.push_back({});
-      SYdependencies_.push_back({});
-      SZdependencies_.push_back({});
-      uIsZero_.push_back(false);
-      int ni = 0;
-      for (const auto& v : s.variables())
+      sub2cstr_[i].push_back(constraints_.size());
+      constraints_.push_back(c);
+      constraintsY_.push_back({});
+      CXdependencies_.push_back({});
+      mi += c->size();
+      for(const auto & v : c->variables())
       {
-        sub2x_[i].push_back(x_.variables().size());
-        x2sub_.push_back(i);
-        x_.add(v);
-        xRange_.push_back({ ni, v->size() });
-        ni += v->size();
-        XYdependencies_.push_back({});
-        XZdependencies_.push_back({});
-        cIsZero_.push_back(false);
-      }
-      int mi = 0;
-      for (const auto c : s.constraints())
-      {
-        sub2cstr_[i].push_back(constraints_.size());
-        constraints_.push_back(c);
-        constraintsY_.push_back({});
-        CXdependencies_.push_back({});
-        mi += c->size();
-        for (const auto& v : c->variables())
+        // Is v a variable to be substituted? It is ok to test only with an
+        // incomplete vars_, as the susbtitution are supposed to be given in
+        // a correct order.
+        auto it = std::find(x_.variables().begin(), x_.variables().end(), v);
+        if(it == x_.variables().end())
         {
-          // Is v a variable to be substituted? It is ok to test only with an
-          // incomplete vars_, as the susbtitution are supposed to be given in
-          // a correct order.
-          auto it = std::find(x_.variables().begin(), x_.variables().end(), v);
-          if (it == x_.variables().end())
-          {
-            // v is an y variable.
-            y_.add(v);
-            auto ity = std::find(y_.variables().begin(), y_.variables().end(), v);
-            constraintsY_.back().push_back(static_cast<int>(ity - y_.variables().begin()));
-          }
-          else if (std::find(s.variables().begin(), s.variables().end(), v) == s.variables().end())
-          {
-            // v is an x variable that is not substituted by s
-            CXdependencies_.back().push_back(static_cast<int>(it - x_.variables().begin()));
-          }
+          // v is an y variable.
+          y_.add(v);
+          auto ity = std::find(y_.variables().begin(), y_.variables().end(), v);
+          constraintsY_.back().push_back(static_cast<int>(ity - y_.variables().begin()));
         }
-      }
-      std::stringstream ss;
-      ss << "z" << i;
-      z_.add(Space(ni - s.rank()).createVariable(ss.str()));
-      substitutionMRanges_.push_back({ m_, mi });
-      substitutionNRanges_.push_back({ n,ni });
-      m_ += mi;
-      n += ni;
-    }
-  }
-
-  void SubstitutionUnit::initializeMatrices()
-  {
-    B_.resize(m_, y_.totalSize());
-    Z_.resize(m_, z_.totalSize());
-    c_.resize(m_);
-    M_.resize(x_.totalSize(), y_.totalSize());
-    AsZ_.resize(x_.totalSize(), z_.totalSize());
-    u_.resize(x_.totalSize());
-    for (const auto c : calculators_)
-    {
-      auto mr = c->m() - c->r();
-      StB_.emplace_back(mr, y_.totalSize());
-      StZ_.emplace_back(mr, z_.totalSize());
-      Stc_.emplace_back(mr);
-    }
-    firstY_.resize(y_.variables().size(), true);
-    firstZ_.resize(z_.variables().size(), true);
-
-    //We could put all matrices to zero, but we don't do it to ease possible debug
-    //(at least under msvc, uninitialized values are easy to spot)
-    //We thus only initialize to 0 the parts of B and Z that will be used
-    int m = 0;
-    for (size_t k = 0; k < substitutions_.size(); ++k)
-    {
-      int mk = 0;
-      for (auto i : sub2cstr_[k])
-      {
-        mk += constraints_[i]->size();
-      }
-      for (auto i : SYdependencies_[k])
-      {
-        auto ry = y_[i]->getMappingIn(y_);
-        B_.block(m, ry.start, mk, ry.dim).setZero();
-      }
-      for (auto i : SZdependencies_[k])
-      {
-        auto rz = z_[i]->getMappingIn(z_);
-        Z_.block(m, rz.start, mk, rz.dim).setZero();
-      }
-      m += mk;
-    }
-  }
-
-  void SubstitutionUnit::computeDependencies()
-  {
-    for (size_t k = 0; k < substitutions_.size(); ++k)
-    {
-      std::set<int> sy;
-      std::set<int> sz;
-      for (auto i : sub2cstr_[k])
-      {
-        sy.insert(constraintsY_[i].begin(), constraintsY_[i].end());
-        for (auto j : CXdependencies_[i])
+        else if(std::find(s.variables().begin(), s.variables().end(), v) == s.variables().end())
         {
-          sy.insert(XYdependencies_[j].begin(), XYdependencies_[j].end());
-          sz.insert(XZdependencies_[j].begin(), XZdependencies_[j].end());
-        }
-      }
-
-      SYdependencies_[k].insert(SYdependencies_[k].end(), sy.begin(), sy.end());
-      SZdependencies_[k].insert(SZdependencies_[k].end(), sz.begin(), sz.end());
-
-      for (auto i : sub2x_[k])
-      {
-        XYdependencies_[i] = SYdependencies_[k];
-        XZdependencies_[i] = SZdependencies_[k];
-        if (z_[static_cast<int>(k)]->size() > 0)
-        {
-          XZdependencies_[i].push_back(static_cast<int>(k));
+          // v is an x variable that is not substituted by s
+          CXdependencies_.back().push_back(static_cast<int>(it - x_.variables().begin()));
         }
       }
     }
+    std::stringstream ss;
+    ss << "z" << i;
+    z_.add(Space(ni - s.rank()).createVariable(ss.str()));
+    substitutionMRanges_.push_back({m_, mi});
+    substitutionNRanges_.push_back({n, ni});
+    m_ += mi;
+    n += ni;
   }
+}
 
-  void SubstitutionUnit::createFunctions()
+void SubstitutionUnit::initializeMatrices()
+{
+  B_.resize(m_, y_.totalSize());
+  Z_.resize(m_, z_.totalSize());
+  c_.resize(m_);
+  M_.resize(x_.totalSize(), y_.totalSize());
+  AsZ_.resize(x_.totalSize(), z_.totalSize());
+  u_.resize(x_.totalSize());
+  for(const auto c : calculators_)
   {
-    for (size_t i = 0; i < x_.variables().size(); ++i)
+    auto mr = c->m() - c->r();
+    StB_.emplace_back(mr, y_.totalSize());
+    StZ_.emplace_back(mr, z_.totalSize());
+    Stc_.emplace_back(mr);
+  }
+  firstY_.resize(y_.variables().size(), true);
+  firstZ_.resize(z_.variables().size(), true);
+
+  // We could put all matrices to zero, but we don't do it to ease possible debug
+  //(at least under msvc, uninitialized values are easy to spot)
+  // We thus only initialize to 0 the parts of B and Z that will be used
+  int m = 0;
+  for(size_t k = 0; k < substitutions_.size(); ++k)
+  {
+    int mk = 0;
+    for(auto i : sub2cstr_[k])
     {
-      std::vector<VariablePtr> vars;
-      for (auto j : XYdependencies_[i])
+      mk += constraints_[i]->size();
+    }
+    for(auto i : SYdependencies_[k])
+    {
+      auto ry = y_[i]->getMappingIn(y_);
+      B_.block(m, ry.start, mk, ry.dim).setZero();
+    }
+    for(auto i : SZdependencies_[k])
+    {
+      auto rz = z_[i]->getMappingIn(z_);
+      Z_.block(m, rz.start, mk, rz.dim).setZero();
+    }
+    m += mk;
+  }
+}
+
+void SubstitutionUnit::computeDependencies()
+{
+  for(size_t k = 0; k < substitutions_.size(); ++k)
+  {
+    std::set<int> sy;
+    std::set<int> sz;
+    for(auto i : sub2cstr_[k])
+    {
+      sy.insert(constraintsY_[i].begin(), constraintsY_[i].end());
+      for(auto j : CXdependencies_[i])
       {
-        vars.push_back(y_[j]);
+        sy.insert(XYdependencies_[j].begin(), XYdependencies_[j].end());
+        sz.insert(XZdependencies_[j].begin(), XZdependencies_[j].end());
       }
-      for (auto j : XZdependencies_[i])
-      {
-        vars.push_back(z_[j]);
-      }
-      varSubstitutions_.emplace_back(new function::BasicLinearFunction(x_[static_cast<int>(i)]->size(), vars));
     }
 
-    for (size_t k = 0; k < substitutions_.size(); ++k)
+    SYdependencies_[k].insert(SYdependencies_[k].end(), sy.begin(), sy.end());
+    SZdependencies_[k].insert(SZdependencies_[k].end(), sz.begin(), sz.end());
+
+    for(auto i : sub2x_[k])
     {
-      std::vector<VariablePtr> vars;
-      for (auto j : SYdependencies_[k])
+      XYdependencies_[i] = SYdependencies_[k];
+      XZdependencies_[i] = SZdependencies_[k];
+      if(z_[static_cast<int>(k)]->size() > 0)
       {
-        vars.push_back(y_[j]);
+        XZdependencies_[i].push_back(static_cast<int>(k));
       }
-      for (auto j : SZdependencies_[k])
-      {
-        vars.push_back(z_[j]);
-      }
-      remaining_.emplace_back(new constraint::BasicLinearConstraint(static_cast<int>(calculators_[k]->m() - calculators_[k]->r()), vars, constraint::Type::EQUAL, constraint::RHS::AS_GIVEN));
     }
   }
+}
 
+void SubstitutionUnit::createFunctions()
+{
+  for(size_t i = 0; i < x_.variables().size(); ++i)
+  {
+    std::vector<VariablePtr> vars;
+    for(auto j : XYdependencies_[i])
+    {
+      vars.push_back(y_[j]);
+    }
+    for(auto j : XZdependencies_[i])
+    {
+      vars.push_back(z_[j]);
+    }
+    varSubstitutions_.emplace_back(new function::BasicLinearFunction(x_[static_cast<int>(i)]->size(), vars));
+  }
+
+  for(size_t k = 0; k < substitutions_.size(); ++k)
+  {
+    std::vector<VariablePtr> vars;
+    for(auto j : SYdependencies_[k])
+    {
+      vars.push_back(y_[j]);
+    }
+    for(auto j : SZdependencies_[k])
+    {
+      vars.push_back(z_[j]);
+    }
+    remaining_.emplace_back(
+        new constraint::BasicLinearConstraint(static_cast<int>(calculators_[k]->m() - calculators_[k]->r()), vars,
+                                              constraint::Type::EQUAL, constraint::RHS::AS_GIVEN));
+  }
 }
-}
-}
+
+} // namespace internal
+} // namespace hint
+} // namespace tvm

--- a/src/hint/Substitutions.cpp
+++ b/src/hint/Substitutions.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>

--- a/src/hint/Substitutions.cpp
+++ b/src/hint/Substitutions.cpp
@@ -1,39 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/hint/internal/Substitutions.h>
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
+#include <tvm/hint/internal/Substitutions.h>
 
 #include <algorithm>
-
-
 
 namespace tvm
 {
@@ -43,176 +41,163 @@ namespace hint
 
 namespace internal
 {
-  /** Return true if \p s is using variables substituted by \p t.*/
-  bool dependsOn(const Substitution& s, const Substitution& t)
+/** Return true if \p s is using variables substituted by \p t.*/
+bool dependsOn(const Substitution & s, const Substitution & t)
+{
+  for(const auto & x : t.variables())
   {
-    for (const auto& x : t.variables())
+    for(const auto & c : s.constraints())
     {
-      for (const auto& c : s.constraints())
+      if(c->variables().contains(*x))
       {
-        if (c->variables().contains(*x))
-        {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-
-  void tvm::hint::internal::Substitutions::add(const Substitution& s)
-  {
-    auto i = dependencies_.addNode();
-    assert(i == substitutions_.size());
-    substitutions_.push_back(s);
-
-    for (size_t j=0; j<substitutions_.size(); ++j)
-    {
-      if (dependsOn(substitutions_[j], s))
-      {
-        dependencies_.addEdge(j, i);
-      }
-      if (dependsOn(s, substitutions_[j]))
-      {
-        dependencies_.addEdge(i, j);
+        return true;
       }
     }
   }
+  return false;
+}
 
-  const std::vector<Substitution>& Substitutions::substitutions() const
+void tvm::hint::internal::Substitutions::add(const Substitution & s)
+{
+  auto i = dependencies_.addNode();
+  assert(i == substitutions_.size());
+  substitutions_.push_back(s);
+
+  for(size_t j = 0; j < substitutions_.size(); ++j)
   {
-    return substitutions_;
+    if(dependsOn(substitutions_[j], s))
+    {
+      dependencies_.addEdge(j, i);
+    }
+    if(dependsOn(s, substitutions_[j]))
+    {
+      dependencies_.addEdge(i, j);
+    }
+  }
+}
+
+const std::vector<Substitution> & Substitutions::substitutions() const { return substitutions_; }
+
+bool Substitutions::uses(LinearConstraintPtr c) const
+{
+  for(const auto & s : substitutions_)
+  {
+    for(const auto & cstr : s.constraints())
+    {
+      if(c == cstr)
+        return true;
+    }
+  }
+  return false;
+}
+
+void Substitutions::finalize()
+{
+  // Detect interdependent substitutions (this corresponds to strongly connected
+  // components of the dependency graph).
+  tvm::graph::internal::DependencyGraph g;
+  std::vector<std::vector<size_t>> scc;
+  std::tie(scc, g) = dependencies_.reduce();
+
+  // Compute the groups of substitutions and the order to carry out the substitutions
+  // in each group. Indices in orderedGroups are relative to scc.
+  auto orderedGroups = g.groupedOrder();
+
+  // We create a unit for each group
+  units_.clear();
+  for(const auto & g : orderedGroups)
+  {
+    units_.emplace_back(substitutions_, scc, g);
   }
 
-  bool Substitutions::uses(LinearConstraintPtr c) const
+  // Retrieve all the variables, functions and constraints
+  variables_.clear();
+  varSubstitutions_.clear();
+  additionalConstraints_.clear();
+  otherVariables_.clear();
+  for(const auto & u : units_)
   {
-    for (const auto& s : substitutions_)
+    const auto & x = u.variables();
+    const auto & f = u.variableSubstitutions();
+    const auto & z = u.additionalVariables();
+    const auto & c = u.additionalConstraints();
+    const auto & y = u.otherVariables();
+    variables_.insert(variables_.end(), x.begin(), x.end());
+    varSubstitutions_.insert(varSubstitutions_.end(), f.begin(), f.end());
+    for(auto & zi : z)
     {
-      for (const auto& cstr : s.constraints())
+      if(zi->size() > 0)
       {
-        if (c == cstr)
-          return true;
+        additionalVariables_.push_back(zi);
       }
     }
-    return false;
-  }
-
-  void Substitutions::finalize()
-  {
-    //Detect interdependent substitutions (this corresponds to strongly connected
-    //components of the dependency graph).
-    tvm::graph::internal::DependencyGraph g;
-    std::vector<std::vector<size_t>> scc;
-    std::tie(scc,g) = dependencies_.reduce();
-
-    //Compute the groups of substitutions and the order to carry out the substitutions
-    //in each group. Indices in orderedGroups are relative to scc.
-    auto orderedGroups = g.groupedOrder();
-
-    //We create a unit for each group
-    units_.clear();
-    for (const auto& g : orderedGroups)
+    for(auto & ci : c)
     {
-      units_.emplace_back(substitutions_, scc, g);
+      if(ci->size() > 0)
+      {
+        additionalConstraints_.push_back(ci);
+      }
     }
-
-    //Retrieve all the variables, functions and constraints
-    variables_.clear();
-    varSubstitutions_.clear();
-    additionalConstraints_.clear();
-    otherVariables_.clear();
-    for (const auto& u : units_)
+    for(auto & yi : y)
     {
-      const auto& x = u.variables();
-      const auto& f = u.variableSubstitutions();
-      const auto& z = u.additionalVariables();
-      const auto& c = u.additionalConstraints();
-      const auto& y = u.otherVariables();
-      variables_.insert(variables_.end(), x.begin(), x.end());
-      varSubstitutions_.insert(varSubstitutions_.end(), f.begin(), f.end());
-      for (auto& zi : z)
+      if(std::find(otherVariables_.begin(), otherVariables_.end(), yi) == otherVariables_.end())
       {
-        if (zi->size() > 0)
-        {
-          additionalVariables_.push_back(zi);
-        }
-      }
-      for (auto& ci : c)
-      {
-        if (ci->size() > 0)
-        {
-          additionalConstraints_.push_back(ci);
-        }
-      }
-      for (auto& yi : y)
-      {
-        if (std::find(otherVariables_.begin(), otherVariables_.end(), yi) == otherVariables_.end())
-        {
-          otherVariables_.push_back(yi);
-        }
+        otherVariables_.push_back(yi);
       }
     }
   }
+}
 
-  void Substitutions::updateSubstitutions()
+void Substitutions::updateSubstitutions()
+{
+  for(auto & u : units_)
   {
-    for (auto& u : units_)
-    {
-      u.update();
-    }
+    u.update();
   }
+}
 
-  void Substitutions::updateVariableValues() const
+void Substitutions::updateVariableValues() const
+{
+  for(size_t i = 0; i < variables_.size(); ++i)
   {
-    for (size_t i = 0; i < variables_.size(); ++i)
-    {
-      varSubstitutions_[i]->updateValue();
-      variables_[i]->value(varSubstitutions_[i]->value());
-    }
+    varSubstitutions_[i]->updateValue();
+    variables_[i]->value(varSubstitutions_[i]->value());
   }
+}
 
-  const std::vector<VariablePtr>& Substitutions::variables() const
+const std::vector<VariablePtr> & Substitutions::variables() const { return variables_; }
+
+const std::vector<std::shared_ptr<function::BasicLinearFunction>> & Substitutions::variableSubstitutions() const
+{
+  return varSubstitutions_;
+}
+
+const std::vector<VariablePtr> & Substitutions::additionalVariables() const { return additionalVariables_; }
+
+const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> & Substitutions::additionalConstraints() const
+{
+  return additionalConstraints_;
+}
+
+const std::vector<VariablePtr> & Substitutions::otherVariables() const { return otherVariables_; }
+
+VariableVector Substitutions::substitute(const VariablePtr & x) const
+{
+  auto it = std::find(variables_.begin(), variables_.end(), x);
+  if(it == variables_.end()) // no substitution of var
   {
-    return variables_;
+    VariableVector v({x});
+    return v;
   }
-
-  const std::vector<std::shared_ptr<function::BasicLinearFunction>>& Substitutions::variableSubstitutions() const
+  else // substitution of var
   {
-    return varSubstitutions_;
+    const auto & f = varSubstitutions_[static_cast<size_t>(it - variables_.begin())];
+    return f->variables();
   }
+}
 
-  const std::vector<VariablePtr>& Substitutions::additionalVariables() const
-  {
-    return additionalVariables_;
-  }
+} // namespace internal
 
-  const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>>& Substitutions::additionalConstraints() const
-  {
-    return additionalConstraints_;
-  }
+} // namespace hint
 
-  const std::vector<VariablePtr>& Substitutions::otherVariables() const
-  {
-    return otherVariables_;
-  }
-
-  VariableVector Substitutions::substitute(const VariablePtr & x) const
-  {
-    auto it = std::find(variables_.begin(), variables_.end(), x);
-    if (it == variables_.end()) //no substitution of var
-    {
-      VariableVector v({ x });
-      return v;
-    }
-    else // substitution of var
-    {
-      const auto& f = varSubstitutions_[static_cast<size_t>(it - variables_.begin())];
-      return f->variables();
-    }
-  }
-
-} // internal
-
-} // hint
-
-} // tvm
+} // namespace tvm

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/internal/FirstOrderProvider.h>
 
@@ -36,92 +36,90 @@ namespace tvm
 
 namespace internal
 {
-  FirstOrderProvider::FirstOrderProvider(int m)
-    : FirstOrderProvider(Space(m))
-  {
-  }
+FirstOrderProvider::FirstOrderProvider(int m) : FirstOrderProvider(Space(m)) {}
 
-  FirstOrderProvider::FirstOrderProvider(Space image)
-    : imageSpace_(std::move(image))
-  {
-    resizeCache(); //resize value_
-  }
+FirstOrderProvider::FirstOrderProvider(Space image) : imageSpace_(std::move(image))
+{
+  resizeCache(); // resize value_
+}
 
-  void FirstOrderProvider::resizeCache()
-  {
-    resizeValueCache();
-    resizeJacobianCache();
-  }
+void FirstOrderProvider::resizeCache()
+{
+  resizeValueCache();
+  resizeJacobianCache();
+}
 
-  void FirstOrderProvider::resizeValueCache()
-  {
-    if (isOutputEnabled((int)Output::Value))
-      value_.resize(imageSpace_.rSize());
-  }
+void FirstOrderProvider::resizeValueCache()
+{
+  if(isOutputEnabled((int)Output::Value))
+    value_.resize(imageSpace_.rSize());
+}
 
-  void FirstOrderProvider::resizeJacobianCache()
+void FirstOrderProvider::resizeJacobianCache()
+{
+  if(isOutputEnabled((int)Output::Jacobian))
   {
-    if (isOutputEnabled((int)Output::Jacobian))
-    {
-      for (auto v : variables_.variables())
-        jacobian_[v.get()].resize(imageSpace_.tSize(), v->space().tSize());
-    }
-  }
-
-  void FirstOrderProvider::addVariable(VariablePtr v, bool linear)
-  {
-    if(variables_.add(v))
-    {
+    for(auto v : variables_.variables())
       jacobian_[v.get()].resize(imageSpace_.tSize(), v->space().tSize());
-      linear_[v.get()] = linear;
-
-      addVariable_(v);
-    }
   }
+}
 
-  void FirstOrderProvider::addVariable(const VariableVector & vv, bool linear)
+void FirstOrderProvider::addVariable(VariablePtr v, bool linear)
+{
+  if(variables_.add(v))
   {
-    for(auto v : vv.variables())
-    {
-      addVariable(v, linear);
-    }
-  }
+    jacobian_[v.get()].resize(imageSpace_.tSize(), v->space().tSize());
+    linear_[v.get()] = linear;
 
-  void FirstOrderProvider::removeVariable(VariablePtr v)
+    addVariable_(v);
+  }
+}
+
+void FirstOrderProvider::addVariable(const VariableVector & vv, bool linear)
+{
+  for(auto v : vv.variables())
   {
-    variables_.remove(*v);
-    jacobian_.erase(v.get());
-    removeVariable_(v);
+    addVariable(v, linear);
   }
+}
 
-  void FirstOrderProvider::addVariable_(VariablePtr)
+void FirstOrderProvider::removeVariable(VariablePtr v)
+{
+  variables_.remove(*v);
+  jacobian_.erase(v.get());
+  removeVariable_(v);
+}
+
+void FirstOrderProvider::addVariable_(VariablePtr)
+{
+  // do nothing
+}
+
+void FirstOrderProvider::removeVariable_(VariablePtr)
+{
+  // do nothing
+}
+
+void FirstOrderProvider::splitJacobian(const MatrixConstRef & J,
+                                       const std::vector<VariablePtr> & vars,
+                                       bool keepProperties)
+{
+  Eigen::DenseIndex s = 0;
+  for(const auto & v : vars)
   {
-    //do nothing
+    auto n = static_cast<Eigen::DenseIndex>(v->space().tSize());
+    jacobian_[v.get()].keepProperties(keepProperties) = J.middleCols(s, n);
+    s += n;
   }
+}
 
-  void FirstOrderProvider::removeVariable_(VariablePtr)
-  {
-    //do nothing
-  }
+void FirstOrderProvider::resize(int m)
+{
+  assert(imageSpace_.isEuclidean());
+  imageSpace_ = Space(m);
+  resizeCache();
+}
 
-  void FirstOrderProvider::splitJacobian(const MatrixConstRef & J, const std::vector<VariablePtr>& vars, bool keepProperties)
-  {
-    Eigen::DenseIndex s = 0;
-    for (const auto& v : vars)
-    {
-      auto n = static_cast<Eigen::DenseIndex>(v->space().tSize());
-      jacobian_[v.get()].keepProperties(keepProperties) = J.middleCols(s, n);
-      s += n;
-    }
-  }
+} // namespace internal
 
-  void FirstOrderProvider::resize(int m)
-  {
-    assert(imageSpace_.isEuclidean());
-    imageSpace_ = Space(m);
-    resizeCache();
-  }
-
-}  // namespace internal
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/internal/FirstOrderProvider.h>
 

--- a/src/internal/MatrixProperties.cpp
+++ b/src/internal/MatrixProperties.cpp
@@ -157,8 +157,7 @@ namespace internal
 MatrixProperties::MatrixProperties()
 : constant_(false), invertible_(false), shape_(MatrixProperties::GENERAL), symmetric_(false),
   positiveness_(MatrixProperties::NA)
-{
-}
+{}
 
 void MatrixProperties::build(const MatrixProperties::Arguments & args, const std::pair<bool, bool> & checks)
 {

--- a/src/internal/MatrixProperties.cpp
+++ b/src/internal/MatrixProperties.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/internal/MatrixProperties.h>
 

--- a/src/internal/MatrixProperties.cpp
+++ b/src/internal/MatrixProperties.cpp
@@ -1,38 +1,37 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/internal/MatrixProperties.h>
 
-#include <assert.h>
 #include <algorithm>
+#include <assert.h>
 #include <stdexcept>
-
 
 using namespace tvm::internal;
 using Constness = MatrixProperties::Constness;
@@ -42,128 +41,139 @@ using Shape = MatrixProperties::Shape;
 
 namespace
 {
-  /** Partial comparison between positiveness caracteristics.
-    * We have the following implications (from left to right)
-    *
-    *      psd
-    *    /     \
-    * pd        \
-    *    \       \
-    *      inz --- i --- NA
-    *    /       /
-    * nd        /
-    *    \     /
-    *      nsd
-    *
-    * with
-    *  - pd  = positive definite
-    *  - psd = positive semidefinite
-    *  - nd  = negative definite
-    *  - nsd = negative semidefinite
-    *  - inz = non zero indefinite
-    *  - i   = indefinite
-    *  - na  = non available
-    *
-    * For a and b two positiveness caracteristics, a > b if a implies b.
-    * If a and b are unrelated (e.g. pd and nsd), an error is thrown.
-    */
-  bool greaterThan(Positiveness a, Positiveness b)
-  {
-    // The following table translates the above graph:
-    //  - table[i][j] = 1 if i > j
-    //  - table[i][j] = -1 if i <= j
-    //  - table[i][j] = 0 if the comparison is not valid.
-                            // NA  | PSD | PD  | NSD | ND  |  I  | INZ
-    const int table[7][7] = {
-                  /* NA  */  { -1  , -1  , -1  , -1  , -1  , -1  , -1  },
-                  /* PSD */  {  1  , -1  , -1  ,  0  ,  0  ,  1  ,  0  },
-                  /* PD  */  {  1  ,  1  , -1  ,  0  ,  0  ,  1  ,  1  },
-                  /* NSD */  {  1  ,  0  ,  0  ,  1  , -1  ,  1  ,  1  },
-                  /* ND  */  {  1  ,  0  ,  0  ,  1  , -1  ,  1  ,  1  },
-                  /*  I  */  {  1  , -1  , -1  , -1  , -1  , -1  , -1  },
-                  /* INZ */  {  1  ,  0  , -1  ,  0  , -1  ,  1  ,  1  }};
-    if (table[static_cast<int>(a)][static_cast<int>(b)] == 0)
-      throw std::runtime_error("Invalid comparison");
+/** Partial comparison between positiveness caracteristics.
+ * We have the following implications (from left to right)
+ *
+ *      psd
+ *    /     \
+ * pd        \
+ *    \       \
+ *      inz --- i --- NA
+ *    /       /
+ * nd        /
+ *    \     /
+ *      nsd
+ *
+ * with
+ *  - pd  = positive definite
+ *  - psd = positive semidefinite
+ *  - nd  = negative definite
+ *  - nsd = negative semidefinite
+ *  - inz = non zero indefinite
+ *  - i   = indefinite
+ *  - na  = non available
+ *
+ * For a and b two positiveness caracteristics, a > b if a implies b.
+ * If a and b are unrelated (e.g. pd and nsd), an error is thrown.
+ */
+bool greaterThan(Positiveness a, Positiveness b)
+{
+  // The following table translates the above graph:
+  //  - table[i][j] = 1 if i > j
+  //  - table[i][j] = -1 if i <= j
+  //  - table[i][j] = 0 if the comparison is not valid.
+  // NA  | PSD | PD  | NSD | ND  |  I  | INZ
+  const int table[7][7] = {/* NA  */ {-1, -1, -1, -1, -1, -1, -1},
+                           /* PSD */ {1, -1, -1, 0, 0, 1, 0},
+                           /* PD  */ {1, 1, -1, 0, 0, 1, 1},
+                           /* NSD */ {1, 0, 0, 1, -1, 1, 1},
+                           /* ND  */ {1, 0, 0, 1, -1, 1, 1},
+                           /*  I  */ {1, -1, -1, -1, -1, -1, -1},
+                           /* INZ */ {1, 0, -1, 0, -1, 1, 1}};
+  if(table[static_cast<int>(a)][static_cast<int>(b)] == 0)
+    throw std::runtime_error("Invalid comparison");
 
-    return table[static_cast<int>(a)][static_cast<int>(b)] > 0;
-  }
+  return table[static_cast<int>(a)][static_cast<int>(b)] > 0;
+}
 
-  Positiveness max(Positiveness a, Positiveness b)
-  {
-    if (greaterThan(a,b))
-      return a;
-    else
-      return b;
-  }
+Positiveness max(Positiveness a, Positiveness b)
+{
+  if(greaterThan(a, b))
+    return a;
+  else
+    return b;
+}
 
-  Positiveness promote(Positiveness p, bool invertible)
+Positiveness promote(Positiveness p, bool invertible)
+{
+  // possibly promote if the matrix is invertible
+  if(invertible)
   {
-    //possibly promote if the matrix is invertible
-    if (invertible)
+    switch(p)
     {
-      switch (p)
-      {
-      case Positiveness::POSITIVE_SEMIDEFINITE: p = Positiveness::POSITIVE_DEFINITE;   break;
-      case Positiveness::NEGATIVE_SEMIDEFINITE: p = Positiveness::NEGATIVE_DEFINITE;   break;
-      case Positiveness::INDEFINITE:            p = Positiveness::NON_ZERO_INDEFINITE; break;
-      default: break;
-      }
+      case Positiveness::POSITIVE_SEMIDEFINITE:
+        p = Positiveness::POSITIVE_DEFINITE;
+        break;
+      case Positiveness::NEGATIVE_SEMIDEFINITE:
+        p = Positiveness::NEGATIVE_DEFINITE;
+        break;
+      case Positiveness::INDEFINITE:
+        p = Positiveness::NON_ZERO_INDEFINITE;
+        break;
+      default:
+        break;
     }
-    return p;
   }
+  return p;
+}
 
-  bool deduceConstance(Shape shape)
+bool deduceConstance(Shape shape)
+{
+  return shape == Shape::IDENTITY || shape == Shape::MINUS_IDENTITY || shape == Shape::ZERO;
+}
+
+bool deduceSymmetry(Shape shape, Positiveness positiveness)
+{
+  return shape >= Shape::DIAGONAL || positiveness != Positiveness::NA;
+}
+
+bool deduceInvertibility(Shape shape, Positiveness positiveness)
+{
+  return shape == Shape::IDENTITY || shape == Shape::MINUS_IDENTITY || positiveness == Positiveness::POSITIVE_DEFINITE
+         || positiveness == Positiveness::NEGATIVE_DEFINITE || positiveness == Positiveness::NON_ZERO_INDEFINITE;
+}
+
+Shape deduceShape(Shape shape, Positiveness positiveness)
+{
+  // if triangular and symmetric we deduce diagonal
+  if((shape == Shape::LOWER_TRIANGULAR || shape == Shape::UPPER_TRIANGULAR) && positiveness != Positiveness::NA)
   {
-    return shape == Shape::IDENTITY
-        || shape == Shape::MINUS_IDENTITY
-        || shape == Shape::ZERO;
+    return Shape::DIAGONAL;
   }
+  else
+    return shape;
+}
 
-  bool deduceSymmetry(Shape shape, Positiveness positiveness)
+Positiveness deducePositiveness(Shape shape, Positiveness positiveness, bool invertible)
+{
+  Positiveness p = Positiveness::NA;
+  // get default positiveness for the shape
+  switch(shape)
   {
-    return shape >= Shape::DIAGONAL || positiveness != Positiveness::NA;
+    case Shape::DIAGONAL:
+      p = Positiveness::INDEFINITE;
+      break;
+    case Shape::MULTIPLE_OF_IDENTITY:
+      p = Positiveness::INDEFINITE;
+      break;
+    case Shape::IDENTITY:
+      p = Positiveness::POSITIVE_DEFINITE;
+      break;
+    case Shape::MINUS_IDENTITY:
+      p = Positiveness::NEGATIVE_DEFINITE;
+      break;
+    case Shape::ZERO:
+      p = Positiveness::INDEFINITE;
+      break;
+    default:
+      break;
   }
 
-  bool deduceInvertibility(Shape shape, Positiveness positiveness)
-  {
-    return shape == Shape::IDENTITY
-        || shape == Shape::MINUS_IDENTITY
-        || positiveness == Positiveness::POSITIVE_DEFINITE
-        || positiveness == Positiveness::NEGATIVE_DEFINITE
-        || positiveness == Positiveness::NON_ZERO_INDEFINITE;
-  }
+  // get tighter positiveness between default one and user-provided one, possibly promoted if invertible
+  return max(promote(p, invertible), promote(positiveness, invertible));
+}
 
-  Shape deduceShape(Shape shape, Positiveness positiveness)
-  {
-    //if triangular and symmetric we deduce diagonal
-    if ((shape == Shape::LOWER_TRIANGULAR || shape == Shape::UPPER_TRIANGULAR)
-      && positiveness != Positiveness::NA)
-    {
-      return Shape::DIAGONAL;
-    }
-    else
-      return shape;
-  }
-
-  Positiveness deducePositiveness(Shape shape, Positiveness positiveness, bool invertible)
-  {
-    Positiveness p = Positiveness::NA;
-    //get default positiveness for the shape
-    switch (shape)
-    {
-    case Shape::DIAGONAL:             p = Positiveness::INDEFINITE;        break;
-    case Shape::MULTIPLE_OF_IDENTITY: p = Positiveness::INDEFINITE;        break;
-    case Shape::IDENTITY:             p = Positiveness::POSITIVE_DEFINITE; break;
-    case Shape::MINUS_IDENTITY:       p = Positiveness::NEGATIVE_DEFINITE; break;
-    case Shape::ZERO:                 p = Positiveness::INDEFINITE;        break;
-    default: break;
-    }
-
-    //get tighter positiveness between default one and user-provided one, possibly promoted if invertible
-    return max(promote(p, invertible), promote(positiveness, invertible));
-  }
-
-}  // namespace
+} // namespace
 
 namespace tvm
 {
@@ -171,228 +181,240 @@ namespace tvm
 namespace internal
 {
 
-  MatrixProperties::MatrixProperties()
-    : constant_(false)
-    , invertible_(false)
-    , shape_(MatrixProperties::GENERAL)
-    , symmetric_(false)
-    , positiveness_(MatrixProperties::NA)
+MatrixProperties::MatrixProperties()
+: constant_(false), invertible_(false), shape_(MatrixProperties::GENERAL), symmetric_(false),
+  positiveness_(MatrixProperties::NA)
+{
+}
+
+void MatrixProperties::build(const MatrixProperties::Arguments & args, const std::pair<bool, bool> & checks)
+{
+  if((args.shape == Shape::ZERO && args.positiveness == Positiveness::POSITIVE_DEFINITE)
+     || (args.shape == Shape::ZERO && args.positiveness == Positiveness::NEGATIVE_DEFINITE)
+     || (args.shape == Shape::ZERO && args.positiveness == Positiveness::NON_ZERO_INDEFINITE)
+     || (args.shape == Shape::IDENTITY && args.positiveness == Positiveness::NEGATIVE_SEMIDEFINITE)
+     || (args.shape == Shape::IDENTITY && args.positiveness == Positiveness::NEGATIVE_DEFINITE)
+     || (args.shape == Shape::MINUS_IDENTITY && args.positiveness == Positiveness::POSITIVE_SEMIDEFINITE)
+     || (args.shape == Shape::MINUS_IDENTITY && args.positiveness == Positiveness::POSITIVE_DEFINITE))
   {
+    throw std::runtime_error("Incompatible shape and positiveness properties.");
   }
 
+  if(checks.first && !args.constant && deduceConstance(args.shape))
+    throw std::runtime_error("You marked as non constant a matrix that is necessarily constant.");
 
-  void MatrixProperties::build(const MatrixProperties::Arguments& args, const std::pair<bool, bool>& checks)
+  if(checks.second)
   {
-    if ((args.shape == Shape::ZERO && args.positiveness == Positiveness::POSITIVE_DEFINITE)
-      || (args.shape == Shape::ZERO && args.positiveness == Positiveness::NEGATIVE_DEFINITE)
-      || (args.shape == Shape::ZERO && args.positiveness == Positiveness::NON_ZERO_INDEFINITE)
-      || (args.shape == Shape::IDENTITY && args.positiveness == Positiveness::NEGATIVE_SEMIDEFINITE)
-      || (args.shape == Shape::IDENTITY && args.positiveness == Positiveness::NEGATIVE_DEFINITE)
-      || (args.shape == Shape::MINUS_IDENTITY && args.positiveness == Positiveness::POSITIVE_SEMIDEFINITE)
-      || (args.shape == Shape::MINUS_IDENTITY && args.positiveness == Positiveness::POSITIVE_DEFINITE))
-    {
-      throw std::runtime_error("Incompatible shape and positiveness properties.");
-    }
-
-    if (checks.first && !args.constant && deduceConstance(args.shape))
-      throw std::runtime_error("You marked as non constant a matrix that is necessarily constant.");
-
-    if (checks.second)
-    {
-      if (!args.invertible && deduceInvertibility(args.shape, args.positiveness))
-        throw std::runtime_error("You marked as non-invertible a matrix that is necessarily invertible.");
-      if (args.invertible && args.shape == Shape::ZERO)
-        throw std::runtime_error("You marked as invertible the matrix 0.");
-    }
-
-    constant_ = args.constant || deduceConstance(args.shape);
-    invertible_ = args.invertible || deduceInvertibility(args.shape, args.positiveness);
-    shape_ = deduceShape(args.shape, args.positiveness);
-    symmetric_ = deduceSymmetry(args.shape, args.positiveness);
-    positiveness_ = deducePositiveness(args.shape, args.positiveness, args.invertible);
+    if(!args.invertible && deduceInvertibility(args.shape, args.positiveness))
+      throw std::runtime_error("You marked as non-invertible a matrix that is necessarily invertible.");
+    if(args.invertible && args.shape == Shape::ZERO)
+      throw std::runtime_error("You marked as invertible the matrix 0.");
   }
 
-  Constness operator-(const Constness& c) { return c; }
-  Constness operator*(double, const Constness& c) { return c; }
-  Constness operator+(const Constness& c1, const Constness& c2) { return c1 && c2; }
-  Constness operator-(const Constness& c1, const Constness& c2) { return c1 && c2; }
-  Constness operator*(const Constness& c1, const Constness& c2) { return c1 && c2; }
-  Invertibility operator-(const Invertibility& i) { return i; }
-  Invertibility operator*(double d, const Invertibility& i) { return d == 0 ? Invertibility(false) : i; }
-  Invertibility operator+(const Invertibility&, const Invertibility&) { return false; }
-  Invertibility operator-(const Invertibility&, const Invertibility&) { return false; }
-  Invertibility operator*(const Invertibility& i1, const Invertibility& i2) { return i1 && i2; }
+  constant_ = args.constant || deduceConstance(args.shape);
+  invertible_ = args.invertible || deduceInvertibility(args.shape, args.positiveness);
+  shape_ = deduceShape(args.shape, args.positiveness);
+  symmetric_ = deduceSymmetry(args.shape, args.positiveness);
+  positiveness_ = deducePositiveness(args.shape, args.positiveness, args.invertible);
+}
 
-  Positiveness operator-(const Positiveness& p)
+Constness operator-(const Constness & c) { return c; }
+Constness operator*(double, const Constness & c) { return c; }
+Constness operator+(const Constness & c1, const Constness & c2) { return c1 && c2; }
+Constness operator-(const Constness & c1, const Constness & c2) { return c1 && c2; }
+Constness operator*(const Constness & c1, const Constness & c2) { return c1 && c2; }
+Invertibility operator-(const Invertibility & i) { return i; }
+Invertibility operator*(double d, const Invertibility & i) { return d == 0 ? Invertibility(false) : i; }
+Invertibility operator+(const Invertibility &, const Invertibility &) { return false; }
+Invertibility operator-(const Invertibility &, const Invertibility &) { return false; }
+Invertibility operator*(const Invertibility & i1, const Invertibility & i2) { return i1 && i2; }
+
+Positiveness operator-(const Positiveness & p)
+{
+  switch(p)
   {
-    switch (p)
-    {
-    case Positiveness::NA:                    return Positiveness::NA;
-    case Positiveness::POSITIVE_SEMIDEFINITE: return Positiveness::NEGATIVE_SEMIDEFINITE;
-    case Positiveness::POSITIVE_DEFINITE:     return Positiveness::NEGATIVE_DEFINITE;
-    case Positiveness::NEGATIVE_SEMIDEFINITE: return Positiveness::POSITIVE_SEMIDEFINITE;
-    case Positiveness::NEGATIVE_DEFINITE:     return Positiveness::POSITIVE_DEFINITE;
-    case Positiveness::INDEFINITE:            return Positiveness::INDEFINITE;
-    case Positiveness::NON_ZERO_INDEFINITE:   return Positiveness::NON_ZERO_INDEFINITE;
-    default: throw std::runtime_error("Case not possible.");
-    }
+    case Positiveness::NA:
+      return Positiveness::NA;
+    case Positiveness::POSITIVE_SEMIDEFINITE:
+      return Positiveness::NEGATIVE_SEMIDEFINITE;
+    case Positiveness::POSITIVE_DEFINITE:
+      return Positiveness::NEGATIVE_DEFINITE;
+    case Positiveness::NEGATIVE_SEMIDEFINITE:
+      return Positiveness::POSITIVE_SEMIDEFINITE;
+    case Positiveness::NEGATIVE_DEFINITE:
+      return Positiveness::POSITIVE_DEFINITE;
+    case Positiveness::INDEFINITE:
+      return Positiveness::INDEFINITE;
+    case Positiveness::NON_ZERO_INDEFINITE:
+      return Positiveness::NON_ZERO_INDEFINITE;
+    default:
+      throw std::runtime_error("Case not possible.");
   }
+}
 
-  Positiveness operator*(double d, const Positiveness& p)
-  {
-    if (d < 0) return -p;
-    else if (d > 0) return p;
-    else if (p == Positiveness::NA) return p; // matrix is zero but maybe not square
-    else return Positiveness::INDEFINITE;     // matrix is zero and square
-  }
+Positiveness operator*(double d, const Positiveness & p)
+{
+  if(d < 0)
+    return -p;
+  else if(d > 0)
+    return p;
+  else if(p == Positiveness::NA)
+    return p; // matrix is zero but maybe not square
+  else
+    return Positiveness::INDEFINITE; // matrix is zero and square
+}
 
-  Positiveness operator+(const Positiveness& p1, const Positiveness& p2)
-  {
-    if (p1 == Positiveness::NA || p2 == Positiveness::NA) return Positiveness::NA;
-    else if ((p1 == Positiveness::POSITIVE_SEMIDEFINITE
-      || p1 == Positiveness::POSITIVE_DEFINITE)
-      && (p2 == Positiveness::POSITIVE_SEMIDEFINITE
-        || p2 == Positiveness::POSITIVE_DEFINITE)) return max(p1, p2);
-    else if ((p1 == Positiveness::NEGATIVE_SEMIDEFINITE
-      || p1 == Positiveness::NEGATIVE_DEFINITE)
-      && (p2 == Positiveness::NEGATIVE_SEMIDEFINITE
-        || p2 == Positiveness::NEGATIVE_DEFINITE)) return max(p1, p2);
-    else return Positiveness::INDEFINITE;
-  }
-
-  Positiveness operator-(const Positiveness& p1, const Positiveness& p2)
-  {
-    return p1 + (-p2);
-  }
-
-  Positiveness operator*(const Positiveness&, const Positiveness&)
-  {
-    // The product of two symmetric matrices is in not symmetric (unless they permute).
+Positiveness operator+(const Positiveness & p1, const Positiveness & p2)
+{
+  if(p1 == Positiveness::NA || p2 == Positiveness::NA)
     return Positiveness::NA;
-  }
+  else if((p1 == Positiveness::POSITIVE_SEMIDEFINITE || p1 == Positiveness::POSITIVE_DEFINITE)
+          && (p2 == Positiveness::POSITIVE_SEMIDEFINITE || p2 == Positiveness::POSITIVE_DEFINITE))
+    return max(p1, p2);
+  else if((p1 == Positiveness::NEGATIVE_SEMIDEFINITE || p1 == Positiveness::NEGATIVE_DEFINITE)
+          && (p2 == Positiveness::NEGATIVE_SEMIDEFINITE || p2 == Positiveness::NEGATIVE_DEFINITE))
+    return max(p1, p2);
+  else
+    return Positiveness::INDEFINITE;
+}
 
-  Shape operator-(const Shape& s)
+Positiveness operator-(const Positiveness & p1, const Positiveness & p2) { return p1 + (-p2); }
+
+Positiveness operator*(const Positiveness &, const Positiveness &)
+{
+  // The product of two symmetric matrices is in not symmetric (unless they permute).
+  return Positiveness::NA;
+}
+
+Shape operator-(const Shape & s)
+{
+  if(s == Shape::IDENTITY)
+    return Shape::MINUS_IDENTITY;
+  else if(s == Shape::MINUS_IDENTITY)
+    return Shape::IDENTITY;
+  else
+    return s;
+}
+
+Shape operator*(double d, const Shape & s)
+{
+  if(d < 0)
+    return -s;
+  else if(d > 0)
+    return s;
+  else
+    return Shape::ZERO;
+}
+
+Shape operator+(const Shape & s1, const Shape & s2)
+{
+  // the addition is commutative so we order s1 and s2 to consider only about half the cases
+  auto s = std::minmax(s1, s2);
+
+  //    |  G |  L |  U |  D | aI |  I | -I |  0 |
+  //  G |  G |  G |  G |  G |  G |  G |  G |  G |
+  //  L |    |  L |  G |  L |  L |  L |  L |  L |
+  //  U |    |    |  U |  U |  U |  U |  U |  U |
+  //  D |    |    |    |  D |  D |  D |  D |  D |
+  // aI |    |    |    |    | aI | aI | aI | aI |
+  //  I |    |    |    |    |    | aI |  0 |  I |
+  // -I |    |    |    |    |    |    | aI | -I |
+  //  0 |    |    |    |    |    |    |    |  0 |
+  switch(s.first)
   {
-    if (s == Shape::IDENTITY) return Shape::MINUS_IDENTITY;
-    else if (s == Shape::MINUS_IDENTITY) return Shape::IDENTITY;
-    else return s;
-  }
-
-  Shape operator*(double d, const Shape& s)
-  {
-    if (d < 0) return -s;
-    else if (d > 0) return s;
-    else return Shape::ZERO;
-  }
-
-  Shape operator+(const Shape& s1, const Shape& s2)
-  {
-    // the addition is commutative so we order s1 and s2 to consider only about half the cases
-    auto s = std::minmax(s1, s2);
-
-    //    |  G |  L |  U |  D | aI |  I | -I |  0 |
-    //  G |  G |  G |  G |  G |  G |  G |  G |  G |
-    //  L |    |  L |  G |  L |  L |  L |  L |  L |
-    //  U |    |    |  U |  U |  U |  U |  U |  U |
-    //  D |    |    |    |  D |  D |  D |  D |  D |
-    // aI |    |    |    |    | aI | aI | aI | aI |
-    //  I |    |    |    |    |    | aI |  0 |  I |
-    // -I |    |    |    |    |    |    | aI | -I |
-    //  0 |    |    |    |    |    |    |    |  0 |
-    switch (s.first)
-    {
-    case Shape::GENERAL:              return Shape::GENERAL;
+    case Shape::GENERAL:
+      return Shape::GENERAL;
     case Shape::LOWER_TRIANGULAR:
       return s.second == Shape::UPPER_TRIANGULAR ? Shape::GENERAL : Shape::LOWER_TRIANGULAR;
-    case Shape::UPPER_TRIANGULAR:     return Shape::UPPER_TRIANGULAR;
-    case Shape::DIAGONAL:             return Shape::DIAGONAL;
-    case Shape::MULTIPLE_OF_IDENTITY: return Shape::MULTIPLE_OF_IDENTITY;
+    case Shape::UPPER_TRIANGULAR:
+      return Shape::UPPER_TRIANGULAR;
+    case Shape::DIAGONAL:
+      return Shape::DIAGONAL;
+    case Shape::MULTIPLE_OF_IDENTITY:
+      return Shape::MULTIPLE_OF_IDENTITY;
     case Shape::IDENTITY:
-      if (s.second == Shape::IDENTITY)            return Shape::MULTIPLE_OF_IDENTITY;
-      else if (s.second == Shape::MINUS_IDENTITY) return Shape::ZERO;
-      else                                        return Shape::IDENTITY;
+      if(s.second == Shape::IDENTITY)
+        return Shape::MULTIPLE_OF_IDENTITY;
+      else if(s.second == Shape::MINUS_IDENTITY)
+        return Shape::ZERO;
+      else
+        return Shape::IDENTITY;
     case Shape::MINUS_IDENTITY:
       return s.second == Shape::MINUS_IDENTITY ? Shape::MULTIPLE_OF_IDENTITY : Shape::MINUS_IDENTITY;
-    case Shape::ZERO:                 return Shape::ZERO;
-    default: throw std::runtime_error("Case not possible.");
-    }
+    case Shape::ZERO:
+      return Shape::ZERO;
+    default:
+      throw std::runtime_error("Case not possible.");
   }
+}
 
-  Shape operator-(const Shape& s1, const Shape& s2)
+Shape operator-(const Shape & s1, const Shape & s2) { return s1 + (-s2); }
+
+Shape operator*(const Shape & s1, const Shape & s2)
+{
+  // the multiplication is commutative so we order s1 and s2 to consider only about half the cases
+  auto s = std::minmax(s1, s2);
+
+  //    |  G |  L |  U |  D | aI |  I | -I |  0 |
+  //  G |  G |  G |  G |  G |  G |  G |  G |  0 |
+  //  L |    |  L |  G |  L |  L |  L |  L |  0 |
+  //  U |    |    |  U |  U |  U |  U |  U |  0 |
+  //  D |    |    |    |  D |  D |  D |  D |  0 |
+  // aI |    |    |    |    | aI | aI | aI |  0 |
+  //  I |    |    |    |    |    |  I | -I |  0 |
+  // -I |    |    |    |    |    |    |  I |  0 |
+  //  0 |    |    |    |    |    |    |    |  0 |
+  if(s.second == Shape::ZERO)
+    return Shape::ZERO;
+  switch(s.first)
   {
-    return s1 + (-s2);
-  }
-
-  Shape operator*(const Shape& s1, const Shape& s2)
-  {
-    // the multiplication is commutative so we order s1 and s2 to consider only about half the cases
-    auto s = std::minmax(s1, s2);
-
-    //    |  G |  L |  U |  D | aI |  I | -I |  0 |
-    //  G |  G |  G |  G |  G |  G |  G |  G |  0 |
-    //  L |    |  L |  G |  L |  L |  L |  L |  0 |
-    //  U |    |    |  U |  U |  U |  U |  U |  0 |
-    //  D |    |    |    |  D |  D |  D |  D |  0 |
-    // aI |    |    |    |    | aI | aI | aI |  0 |
-    //  I |    |    |    |    |    |  I | -I |  0 |
-    // -I |    |    |    |    |    |    |  I |  0 |
-    //  0 |    |    |    |    |    |    |    |  0 |
-    if (s.second == Shape::ZERO) return Shape::ZERO;
-    switch (s.first)
-    {
-    case Shape::GENERAL:              return Shape::GENERAL;
+    case Shape::GENERAL:
+      return Shape::GENERAL;
     case Shape::LOWER_TRIANGULAR:
       return s.second == Shape::UPPER_TRIANGULAR ? Shape::GENERAL : Shape::LOWER_TRIANGULAR;
-    case Shape::UPPER_TRIANGULAR:     return Shape::UPPER_TRIANGULAR;
-    case Shape::DIAGONAL:             return Shape::DIAGONAL;
-    case Shape::MULTIPLE_OF_IDENTITY: return Shape::MULTIPLE_OF_IDENTITY;
+    case Shape::UPPER_TRIANGULAR:
+      return Shape::UPPER_TRIANGULAR;
+    case Shape::DIAGONAL:
+      return Shape::DIAGONAL;
+    case Shape::MULTIPLE_OF_IDENTITY:
+      return Shape::MULTIPLE_OF_IDENTITY;
     case Shape::IDENTITY:
       return s.second == Shape::IDENTITY ? Shape::IDENTITY : Shape::MINUS_IDENTITY;
-    case Shape::MINUS_IDENTITY:       return Shape::IDENTITY;
-    default: throw std::runtime_error("Case not possible.");
-    }
+    case Shape::MINUS_IDENTITY:
+      return Shape::IDENTITY;
+    default:
+      throw std::runtime_error("Case not possible.");
   }
+}
 
-  MatrixProperties operator-(const MatrixProperties& p)
-  {
-    return {-p.shape(),
-            -p.positiveness(),
-            -p.constness(),
-            -p.invertibility() };
-  }
+MatrixProperties operator-(const MatrixProperties & p)
+{
+  return {-p.shape(), -p.positiveness(), -p.constness(), -p.invertibility()};
+}
 
-  MatrixProperties operator*(double d, const MatrixProperties& p)
-  {
-    return {d * p.shape(),
-            d * p.positiveness(),
-            d * p.constness(),
-            d * p.invertibility() };
-  }
+MatrixProperties operator*(double d, const MatrixProperties & p)
+{
+  return {d * p.shape(), d * p.positiveness(), d * p.constness(), d * p.invertibility()};
+}
 
-  MatrixProperties operator+(const MatrixProperties& p1, const MatrixProperties& p2)
-  {
-    return {p1.shape() + p2.shape(),
-            p1.positiveness() + p2.positiveness(),
-            p1.constness() + p2.constness(),
-            p1.invertibility() + p2.invertibility() };
-  }
+MatrixProperties operator+(const MatrixProperties & p1, const MatrixProperties & p2)
+{
+  return {p1.shape() + p2.shape(), p1.positiveness() + p2.positiveness(), p1.constness() + p2.constness(),
+          p1.invertibility() + p2.invertibility()};
+}
 
-  MatrixProperties operator-(const MatrixProperties& p1, const MatrixProperties& p2)
-  {
-    return {p1.shape() - p2.shape(),
-            p1.positiveness() - p2.positiveness(),
-            p1.constness() - p2.constness(),
-            p1.invertibility() - p2.invertibility() };
-  }
+MatrixProperties operator-(const MatrixProperties & p1, const MatrixProperties & p2)
+{
+  return {p1.shape() - p2.shape(), p1.positiveness() - p2.positiveness(), p1.constness() - p2.constness(),
+          p1.invertibility() - p2.invertibility()};
+}
 
-  MatrixProperties operator*(const MatrixProperties& p1, const MatrixProperties & p2)
-  {
-    return {p1.shape() * p2.shape(),
-            p1.positiveness() * p2.positiveness(),
-            p1.constness() * p2.constness(),
-            p1.invertibility() * p2.invertibility() };
-  }
+MatrixProperties operator*(const MatrixProperties & p1, const MatrixProperties & p2)
+{
+  return {p1.shape() * p2.shape(), p1.positiveness() * p2.positiveness(), p1.constness() * p2.constness(),
+          p1.invertibility() * p2.invertibility()};
+}
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/internal/ObjWithId.cpp
+++ b/src/internal/ObjWithId.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/internal/ObjWithId.h>
 

--- a/src/internal/ObjWithId.cpp
+++ b/src/internal/ObjWithId.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/internal/ObjWithId.h>
 
@@ -33,6 +33,6 @@ namespace tvm
 {
 namespace internal
 {
-  IdProvider ObjWithId::idProvider_;
+IdProvider ObjWithId::idProvider_;
 }
-}
+} // namespace tvm

--- a/src/robot/CoMFunction.cpp
+++ b/src/robot/CoMFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/CoMFunction.h>
 

--- a/src/robot/CoMFunction.cpp
+++ b/src/robot/CoMFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/CoMFunction.h>
 
@@ -35,17 +35,16 @@ namespace tvm
 namespace robot
 {
 
-CoMFunction::CoMFunction(RobotPtr robot)
-: function::abstract::Function(3),
-  robot_(robot),
-  jac_(robot_->mb())
+CoMFunction::CoMFunction(RobotPtr robot) : function::abstract::Function(3), robot_(robot), jac_(robot_->mb())
 {
   reset();
+  // clang-format off
   registerUpdates(Update::Value, &CoMFunction::updateValue,
                   Update::Velocity, &CoMFunction::updateVelocity,
                   Update::Jacobian, &CoMFunction::updateJacobian,
                   Update::NormalAcceleration, &CoMFunction::updateNormalAcceleration,
                   Update::JDot, &CoMFunction::updateJDot);
+  // clang-format on
   addOutputDependency<CoMFunction>(Output::Value, Update::Value);
   addOutputDependency<CoMFunction>(Output::Velocity, Update::Velocity);
   addOutputDependency<CoMFunction>(Output::Jacobian, Update::Jacobian);
@@ -59,35 +58,20 @@ CoMFunction::CoMFunction(RobotPtr robot)
   addInputDependency<CoMFunction>(Update::JDot, robot_, Robot::Output::NormalAcceleration);
 }
 
-void CoMFunction::reset()
-{
-  com_ = robot_->com();
-}
+void CoMFunction::reset() { com_ = robot_->com(); }
 
-void CoMFunction::updateValue()
-{
-  value_ = robot_->com() - com_;
-}
+void CoMFunction::updateValue() { value_ = robot_->com() - com_; }
 
-void CoMFunction::updateVelocity()
-{
-  velocity_ = jac_.velocity(robot_->mb(), robot_->mbc());
-}
+void CoMFunction::updateVelocity() { velocity_ = jac_.velocity(robot_->mb(), robot_->mbc()); }
 
-void CoMFunction::updateJacobian()
-{
-  splitJacobian(jac_.jacobian(robot_->mb(), robot_->mbc()), robot_->q());
-}
+void CoMFunction::updateJacobian() { splitJacobian(jac_.jacobian(robot_->mb(), robot_->mbc()), robot_->q()); }
 
 void CoMFunction::updateNormalAcceleration()
 {
   normalAcceleration_ = jac_.normalAcceleration(robot_->mb(), robot_->mbc(), robot_->normalAccB());
 }
 
-void CoMFunction::updateJDot()
-{
-  splitJacobian(jac_.jacobianDot(robot_->mb(), robot_->mbc()), robot_->q());
-}
+void CoMFunction::updateJDot() { splitJacobian(jac_.jacobianDot(robot_->mb(), robot_->mbc()), robot_->q()); }
 
 } // namespace robot
 

--- a/src/robot/CoMInConvexFunction.cpp
+++ b/src/robot/CoMInConvexFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/CoMInConvexFunction.h>
 
@@ -35,16 +35,11 @@ namespace tvm
 namespace robot
 {
 
-CoMInConvexFunction::CoMInConvexFunction(RobotPtr robot)
-: robot_(robot),
-  jac_(robot_->mb())
+CoMInConvexFunction::CoMInConvexFunction(RobotPtr robot) : robot_(robot), jac_(robot_->mb())
 {
-  registerUpdates(
-                  Update::Value, &CoMInConvexFunction::updateValue,
-                  Update::Velocity, &CoMInConvexFunction::updateVelocity,
-                  Update::Jacobian, &CoMInConvexFunction::updateJacobian,
-                  Update::NormalAcceleration, &CoMInConvexFunction::updateNormalAcceleration
-                 );
+  registerUpdates(Update::Value, &CoMInConvexFunction::updateValue, Update::Velocity,
+                  &CoMInConvexFunction::updateVelocity, Update::Jacobian, &CoMInConvexFunction::updateJacobian,
+                  Update::NormalAcceleration, &CoMInConvexFunction::updateNormalAcceleration);
   addOutputDependency<CoMInConvexFunction>(Output::Value, Update::Value);
   addOutputDependency<CoMInConvexFunction>(Output::Velocity, Update::Velocity);
   addOutputDependency<CoMInConvexFunction>(Output::Jacobian, Update::Jacobian);
@@ -89,8 +84,7 @@ void CoMInConvexFunction::updateVelocity()
   comSpeed_ = jac_.velocity(robot_->mb(), robot_->mbc());
   for(const auto & p : planes_)
   {
-    velocity_(i++) = p->normal().dot(comSpeed_ - p->speed()) +
-                     p->normalDot().dot(robot_->com() - p->point());
+    velocity_(i++) = p->normal().dot(comSpeed_ - p->speed()) + p->normalDot().dot(robot_->com() - p->point());
   }
 }
 
@@ -98,8 +92,10 @@ void CoMInConvexFunction::updateJacobian()
 {
   Eigen::DenseIndex i = 0;
   const Eigen::MatrixXd & jac = jac_.jacobian(robot_->mb(), robot_->mbc());
-  const auto & qFF = robot_->qFreeFlyer(); int qFFSize = qFF->space().tSize();
-  const auto & qJoints = robot_->qJoints(); int qJointsSize = qJoints->space().tSize();
+  const auto & qFF = robot_->qFreeFlyer();
+  int qFFSize = qFF->space().tSize();
+  const auto & qJoints = robot_->qJoints();
+  int qJointsSize = qJoints->space().tSize();
   for(const auto & p : planes_)
   {
     if(qFFSize)
@@ -120,10 +116,9 @@ void CoMInConvexFunction::updateNormalAcceleration()
   Eigen::Vector3d comNAcc = jac_.normalAcceleration(robot_->mb(), robot_->mbc());
   for(const auto & p : planes_)
   {
-    normalAcceleration_(i++) =
-      p->normal().dot(comNAcc - p->acceleration()) +
-      2 * p->normalDot().dot(comSpeed_ - p->speed()) +
-      p->normalDotDot().dot(robot_->com() - p->point());
+    normalAcceleration_(i++) = p->normal().dot(comNAcc - p->acceleration())
+                               + 2 * p->normalDot().dot(comSpeed_ - p->speed())
+                               + p->normalDotDot().dot(robot_->com() - p->point());
   }
 }
 

--- a/src/robot/CoMInConvexFunction.cpp
+++ b/src/robot/CoMInConvexFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/CoMInConvexFunction.h>
 

--- a/src/robot/CollisionFunction.cpp
+++ b/src/robot/CollisionFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/CollisionFunction.h>
 

--- a/src/robot/CollisionFunction.cpp
+++ b/src/robot/CollisionFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/CollisionFunction.h>
 
@@ -39,14 +39,12 @@ namespace robot
 {
 
 CollisionFunction::CollisionFunction(Clock & clock)
-: function::abstract::Function(0),
-  clock_(clock), last_tick_(clock.ticks())
+: function::abstract::Function(0), clock_(clock), last_tick_(clock.ticks())
 {
-  registerUpdates(Update::Value, &CollisionFunction::updateValue,
-                  Update::Velocity, &CollisionFunction::updateVelocity,
-                  Update::Jacobian, &CollisionFunction::updateJacobian,
-                  Update::Time, &CollisionFunction::updateTimeDependency,
-                  Update::NormalAcceleration, &CollisionFunction::updateNormalAcceleration);
+  registerUpdates(Update::Value, &CollisionFunction::updateValue, Update::Velocity, &CollisionFunction::updateVelocity,
+                  Update::Jacobian, &CollisionFunction::updateJacobian, Update::Time,
+                  &CollisionFunction::updateTimeDependency, Update::NormalAcceleration,
+                  &CollisionFunction::updateNormalAcceleration);
 
   addOutputDependency<CollisionFunction>(Output::Value, Update::Value);
   addOutputDependency<CollisionFunction>(Output::Velocity, Update::Velocity);
@@ -78,15 +76,10 @@ void CollisionFunction::addCollision(ConvexHullPtr ch1, ConvexHullPtr ch2)
   distJac_.resize(1, maxDof);
 }
 
-CollisionFunction::CollisionData::CollisionData()
-: pair_(nullptr, nullptr)
-{
-}
+CollisionFunction::CollisionData::CollisionData() : pair_(nullptr, nullptr) {}
 
-CollisionFunction::CollisionData::CollisionData(CollisionFunction & fn,
-                                                ConvexHullPtr ch1, ConvexHullPtr ch2)
-: ch_{ch1, ch2},
-  pair_(ch_[0]->makePair(*ch_[1]))
+CollisionFunction::CollisionData::CollisionData(CollisionFunction & fn, ConvexHullPtr ch1, ConvexHullPtr ch2)
+: ch_{ch1, ch2}, pair_(ch_[0]->makePair(*ch_[1]))
 {
   for(size_t i = 0; i < 2; ++i)
   {
@@ -110,19 +103,21 @@ void CollisionFunction::updateValue()
   {
     double dist = tvm::utils::distance(col.pair_, closestPoints_[0], closestPoints_[1]);
     dist = dist >= 0 ? std::sqrt(dist) : -std::sqrt(-dist);
-    if(dist == 0) { dist = std::numeric_limits<double>::min(); }
+    if(dist == 0)
+    {
+      dist = std::numeric_limits<double>::min();
+    }
     col.normVecDist_ = (closestPoints_[0] - closestPoints_[1]) / dist;
 
     for(size_t j = 0; j < col.objects_.size(); ++j)
     {
       auto & o = col.objects_[j];
-      o.nearestPoint_ = (sva::PTransformd(closestPoints_[i])*col.ch_[j]->frame().position().inv()).translation();
+      o.nearestPoint_ = (sva::PTransformd(closestPoints_[i]) * col.ch_[j]->frame().position().inv()).translation();
       o.jac_.point(o.nearestPoint_);
     }
 
     value_(i++) = dist;
   }
-
 }
 
 void CollisionFunction::updateJacobian()
@@ -141,21 +136,17 @@ void CollisionFunction::updateJacobian()
       const auto & r = col.ch_[j]->frame().robot();
       const Eigen::MatrixXd & jac = o.jac_.jacobian(r.mb(), r.mbc());
       distJac_.block(0, 0, 1, o.jac_.dof()).noalias() =
-        (sign *  col.normVecDist_).transpose() * jac.block(3, 0, 3, o.jac_.dof());
-      o.jac_.fullJacobian(r.mb(),
-                          distJac_.block(0, 0, 1, o.jac_.dof()),
-                          fullJac_);
+          (sign * col.normVecDist_).transpose() * jac.block(3, 0, 3, o.jac_.dof());
+      o.jac_.fullJacobian(r.mb(), distJac_.block(0, 0, 1, o.jac_.dof()), fullJac_);
       int ffSize = r.qFreeFlyer()->space().tSize();
       int jSize = r.qJoints()->space().tSize();
       if(ffSize)
       {
-        jacobian_[r.qFreeFlyer().get()].block(i, 0, 1, ffSize) +=
-          fullJac_.block(0, 0, 1, ffSize);
+        jacobian_[r.qFreeFlyer().get()].block(i, 0, 1, ffSize) += fullJac_.block(0, 0, 1, ffSize);
       }
       if(jSize)
       {
-        jacobian_[r.qJoints().get()].block(i, 0, 1, jSize) +=
-          fullJac_.block(0, ffSize, 1, jSize);
+        jacobian_[r.qJoints().get()].block(i, 0, 1, jSize) += fullJac_.block(0, ffSize, 1, jSize);
       }
       sign *= -1.;
     }
@@ -208,7 +199,7 @@ void CollisionFunction::updateNormalAcceleration()
       const auto & r = col.ch_[j]->frame().robot();
       Eigen::Vector3d pNormalAcc = o.jac_.normalAcceleration(r.mb(), r.mbc(), r.normalAccB()).linear();
       Eigen::Vector3d pSpeed = o.jac_.velocity(r.mb(), r.mbc()).linear();
-      normalAcceleration_(i) += sign * ( pNormalAcc.dot(col.normVecDist_) + pSpeed.dot(col.speedVec_) );
+      normalAcceleration_(i) += sign * (pNormalAcc.dot(col.normVecDist_) + pSpeed.dot(col.speedVec_));
       sign *= -1.;
     }
     ++i;

--- a/src/robot/Contact.cpp
+++ b/src/robot/Contact.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/Contact.h>
 

--- a/src/robot/Contact.cpp
+++ b/src/robot/Contact.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/Contact.h>
 
@@ -37,14 +37,8 @@ namespace tvm
 namespace robot
 {
 
-
-Contact::Contact(FramePtr f1, FramePtr f2,
-                 std::vector<sva::PTransformd> points,
-                 int ambiguityId)
-: f1_(f1), f2_(f2), f1Points_(points),
-  id_ { f1->robot().name(), f1->name(),
-        f2->robot().name(), f2->name(),
-        ambiguityId }
+Contact::Contact(FramePtr f1, FramePtr f2, std::vector<sva::PTransformd> points, int ambiguityId)
+: f1_(f1), f2_(f2), f1Points_(points), id_{f1->robot().name(), f1->name(), f2->robot().name(), f2->name(), ambiguityId}
 
 {
   // X_f1_f2 = X_0_f2 * X_0_f1.inv()
@@ -64,14 +58,12 @@ Contact::Contact(FramePtr f1, FramePtr f2,
   addDirectDependency(Output::F2NormalAcceleration, f2, Frame::Output::NormalAcceleration);
 }
 
-}
+} // namespace robot
 
-}
+} // namespace tvm
 
 std::ostream & operator<<(std::ostream & os, const tvm::robot::Contact::Id & c)
 {
-  os << c.r1 << "::" << c.f1 << "/"
-     << c.r2 << "::" << c.f2
-     << " (id: " << c.ambiguityId << ")";
+  os << c.r1 << "::" << c.f1 << "/" << c.r2 << "::" << c.f2 << " (id: " << c.ambiguityId << ")";
   return os;
 }

--- a/src/robot/ConvexHull.cpp
+++ b/src/robot/ConvexHull.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/ConvexHull.h>
 

--- a/src/robot/ConvexHull.cpp
+++ b/src/robot/ConvexHull.cpp
@@ -12,8 +12,7 @@ namespace robot
 
 ConvexHull::ConvexHull(const std::string & path, FramePtr f, const sva::PTransformd & X_f_o)
 : ConvexHull(tvm::utils::Polyhedron(path), f, X_f_o)
-{
-}
+{}
 
 ConvexHull::ConvexHull(std::shared_ptr<sch::S_Object> o, FramePtr f, const sva::PTransformd & X_f_o)
 : o_(o), f_(f), X_f_o_(X_f_o)

--- a/src/robot/ConvexHull.cpp
+++ b/src/robot/ConvexHull.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/ConvexHull.h>
 
@@ -37,14 +37,12 @@ namespace tvm
 namespace robot
 {
 
-ConvexHull::ConvexHull(const std::string & path,
-                       FramePtr f, const sva::PTransformd & X_f_o)
+ConvexHull::ConvexHull(const std::string & path, FramePtr f, const sva::PTransformd & X_f_o)
 : ConvexHull(tvm::utils::Polyhedron(path), f, X_f_o)
 {
 }
 
-ConvexHull::ConvexHull(std::shared_ptr<sch::S_Object> o,
-                       FramePtr f, const sva::PTransformd & X_f_o)
+ConvexHull::ConvexHull(std::shared_ptr<sch::S_Object> o, FramePtr f, const sva::PTransformd & X_f_o)
 : o_(o), f_(f), X_f_o_(X_f_o)
 {
   registerUpdates(Update::Position, &ConvexHull::updatePosition);
@@ -55,25 +53,13 @@ ConvexHull::ConvexHull(std::shared_ptr<sch::S_Object> o,
   updatePosition();
 }
 
-sch::CD_Pair ConvexHull::makePair(const ConvexHull & hull) const
-{
-  return sch::CD_Pair(o_.get(), hull.o_.get());
-}
+sch::CD_Pair ConvexHull::makePair(const ConvexHull & hull) const { return sch::CD_Pair(o_.get(), hull.o_.get()); }
 
-void ConvexHull::updatePosition()
-{
-  tvm::utils::transform(*o_, X_f_o_ * f_->position());
-}
+void ConvexHull::updatePosition() { tvm::utils::transform(*o_, X_f_o_ * f_->position()); }
 
-const Frame & ConvexHull::frame() const
-{
-  return *f_;
-}
+const Frame & ConvexHull::frame() const { return *f_; }
 
-Frame & ConvexHull::frame()
-{
-  return *f_;
-}
+Frame & ConvexHull::frame() { return *f_; }
 
 } // namespace robot
 

--- a/src/robot/DynamicFunction.cpp
+++ b/src/robot/DynamicFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/internal/DynamicFunction.h>
 

--- a/src/robot/DynamicFunction.cpp
+++ b/src/robot/DynamicFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/internal/DynamicFunction.h>
 
@@ -49,8 +49,7 @@ namespace internal
 {
 
 DynamicFunction::DynamicFunction(RobotPtr robot)
-: function::abstract::LinearFunction(robot->mb().nrDof()),
-  robot_(robot)
+: function::abstract::LinearFunction(robot->mb().nrDof()), robot_(robot)
 {
   registerUpdates(Update::B, &DynamicFunction::updateb);
   registerUpdates(Update::Jacobian, &DynamicFunction::updateJacobian);
@@ -60,16 +59,18 @@ DynamicFunction::DynamicFunction(RobotPtr robot)
   addInputDependency<DynamicFunction>(Update::B, robot, Robot::Output::C);
   addVariable(dot(robot->q(), 2), true);
   addVariable(robot->tau(), true);
-  jacobian_[robot_->tau().get()] =  - Eigen::MatrixXd::Identity(robot_->mb().nrDof(), robot_->mb().nrDof());
+  jacobian_[robot_->tau().get()] = -Eigen::MatrixXd::Identity(robot_->mb().nrDof(), robot_->mb().nrDof());
   jacobian_[robot_->tau().get()].properties(tvm::internal::MatrixProperties::MINUS_IDENTITY);
   velocity_.setZero();
 }
 
-bool DynamicFunction::addContact(ContactPtr contact, bool linearize,
-                                 double mu, unsigned int nrGen)
+bool DynamicFunction::addContact(ContactPtr contact, bool linearize, double mu, unsigned int nrGen)
 {
   auto it = getContact(contact->id());
-  if(it != contacts_.end()) { return false; }
+  if(it != contacts_.end())
+  {
+    return false;
+  }
   bool added = false;
   if(contact->f1().robot().name() == robot_->name())
   {
@@ -81,13 +82,20 @@ bool DynamicFunction::addContact(ContactPtr contact, bool linearize,
     added = true;
     addContact_(contact->f2View(), linearize, mu, nrGen, -1);
   }
-  // FIXME When contact forces are being added for two, we may want to return the variables that were added so that we can have opposite forces constraint
-  if(added) { std::cout << "Added contact " << contact->id() << std::endl; }
+  // FIXME When contact forces are being added for two, we may want to return the variables that were added so that we
+  // can have opposite forces constraint
+  if(added)
+  {
+    std::cout << "Added contact " << contact->id() << std::endl;
+  }
   return added;
 }
 
-void DynamicFunction::addContact_(const Contact::View & contact, bool linearize,
-                                  double mu, unsigned int nrGen, double dir)
+void DynamicFunction::addContact_(const Contact::View & contact,
+                                  bool linearize,
+                                  double mu,
+                                  unsigned int nrGen,
+                                  double dir)
 {
   const auto & cPoints = contact.points;
   ForceContact fc;
@@ -104,30 +112,24 @@ void DynamicFunction::addContact_(const Contact::View & contact, bool linearize,
       fc.forces_.push_back(tvm::Space(3).createVariable("force"));
       fc.forces_.back()->value(Eigen::Vector3d::Zero());
     }
-    fc.updateJacobians_ = [f,cPoints,dir](ForceContact & self,
-                              DynamicFunction & df)
-    {
+    fc.updateJacobians_ = [f, cPoints, dir](ForceContact & self, DynamicFunction & df) {
       const auto & bodyJac = f->rbdJacobian().bodyJacobian(df.robot_->mb(), df.robot_->mbc());
       for(size_t i = 0; i < self.forces_.size(); ++i)
       {
         const auto & v = self.forces_[i];
         const auto & p = cPoints[i];
         f->rbdJacobian().translateBodyJacobian(bodyJac, df.robot_->mbc(), p.translation(), self.force_jac_);
-        f->rbdJacobian().fullJacobian(df.robot_->mb(),
-                                      self.force_jac_,
-                                      self.full_jac_);
-        df.jacobian_[v.get()].noalias() = dir*self.full_jac_.block(3, 0, 3, f->robot().mb().nrDof()).transpose();
+        f->rbdJacobian().fullJacobian(df.robot_->mb(), self.force_jac_, self.full_jac_);
+        df.jacobian_[v.get()].noalias() = dir * self.full_jac_.block(3, 0, 3, f->robot().mb().nrDof()).transpose();
       }
     };
-    fc.force_ = [cPoints](const ForceContact & self)
-    {
-      sva::ForceVecd ret {Eigen::Vector6d::Zero()};
+    fc.force_ = [cPoints](const ForceContact & self) {
+      sva::ForceVecd ret{Eigen::Vector6d::Zero()};
       for(size_t i = 0; i < self.forces_.size(); ++i)
       {
         const auto & f = self.forces_[i];
         const auto & p = cPoints[i];
-        sva::ForceVecd f_p { Eigen::Vector3d::Zero(),
-                             f->value() };
+        sva::ForceVecd f_p{Eigen::Vector3d::Zero(), f->value()};
         ret += p.transMul(f_p);
       }
       return ret;
@@ -143,40 +145,35 @@ void DynamicFunction::addContact_(const Contact::View & contact, bool linearize,
     {
       fc.forces_.push_back(tvm::Space(nrGen).createVariable(f->name() + "_lambda_" + std::to_string(nrPoints)));
       fc.forces_.back()->value(Eigen::VectorXd::Zero(nrGen));
-      FrictionCone cone {dir*p.rotation(), nrGen, mu, dir};
+      FrictionCone cone{dir * p.rotation(), nrGen, mu, dir};
       for(size_t i = 0; i < cone.generators.size(); ++i)
       {
         auto & g = cone.generators[i];
-        generators.col(nrGen*nrPoints + i) = -g;
+        generators.col(nrGen * nrPoints + i) = -g;
       }
       nrPoints++;
     }
-    fc.updateJacobians_ = [f, cPoints, generators, nrGen]
-      (ForceContact & self, DynamicFunction & df)
-    {
+    fc.updateJacobians_ = [f, cPoints, generators, nrGen](ForceContact & self, DynamicFunction & df) {
       const auto & bodyJac = f->rbdJacobian().bodyJacobian(df.robot_->mb(), df.robot_->mbc());
       for(size_t i = 0; i < cPoints.size(); ++i)
       {
         const auto & p = cPoints[i];
         f->rbdJacobian().translateBodyJacobian(bodyJac, df.robot_->mbc(), p.translation(), self.force_jac_);
         const auto & lambda = self.forces_[i];
-        const auto & generator = generators.middleCols(nrGen*i, nrGen);
-        f->rbdJacobian().fullJacobian(df.robot_->mb(),
-                                       self.force_jac_,
-                                       self.full_jac_);
-        df.jacobian_[lambda.get()].noalias() = (generator.transpose() * self.full_jac_.block(3, 0, 3, f->robot().mb().nrDof())).transpose();
+        const auto & generator = generators.middleCols(nrGen * i, nrGen);
+        f->rbdJacobian().fullJacobian(df.robot_->mb(), self.force_jac_, self.full_jac_);
+        df.jacobian_[lambda.get()].noalias() =
+            (generator.transpose() * self.full_jac_.block(3, 0, 3, f->robot().mb().nrDof())).transpose();
       }
     };
-    fc.force_ = [cPoints, generators, nrGen](const ForceContact & self)
-    {
-      sva::ForceVecd ret {Eigen::Vector6d::Zero()};
+    fc.force_ = [cPoints, generators, nrGen](const ForceContact & self) {
+      sva::ForceVecd ret{Eigen::Vector6d::Zero()};
       for(size_t i = 0; i < cPoints.size(); ++i)
       {
         const auto & p = cPoints[i];
-        const auto & lambda = self.forces_[nrGen*i];
-        const auto & generator = -generators.middleCols(nrGen*i, nrGen);
-        sva::ForceVecd f_p { Eigen::Vector3d::Zero(),
-                             generator*lambda->value() };
+        const auto & lambda = self.forces_[nrGen * i];
+        const auto & generator = -generators.middleCols(nrGen * i, nrGen);
+        sva::ForceVecd f_p{Eigen::Vector3d::Zero(), generator * lambda->value()};
         ret += p.transMul(f_p);
       }
       return ret;
@@ -193,7 +190,10 @@ void DynamicFunction::addContact_(const Contact::View & contact, bool linearize,
 void DynamicFunction::removeContact(const Contact::Id & id)
 {
   auto it = getContact(id);
-  if(it != contacts_.end()) { contacts_.erase(it); }
+  if(it != contacts_.end())
+  {
+    contacts_.erase(it);
+  }
 }
 
 sva::ForceVecd DynamicFunction::contactForce(const Contact::Id & id) const
@@ -224,10 +224,7 @@ void DynamicFunction::addPositiveLambdaToProblem(ControlProblem & problem)
   }
 }
 
-void DynamicFunction::updateb()
-{
-  b_ = robot_->C();
-}
+void DynamicFunction::updateb() { b_ = robot_->C(); }
 
 void DynamicFunction::updateJacobian()
 {
@@ -238,22 +235,18 @@ void DynamicFunction::updateJacobian()
   }
 }
 
-std::vector<DynamicFunction::ForceContact>::iterator
-  DynamicFunction::getContact(const Contact::Id & id)
+std::vector<DynamicFunction::ForceContact>::iterator DynamicFunction::getContact(const Contact::Id & id)
 {
-  return std::find_if(contacts_.begin(), contacts_.end(),
-                      [&id](const ForceContact & in) { return in.id_ == id; });
+  return std::find_if(contacts_.begin(), contacts_.end(), [&id](const ForceContact & in) { return in.id_ == id; });
 }
 
-std::vector<DynamicFunction::ForceContact>::const_iterator
-  DynamicFunction::getContact(const Contact::Id & id) const
+std::vector<DynamicFunction::ForceContact>::const_iterator DynamicFunction::getContact(const Contact::Id & id) const
 {
-  return std::find_if(contacts_.cbegin(), contacts_.cend(),
-                      [&id](const ForceContact & in) { return in.id_ == id; });
+  return std::find_if(contacts_.cbegin(), contacts_.cend(), [&id](const ForceContact & in) { return in.id_ == id; });
 }
 
-}
+} // namespace internal
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/src/robot/Frame.cpp
+++ b/src/robot/Frame.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/Frame.h>
 
@@ -33,15 +33,13 @@
 
 namespace
 {
-  Eigen::Matrix3d hat(const Eigen::Vector3d & v)
-  {
-    Eigen::Matrix3d ret;
-    ret << 0., -v.z(), v.y(),
-           v.z(), 0., -v.x(),
-           -v.y(), v.x(), 0.;
-    return ret;
-  }
+Eigen::Matrix3d hat(const Eigen::Vector3d & v)
+{
+  Eigen::Matrix3d ret;
+  ret << 0., -v.z(), v.y(), v.z(), 0., -v.x(), -v.y(), v.x(), 0.;
+  return ret;
 }
+} // namespace
 
 namespace tvm
 {
@@ -49,25 +47,13 @@ namespace tvm
 namespace robot
 {
 
-Frame::Frame(std::string name,
-             RobotPtr robot,
-             const std::string & body,
-             sva::PTransformd X_b_f)
-: name_(std::move(name)),
-  robot_(robot),
-  bodyId_(robot->mb().bodyIndexByName(body)),
-  jac_(robot->mb(), body),
-  X_b_f_(std::move(X_b_f)),
-  jacTmp_(6, jac_.dof()),
+Frame::Frame(std::string name, RobotPtr robot, const std::string & body, sva::PTransformd X_b_f)
+: name_(std::move(name)), robot_(robot), bodyId_(robot->mb().bodyIndexByName(body)), jac_(robot->mb(), body),
+  X_b_f_(std::move(X_b_f)), jacTmp_(6, jac_.dof()),
   jacobian_(6, robot->mb().nrDof()) // FIXME Don't allocate until needed?
 {
-  registerUpdates(
-                  Update::Position, &Frame::updatePosition,
-                  Update::Jacobian, &Frame::updateJacobian,
-                  Update::Velocity, &Frame::updateVelocity,
-                  Update::NormalAcceleration, &Frame::updateNormalAcceleration
-                 );
-
+  registerUpdates(Update::Position, &Frame::updatePosition, Update::Jacobian, &Frame::updateJacobian, Update::Velocity,
+                  &Frame::updateVelocity, Update::NormalAcceleration, &Frame::updateNormalAcceleration);
 
   addOutputDependency(Output::Position, Update::Position);
   addInputDependency(Update::Position, robot_, Robot::Output::FK);
@@ -99,29 +85,22 @@ void Frame::updatePosition()
 void Frame::updateJacobian()
 {
   assert(jacobian_.rows() == 6 && jacobian_.cols() == robot_->mb().nrDof());
-  const auto & partialJac = jac_.jacobian(robot_->mb(),
-                                          robot_->mbc());
+  const auto & partialJac = jac_.jacobian(robot_->mb(), robot_->mbc());
   jacTmp_ = partialJac;
   Eigen::Matrix3d h = -hat(robot_->mbc().bodyPosW[bodyId_].rotation().transpose() * X_b_f_.translation());
   jacTmp_.block(3, 0, 3, jac_.dof()).noalias() += h * partialJac.block(3, 0, 3, jac_.dof());
   jac_.fullJacobian(robot_->mb(), jacTmp_, jacobian_);
 }
 
-void Frame::updateVelocity()
-{
-  velocity_ = X_b_f_ * robot_->mbc().bodyVelW[bodyId_];
-}
+void Frame::updateVelocity() { velocity_ = X_b_f_ * robot_->mbc().bodyVelW[bodyId_]; }
 
 void Frame::updateNormalAcceleration()
 {
   normalAcceleration_ = X_b_f_ * jac_.normalAcceleration(robot_->mb(), robot_->mbc(), robot_->normalAccB());
 }
 
-const std::string & Frame::body() const
-{
-  return robot_->mb().body(bodyId_).name();
-}
+const std::string & Frame::body() const { return robot_->mb().body(bodyId_).name(); }
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/src/robot/Frame.cpp
+++ b/src/robot/Frame.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/Frame.h>
 

--- a/src/robot/FrictionCone.cpp
+++ b/src/robot/FrictionCone.cpp
@@ -1,37 +1,36 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/defs.h>
 #include <tvm/robot/internal/FrictionCone.h>
 
 #include <Eigen/Geometry>
-
 
 namespace tvm
 {
@@ -42,25 +41,23 @@ namespace robot
 namespace internal
 {
 
-FrictionCone::FrictionCone(const Eigen::Matrix3d & frame,
-                           unsigned int nrGen, double mu, double dir)
-: generators(nrGen)
+FrictionCone::FrictionCone(const Eigen::Matrix3d & frame, unsigned int nrGen, double mu, double dir) : generators(nrGen)
 {
   Eigen::Vector3d normal = frame.row(2);
-  Eigen::Vector3d tan = dir*frame.row(0);
+  Eigen::Vector3d tan = dir * frame.row(0);
   double angle = std::atan(mu);
 
-  Eigen::Vector3d gen = Eigen::AngleAxisd(angle, tan)*normal;
-  double step = tvm::constant::pi*2./nrGen;
+  Eigen::Vector3d gen = Eigen::AngleAxisd(angle, tan) * normal;
+  double step = tvm::constant::pi * 2. / nrGen;
 
   for(unsigned int i = 0; i < nrGen; ++i)
   {
-    generators[i] = Eigen::AngleAxisd(dir*step*i, normal)*gen;
+    generators[i] = Eigen::AngleAxisd(dir * step * i, normal) * gen;
   }
 }
 
-}
+} // namespace internal
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/src/robot/FrictionCone.cpp
+++ b/src/robot/FrictionCone.cpp
@@ -1,6 +1,7 @@
 /** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/defs.h>
+
 #include <tvm/robot/internal/FrictionCone.h>
 
 #include <Eigen/Geometry>

--- a/src/robot/FrictionCone.cpp
+++ b/src/robot/FrictionCone.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/defs.h>
 #include <tvm/robot/internal/FrictionCone.h>

--- a/src/robot/GeometricContactFunction.cpp
+++ b/src/robot/GeometricContactFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/internal/GeometricContactFunction.h>
 

--- a/src/robot/GeometricContactFunction.cpp
+++ b/src/robot/GeometricContactFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/internal/GeometricContactFunction.h>
 
@@ -41,8 +41,7 @@ namespace internal
 {
 
 GeometricContactFunction::GeometricContactFunction(ContactPtr contact, Eigen::Matrix6d dof)
-: function::abstract::Function(6),
-  contact_(contact), dof_(dof)
+: function::abstract::Function(6), contact_(contact), dof_(dof)
 {
   const auto & f1 = contact_->f1();
   const auto & f2 = contact_->f2();
@@ -50,12 +49,10 @@ GeometricContactFunction::GeometricContactFunction(ContactPtr contact, Eigen::Ma
   const auto & r2 = f2.robot();
   assert(r1.mb().nrDof() > 0 || r2.mb().nrDof() > 0);
 
-  registerUpdates(
-                  Update::Value, &GeometricContactFunction::updateValue,
-                  Update::Jacobian, &GeometricContactFunction::updateJacobian,
-                  Update::Velocity, &GeometricContactFunction::updateVelocity,
-                  Update::NormalAcceleration, &GeometricContactFunction::updateNormalAcceleration
-                 );
+  registerUpdates(Update::Value, &GeometricContactFunction::updateValue, Update::Jacobian,
+                  &GeometricContactFunction::updateJacobian, Update::Velocity,
+                  &GeometricContactFunction::updateVelocity, Update::NormalAcceleration,
+                  &GeometricContactFunction::updateNormalAcceleration);
 
   addOutputDependency<GeometricContactFunction>(Output::Value, Update::Value);
   addOutputDependency<GeometricContactFunction>(Output::Velocity, Update::Velocity);
@@ -74,7 +71,8 @@ GeometricContactFunction::GeometricContactFunction(ContactPtr contact, Eigen::Ma
   if(has_f1_)
   {
     addInputDependency<GeometricContactFunction>(Update::Velocity, contact_, Contact::Output::F1Velocity);
-    addInputDependency<GeometricContactFunction>(Update::NormalAcceleration, contact_, Contact::Output::F1NormalAcceleration);
+    addInputDependency<GeometricContactFunction>(Update::NormalAcceleration, contact_,
+                                                 Contact::Output::F1NormalAcceleration);
     addInputDependency<GeometricContactFunction>(Update::Jacobian, contact_, Contact::Output::F1Jacobian);
     addVariable(r1.q(), false);
   }
@@ -82,7 +80,8 @@ GeometricContactFunction::GeometricContactFunction(ContactPtr contact, Eigen::Ma
   if(has_f2_)
   {
     addInputDependency<GeometricContactFunction>(Update::Velocity, contact_, Contact::Output::F2Velocity);
-    addInputDependency<GeometricContactFunction>(Update::NormalAcceleration, contact_, Contact::Output::F2NormalAcceleration);
+    addInputDependency<GeometricContactFunction>(Update::NormalAcceleration, contact_,
+                                                 Contact::Output::F2NormalAcceleration);
     addInputDependency<GeometricContactFunction>(Update::Jacobian, contact_, Contact::Output::F2Jacobian);
     addVariable(r2.q(), false);
   }
@@ -144,8 +143,8 @@ void GeometricContactFunction::updateJacobian()
   }
 }
 
-}
+} // namespace internal
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/src/robot/JointsSelector.cpp
+++ b/src/robot/JointsSelector.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/JointsSelector.h>
 

--- a/src/robot/JointsSelector.cpp
+++ b/src/robot/JointsSelector.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/JointsSelector.h>
 
@@ -41,15 +41,15 @@ std::unique_ptr<JointsSelector> JointsSelector::ActiveJoints(FunctionPtr f,
                                                              RobotPtr robot,
                                                              const std::vector<std::string> & activeJoints)
 {
-  auto checkRobotVariable = [&](const std::string & name, const VariablePtr & v)
-  {
+  auto checkRobotVariable = [&](const std::string & name, const VariablePtr & v) {
     if(v->size())
     {
       const auto & f_vars = f->variables();
       auto it = std::find(f_vars.begin(), f_vars.end(), v);
       if(it == f_vars.end())
       {
-        throw exception::FunctionException("Cannot setup joint selector for the provided function: it does not uses " + name + " variable of " + robot->name());
+        throw exception::FunctionException("Cannot setup joint selector for the provided function: it does not uses "
+                                           + name + " variable of " + robot->name());
       }
     }
   };
@@ -59,22 +59,20 @@ std::unique_ptr<JointsSelector> JointsSelector::ActiveJoints(FunctionPtr f,
   const auto & mb = robot->mb();
 
   std::vector<std::string> joints = activeJoints;
-  std::sort(joints.begin(), joints.end(),
-            [&mb](const std::string & lhs, const std::string & rhs)
-            {
-            return mb.jointPosInDof(mb.jointIndexByName(lhs)) <
-                    mb.jointPosInDof(mb.jointIndexByName(rhs));
-            });
+  std::sort(joints.begin(), joints.end(), [&mb](const std::string & lhs, const std::string & rhs) {
+    return mb.jointPosInDof(mb.jointIndexByName(lhs)) < mb.jointPosInDof(mb.jointIndexByName(rhs));
+  });
 
-
-  bool ffActive = joints.size() > 0 &&
-                  joints[0] == mb.joint(0).name() &&
-                  mb.joint(0).dof() == 6;
-  if(ffActive) { joints.erase(joints.begin()); }
+  bool ffActive = joints.size() > 0 && joints[0] == mb.joint(0).name() && mb.joint(0).dof() == 6;
+  if(ffActive)
+  {
+    joints.erase(joints.begin());
+  }
 
   Eigen::DenseIndex ffSize = mb.joint(0).dof() == 6 ? 6 : 0;
   std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> activeIndex;
-  Eigen::DenseIndex start = 0; Eigen::DenseIndex size = 0;
+  Eigen::DenseIndex start = 0;
+  Eigen::DenseIndex size = 0;
   for(const auto & j : joints)
   {
     auto jIndex = mb.jointIndexByName(j);
@@ -96,21 +94,21 @@ std::unique_ptr<JointsSelector> JointsSelector::ActiveJoints(FunctionPtr f,
   }
   if(size != 0)
   {
-    activeIndex.push_back({start,size});
+    activeIndex.push_back({start, size});
   }
 
   return std::unique_ptr<JointsSelector>(new JointsSelector(f, robot, ffActive, activeIndex));
 }
 
 std::unique_ptr<JointsSelector> JointsSelector::InactiveJoints(FunctionPtr f,
-                                                             RobotPtr robot,
-                                                             const std::vector<std::string> & inactiveJoints)
+                                                               RobotPtr robot,
+                                                               const std::vector<std::string> & inactiveJoints)
 {
-  std::vector<std::string> activeJoints {};
+  std::vector<std::string> activeJoints{};
   for(const auto & j : robot->mb().joints())
   {
-    if(std::find_if(inactiveJoints.begin(), inactiveJoints.end(),
-                    [&j](const std::string & s) { return s == j.name(); }) == inactiveJoints.end())
+    if(std::find_if(inactiveJoints.begin(), inactiveJoints.end(), [&j](const std::string & s) { return s == j.name(); })
+       == inactiveJoints.end())
     {
       activeJoints.push_back(j.name());
     }
@@ -118,12 +116,11 @@ std::unique_ptr<JointsSelector> JointsSelector::InactiveJoints(FunctionPtr f,
   return ActiveJoints(f, robot, activeJoints);
 }
 
- JointsSelector::JointsSelector(FunctionPtr f, RobotPtr robot, bool ffActive, const std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> & activeIndex)
-: function::abstract::Function(f->imageSpace()),
-  f_(f),
-  robot_(robot),
-  ffActive_(ffActive),
-  activeIndex_(activeIndex)
+JointsSelector::JointsSelector(FunctionPtr f,
+                               RobotPtr robot,
+                               bool ffActive,
+                               const std::vector<std::pair<Eigen::DenseIndex, Eigen::DenseIndex>> & activeIndex)
+: function::abstract::Function(f->imageSpace()), f_(f), robot_(robot), ffActive_(ffActive), activeIndex_(activeIndex)
 {
   addDirectDependency<JointsSelector>(Output::Value, *f_, Function::Output::Value);
   addDirectDependency<JointsSelector>(Output::Velocity, *f_, Function::Output::Velocity);
@@ -138,14 +135,14 @@ std::unique_ptr<JointsSelector> JointsSelector::InactiveJoints(FunctionPtr f,
   addInputDependency<JointsSelector>(Update::Jacobian, *f_, Function::Output::Jacobian);
   addInputDependency<JointsSelector>(Update::JDot, *f_, Function::Output::JDot);
 
-  if(ffActive_) 
-  { 
-    addVariable(robot_->qFreeFlyer(), f_->linearIn(*robot_->qFreeFlyer())); 
+  if(ffActive_)
+  {
+    addVariable(robot_->qFreeFlyer(), f_->linearIn(*robot_->qFreeFlyer()));
     jacobian_.at(robot_->qFreeFlyer().get()).setZero();
   }
-  if(activeIndex.size()) 
-  { 
-    addVariable(robot_->qJoints(), f_->linearIn(*robot_->qJoints())); 
+  if(activeIndex.size())
+  {
+    addVariable(robot_->qJoints(), f_->linearIn(*robot_->qJoints()));
     jacobian_.at(robot_->qJoints().get()).setZero();
   }
 }
@@ -162,7 +159,7 @@ void JointsSelector::updateJacobian()
     for(const auto & p : activeIndex_)
     {
       jacobian_[robot_->qJoints().get()].middleCols(p.first, p.second) =
-        jacIn.block(0, p.first, jacIn.rows(), p.second);
+          jacIn.block(0, p.first, jacIn.rows(), p.second);
     }
   }
 }
@@ -178,8 +175,7 @@ void JointsSelector::updateJDot()
     const auto & JDotIn = f_->JDot(*robot_->qJoints());
     for(const auto & p : activeIndex_)
     {
-      JDot_[robot_->qJoints().get()].middleCols(p.first, p.second) =
-        JDotIn.block(0, p.first, JDotIn.rows(), p.second);
+      JDot_[robot_->qJoints().get()].middleCols(p.first, p.second) = JDotIn.block(0, p.first, JDotIn.rows(), p.second);
     }
   }
 }

--- a/src/robot/OrientationFunction.cpp
+++ b/src/robot/OrientationFunction.cpp
@@ -1,34 +1,34 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/robot/OrientationFunction.h>
 #include <tvm/Robot.h>
+#include <tvm/robot/OrientationFunction.h>
 
 namespace tvm
 {
@@ -36,16 +36,15 @@ namespace tvm
 namespace robot
 {
 
-
-OrientationFunction::OrientationFunction(FramePtr frame)
-: function::abstract::Function(3),
-  frame_(frame)
+OrientationFunction::OrientationFunction(FramePtr frame) : function::abstract::Function(3), frame_(frame)
 {
   reset();
+  // clang-format off
   registerUpdates(Update::Value, &OrientationFunction::updateValue,
                   Update::Velocity, &OrientationFunction::updateVelocity,
                   Update::Jacobian, &OrientationFunction::updateJacobian,
                   Update::NormalAcceleration, &OrientationFunction::updateNormalAcceleration);
+  // clang-format on
   addOutputDependency<OrientationFunction>(Output::Value, Update::Value);
   addOutputDependency<OrientationFunction>(Output::Velocity, Update::Velocity);
   addOutputDependency<OrientationFunction>(Output::Jacobian, Update::Jacobian);
@@ -58,30 +57,15 @@ OrientationFunction::OrientationFunction(FramePtr frame)
   addInputDependency<OrientationFunction>(Update::NormalAcceleration, frame_, Frame::Output::NormalAcceleration);
 }
 
-void OrientationFunction::reset()
-{
-  ori_ = frame_->position().rotation();
-}
+void OrientationFunction::reset() { ori_ = frame_->position().rotation(); }
 
-void OrientationFunction::updateValue()
-{
-  value_ = sva::rotationError(ori_, frame_->position().rotation());
-}
+void OrientationFunction::updateValue() { value_ = sva::rotationError(ori_, frame_->position().rotation()); }
 
-void OrientationFunction::updateVelocity()
-{
-  velocity_ = frame_->velocity().angular();
-}
+void OrientationFunction::updateVelocity() { velocity_ = frame_->velocity().angular(); }
 
-void OrientationFunction::updateJacobian()
-{
-  splitJacobian(frame_->jacobian().topRows<3>(), frame_->robot().q());
-}
+void OrientationFunction::updateJacobian() { splitJacobian(frame_->jacobian().topRows<3>(), frame_->robot().q()); }
 
-void OrientationFunction::updateNormalAcceleration()
-{
-  normalAcceleration_ = frame_->normalAcceleration().angular();
-}
+void OrientationFunction::updateNormalAcceleration() { normalAcceleration_ = frame_->normalAcceleration().angular(); }
 
 } // namespace robot
 

--- a/src/robot/OrientationFunction.cpp
+++ b/src/robot/OrientationFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Robot.h>
 #include <tvm/robot/OrientationFunction.h>

--- a/src/robot/PositionFunction.cpp
+++ b/src/robot/PositionFunction.cpp
@@ -1,34 +1,34 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/robot/PositionFunction.h>
 #include <tvm/Robot.h>
+#include <tvm/robot/PositionFunction.h>
 
 namespace tvm
 {
@@ -36,15 +36,15 @@ namespace tvm
 namespace robot
 {
 
-PositionFunction::PositionFunction(FramePtr frame)
-: function::abstract::Function(3),
-  frame_(frame)
+PositionFunction::PositionFunction(FramePtr frame) : function::abstract::Function(3), frame_(frame)
 {
   reset();
+  // clang-format off
   registerUpdates(Update::Value, &PositionFunction::updateValue,
                   Update::Velocity, &PositionFunction::updateVelocity,
                   Update::Jacobian, &PositionFunction::updateJacobian,
                   Update::NormalAcceleration, &PositionFunction::updateNormalAcceleration);
+  // clang-format on
   addOutputDependency<PositionFunction>(Output::Value, Update::Value);
   addOutputDependency<PositionFunction>(Output::Velocity, Update::Velocity);
   addOutputDependency<PositionFunction>(Output::Jacobian, Update::Jacobian);
@@ -57,30 +57,15 @@ PositionFunction::PositionFunction(FramePtr frame)
   addInputDependency<PositionFunction>(Update::NormalAcceleration, frame_, Frame::Output::NormalAcceleration);
 }
 
-void PositionFunction::reset()
-{
-  pos_ = frame_->position().translation();
-}
+void PositionFunction::reset() { pos_ = frame_->position().translation(); }
 
-void PositionFunction::updateValue()
-{
-  value_ = frame_->position().translation() - pos_;
-}
+void PositionFunction::updateValue() { value_ = frame_->position().translation() - pos_; }
 
-void PositionFunction::updateVelocity()
-{
-  velocity_ = frame_->velocity().linear();
-}
+void PositionFunction::updateVelocity() { velocity_ = frame_->velocity().linear(); }
 
-void PositionFunction::updateJacobian()
-{
-  splitJacobian(frame_->jacobian().bottomRows<3>(), frame_->robot().q());
-}
+void PositionFunction::updateJacobian() { splitJacobian(frame_->jacobian().bottomRows<3>(), frame_->robot().q()); }
 
-void PositionFunction::updateNormalAcceleration()
-{
-  normalAcceleration_ = frame_->normalAcceleration().linear();
-}
+void PositionFunction::updateNormalAcceleration() { normalAcceleration_ = frame_->normalAcceleration().linear(); }
 
 } // namespace robot
 

--- a/src/robot/PositionFunction.cpp
+++ b/src/robot/PositionFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Robot.h>
 #include <tvm/robot/PositionFunction.h>

--- a/src/robot/PostureFunction.cpp
+++ b/src/robot/PostureFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/PostureFunction.h>
 
@@ -36,12 +36,13 @@ namespace robot
 {
 
 PostureFunction::PostureFunction(RobotPtr robot)
-: function::abstract::Function(robot->qJoints()->space().tSize()),
-  robot_(robot),
+: function::abstract::Function(robot->qJoints()->space().tSize()), robot_(robot),
   j0_(robot_->mb().joint(0).type() == rbd::Joint::Free ? 1 : 0)
 {
+  // clang-format off
   registerUpdates(Update::Value, &PostureFunction::updateValue,
                   Update::Velocity, &PostureFunction::updateVelocity);
+  // clang-format on
   addOutputDependency<PostureFunction>(Output::Value, Update::Value);
   addOutputDependency<PostureFunction>(Output::Velocity, Update::Velocity);
   addInputDependency<PostureFunction>(Update::Value, robot_, Robot::Output::FK);
@@ -56,13 +57,9 @@ PostureFunction::PostureFunction(RobotPtr robot)
   reset();
 }
 
-void PostureFunction::reset()
-{
-  posture_ = robot_->mbc().q;
-}
+void PostureFunction::reset() { posture_ = robot_->mbc().q; }
 
-void PostureFunction::posture(const std::string & j,
-                              const std::vector<double> & q)
+void PostureFunction::posture(const std::string & j, const std::vector<double> & q)
 {
   // This assert throws if j is not part of robot.mb
   assert(robot_->mb().sJointIndexByName(j));
@@ -73,17 +70,22 @@ void PostureFunction::posture(const std::string & j,
 
 namespace
 {
-  bool isValidPosture(const std::vector<std::vector<double>> & ref,
-                      const std::vector<std::vector<double>> & in)
+bool isValidPosture(const std::vector<std::vector<double>> & ref, const std::vector<std::vector<double>> & in)
+{
+  if(ref.size() != in.size())
   {
-    if(ref.size() != in.size()) { return false; }
-    for(size_t i = 0; i < ref.size(); ++i)
-    {
-      if(ref[i].size() != in[i].size()) { return false; }
-    }
-    return true;
+    return false;
   }
+  for(size_t i = 0; i < ref.size(); ++i)
+  {
+    if(ref[i].size() != in[i].size())
+    {
+      return false;
+    }
+  }
+  return true;
 }
+} // namespace
 
 void PostureFunction::posture(const std::vector<std::vector<double>> & p)
 {
@@ -105,10 +107,7 @@ void PostureFunction::updateValue()
     else if(j.dof() == 4) // spherical
     {
       Eigen::Matrix3d ori(
-        Eigen::Quaterniond(posture_[jI][0],
-                           posture_[jI][1],
-                           posture_[jI][2],
-                           posture_[jI][3]).matrix());
+          Eigen::Quaterniond(posture_[jI][0], posture_[jI][1], posture_[jI][2], posture_[jI][3]).matrix());
       auto error = sva::rotationError(ori, robot_->mbc().jointConfig[jI].rotation());
       value_.segment(pos, 3) = error;
       pos += 3;
@@ -129,6 +128,6 @@ void PostureFunction::updateVelocity()
   }
 }
 
-}
+} // namespace robot
 
-}
+} // namespace tvm

--- a/src/robot/PostureFunction.cpp
+++ b/src/robot/PostureFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/PostureFunction.h>
 

--- a/src/robot/utils.cpp
+++ b/src/robot/utils.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/robot/utils.h>
 

--- a/src/robot/utils.cpp
+++ b/src/robot/utils.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/robot/utils.h>
 
@@ -41,8 +41,10 @@ namespace tvm
 namespace robot
 {
 
-std::unique_ptr<Robot> fromURDF(tvm::Clock & clock, const std::string & name,
-                                const std::string & path, bool fixed,
+std::unique_ptr<Robot> fromURDF(tvm::Clock & clock,
+                                const std::string & name,
+                                const std::string & path,
+                                bool fixed,
                                 const std::vector<std::string> & filteredLinks,
                                 const std::map<std::string, std::vector<double>> & q)
 {
@@ -66,7 +68,8 @@ std::unique_ptr<Robot> fromURDF(tvm::Clock & clock, const std::string & name,
     auto jIndex = jIndexByName.at(qi.first);
     if(init_q[jIndex].size() != qi.second.size())
     {
-      std::cerr << "Joint " << qi.first << ": provided configuration has " << qi.second.size() << " params but loaded robot has " << init_q[jIndex].size() << " params." << std::endl;
+      std::cerr << "Joint " << qi.first << ": provided configuration has " << qi.second.size()
+                << " params but loaded robot has " << init_q[jIndex].size() << " params." << std::endl;
       continue;
     }
     init_q[jIndex] = qi.second;

--- a/src/scheme/Assignment.cpp
+++ b/src/scheme/Assignment.cpp
@@ -2,9 +2,10 @@
 
 #include <tvm/scheme/internal/Assignment.h>
 
+#include <tvm/defs.h>
+
 #include <tvm/VariableVector.h>
 #include <tvm/constraint/abstract/Constraint.h>
-#include <tvm/defs.h>
 #include <tvm/scheme/internal/helpers.h>
 
 namespace tvm::scheme::internal

--- a/src/scheme/Assignment.cpp
+++ b/src/scheme/Assignment.cpp
@@ -546,7 +546,7 @@ void Assignment::addAssignments(const VariableVector & variables,
                                 bool flip)
 {
   const auto & xs = substitutedVariables_; // susbstituted variables
-  const auto & xc = source_->variables(); // variables of the source constraint
+  const auto & xc = source_->variables();  // variables of the source constraint
 
   addVectorAssignment(f1, v1, flip);
   if(f2)

--- a/src/scheme/Assignment.cpp
+++ b/src/scheme/Assignment.cpp
@@ -2,284 +2,269 @@
 
 #include <tvm/scheme/internal/Assignment.h>
 
-#include <tvm/defs.h>
-#include <tvm/constraint/abstract/Constraint.h>
 #include <tvm/VariableVector.h>
+#include <tvm/constraint/abstract/Constraint.h>
+#include <tvm/defs.h>
 #include <tvm/scheme/internal/helpers.h>
 
 namespace tvm::scheme::internal
 {
-  using constraint::abstract::LinearConstraint;
-  using constraint::Type;
-  using constraint::RHS;
+using constraint::RHS;
+using constraint::Type;
+using constraint::abstract::LinearConstraint;
 
-  double Assignment::big_ = constant::big_number;
+double Assignment::big_ = constant::big_number;
 
-  Assignment::Assignment(LinearConstraintPtr source,
-    SolvingRequirementsPtr req,
-    const AssignmentTarget& target,
-    const VariableVector& variables,
-    const hint::internal::Substitutions* const substitutions,
-    double scalarizationWeight)
-    : source_(source)
-    , target_(target)
-    , scalarizationWeight_(scalarizationWeight)
-    , requirements_(req)
-    , substitutedVariables_(substitutions ? substitutions->variables() : VariableVector())
-    , variableSubstitutions_(substitutions ? substitutions->variableSubstitutions() : std::vector<std::shared_ptr<function::BasicLinearFunction>>())
-    , data_(new ReferenceableData())
+Assignment::Assignment(LinearConstraintPtr source,
+                       SolvingRequirementsPtr req,
+                       const AssignmentTarget & target,
+                       const VariableVector & variables,
+                       const hint::internal::Substitutions * const substitutions,
+                       double scalarizationWeight)
+: source_(source), target_(target), scalarizationWeight_(scalarizationWeight), requirements_(req),
+  substitutedVariables_(substitutions ? substitutions->variables() : VariableVector()),
+  variableSubstitutions_(substitutions ? substitutions->variableSubstitutions()
+                                       : std::vector<std::shared_ptr<function::BasicLinearFunction>>()),
+  data_(new ReferenceableData())
+{
+  checkTarget();
+  // TODO check also that the variables of source are in the variable vector
+  processRequirements();
+  build(variables);
+}
+
+Assignment::Assignment(LinearConstraintPtr source,
+                       const AssignmentTarget & target,
+                       const VariablePtr & variable,
+                       bool first)
+: source_(source), target_(target), requirements_(nullptr), useDefaultScalarWeight_(true),
+  useDefaultAnisotropicWeight_(true), data_(new ReferenceableData())
+{
+  checkBounds();
+  assert(source->variables()[0] == variable);
+  build(variable, first);
+}
+
+Assignment Assignment::reprocess(const Assignment & other,
+                                 const VariableVector & variables,
+                                 const hint::internal::Substitutions * const subs)
+{
+  return Assignment(other.source_, other.requirements_, other.target_, variables, subs, other.scalarizationWeight_);
+}
+
+Assignment Assignment::reprocess(const Assignment & other, const VariablePtr & x, bool first)
+{
+  return Assignment(other.source_, other.target_, x, first);
+}
+
+AssignmentTarget & Assignment::target(IWontForgetToCallUpdates) { return target_; }
+
+bool Assignment::changeScalarWeightIsAllowed() { return !useDefaultScalarWeight_; }
+
+bool Assignment::changeVectorWeightIsAllowed() { return !useDefaultAnisotropicWeight_; }
+
+void Assignment::onUpdatedSource()
+{
+  // TODO
+}
+
+void Assignment::onUpdatedTarget()
+{
+  for(auto & a : matrixAssignments_)
+    a.updateTarget(target_);
+  for(auto & a : matrixSubstitutionAssignments_)
+    a.updateTarget(target_);
+  for(auto & a : vectorAssignments_)
+    a.assignment.to((target_.*a.getTargetVector)());
+  for(auto & a : vectorSubstitutionAssignments_)
+    a.assignment.to((target_.*a.getTargetVector)());
+}
+
+void Assignment::onUpdatedMapping(const VariableVector & newVar, bool updateMatrixTarget)
+{
+  for(auto & a : matrixAssignments_)
+    a.updateMapping(newVar, target_, updateMatrixTarget);
+  for(auto & a : matrixSubstitutionAssignments_)
+    a.updateMapping(newVar, target_, updateMatrixTarget);
+}
+
+void Assignment::onUpdateWeights(bool scalar, bool vector)
+{
+  if(scalar)
   {
-    checkTarget();
-    //TODO check also that the variables of source are in the variable vector
-    processRequirements();
-    build(variables);
+    if(useDefaultScalarWeight_ && requirements_->weight().value() != 1)
+      throw std::runtime_error("[Assignment::onUpdateWeights] Can't update a default weight.");
+
+    data_->scalarWeight_ = std::sqrt(requirements_->weight().value()) * scalarizationWeight_;
+    data_->minusScalarWeight_ = -data_->scalarWeight_;
+  }
+  if(vector)
+  {
+    if(!requirements_->anisotropicWeight().isDefault()
+       && requirements_->anisotropicWeight().value().size() != target_.size())
+      throw std::runtime_error("[Assignment::onUpdateWeights] Anisotropic weight has not the correct size.");
+
+    if(useDefaultAnisotropicWeight_ && !requirements_->anisotropicWeight().isDefault()
+       && !requirements_->anisotropicWeight().value().isConstant(1))
+      throw std::runtime_error("[Assignment::onUpdateWeights] Can't update a default weight.");
+
+    data_->anisotropicWeight_ = requirements_->anisotropicWeight().value().cwiseSqrt();
+    data_->anisotropicWeight_ *= data_->scalarWeight_;
+    data_->minusAnisotropicWeight_ = -data_->anisotropicWeight_;
+  }
+}
+
+void Assignment::run()
+{
+  for(auto & a : matrixAssignments_)
+    a.assignment.run();
+
+  for(auto & a : matrixSubstitutionAssignments_)
+    a.assignment.run();
+
+  for(auto & a : vectorAssignments_)
+    a.assignment.run();
+
+  for(auto & a : vectorSubstitutionAssignments_)
+    a.assignment.run();
+}
+
+void Assignment::checkTarget()
+{
+  // check the type convention
+  if(source_->type() == Type::EQUAL)
+  {
+    if(target_.constraintType() != Type::EQUAL && target_.constraintType() != Type::DOUBLE_SIDED)
+      throw std::runtime_error("Incompatible conventions: source with type EQUAL can only "
+                               "be assigned to target with type EQUAL or DOUBLE SIDED.");
+  }
+  else
+  {
+    if(target_.constraintType() == Type::EQUAL)
+      throw std::runtime_error("Incompatible conventions: source with type other than EQUAL "
+                               "cannot be assigned to a target with type EQUAL. ");
   }
 
-  Assignment::Assignment(LinearConstraintPtr source, const AssignmentTarget& target, const VariablePtr& variable, bool first)
-    : source_(source)
-    , target_(target)
-    , requirements_(nullptr)
-    , useDefaultScalarWeight_(true)
-    , useDefaultAnisotropicWeight_(true)
-    , data_(new ReferenceableData())
+  // check the rhs conventions
+  bool hasNonZero = false;
+  for(const auto & s : variableSubstitutions_)
   {
-    checkBounds();
-    assert(source->variables()[0] == variable);
-    build(variable, first);
+    const auto & p = s->b().properties();
+    hasNonZero = hasNonZero || !p.isZero() || !p.isConstant();
   }
+  if((source_->rhs() != RHS::ZERO || hasNonZero) && target_.constraintRhs() == RHS::ZERO)
+    throw std::runtime_error("Incompatible conventions: source with rhs other than ZERO "
+                             "(or when using susbtitutions with non-zero vector term) "
+                             "cannot be assigned to target with rhs ZERO.");
 
-  Assignment Assignment::reprocess(const Assignment& other, const VariableVector& variables,
-    const hint::internal::Substitutions* const subs)
+  // check the sizes
+  if(source_->type() == Type::DOUBLE_SIDED)
   {
-    return Assignment(other.source_, other.requirements_, other.target_, variables, subs, other.scalarizationWeight_);
-  }
-
-  Assignment Assignment::reprocess(const Assignment& other, const VariablePtr& x, bool first)
-  {
-    return Assignment(other.source_, other.target_, x, first);
-  }
-
-  AssignmentTarget& Assignment::target(IWontForgetToCallUpdates)
-  {
-    return target_;
-  }
-
-  bool Assignment::changeScalarWeightIsAllowed()
-  {
-    return !useDefaultScalarWeight_;
-  }
-
-  bool Assignment::changeVectorWeightIsAllowed()
-  {
-    return !useDefaultAnisotropicWeight_;
-  }
-
-  void Assignment::onUpdatedSource()
-  {
-    //TODO
-  }
-
-  void Assignment::onUpdatedTarget()
-  {
-    for (auto& a : matrixAssignments_)
-      a.updateTarget(target_);
-    for (auto& a : matrixSubstitutionAssignments_)
-      a.updateTarget(target_);
-    for (auto& a : vectorAssignments_)
-      a.assignment.to((target_.*a.getTargetVector)());
-    for (auto& a : vectorSubstitutionAssignments_)
-      a.assignment.to((target_.*a.getTargetVector)());
-  }
-
-  void Assignment::onUpdatedMapping(const VariableVector& newVar, bool updateMatrixTarget)
-  {
-    for (auto& a : matrixAssignments_)
-      a.updateMapping(newVar, target_, updateMatrixTarget);
-    for (auto& a : matrixSubstitutionAssignments_)
-      a.updateMapping(newVar, target_, updateMatrixTarget);
-  }
-
-  void Assignment::onUpdateWeights(bool scalar, bool vector)
-  {
-    if (scalar)
+    if(target_.constraintType() == Type::DOUBLE_SIDED)
     {
-      if (useDefaultScalarWeight_ && requirements_->weight().value() != 1)
-        throw std::runtime_error("[Assignment::onUpdateWeights] Can't update a default weight.");
-
-      data_->scalarWeight_ = std::sqrt(requirements_->weight().value()) * scalarizationWeight_;
-      data_->minusScalarWeight_ = -data_->scalarWeight_;
-    }
-    if (vector)
-    {
-      if (!requirements_->anisotropicWeight().isDefault() && requirements_->anisotropicWeight().value().size() != target_.size())
-        throw std::runtime_error("[Assignment::onUpdateWeights] Anisotropic weight has not the correct size.");
-
-      if (useDefaultAnisotropicWeight_ && !requirements_->anisotropicWeight().isDefault()
-        && !requirements_->anisotropicWeight().value().isConstant(1))
-        throw std::runtime_error("[Assignment::onUpdateWeights] Can't update a default weight.");
-
-      data_->anisotropicWeight_ = requirements_->anisotropicWeight().value().cwiseSqrt();
-      data_->anisotropicWeight_ *= data_->scalarWeight_;
-      data_->minusAnisotropicWeight_ = -data_->anisotropicWeight_;
-    }
-  }
-
-  void Assignment::run()
-  {
-    for (auto& a : matrixAssignments_)
-      a.assignment.run();
-
-    for (auto& a : matrixSubstitutionAssignments_)
-      a.assignment.run();
-
-    for (auto& a : vectorAssignments_)
-      a.assignment.run();
-
-    for (auto& a : vectorSubstitutionAssignments_)
-      a.assignment.run();
-  }
-
-  void Assignment::checkTarget()
-  {
-    //check the type convention
-    if (source_->type() == Type::EQUAL)
-    {
-      if (target_.constraintType() != Type::EQUAL
-        && target_.constraintType() != Type::DOUBLE_SIDED)
-        throw std::runtime_error("Incompatible conventions: source with type EQUAL can only "
-          "be assigned to target with type EQUAL or DOUBLE SIDED.");
-    }
-    else
-    {
-      if (target_.constraintType() == Type::EQUAL)
-        throw std::runtime_error("Incompatible conventions: source with type other than EQUAL "
-          "cannot be assigned to a target with type EQUAL. ");
-    }
-
-    // check the rhs conventions
-    bool hasNonZero = false;
-    for (const auto& s : variableSubstitutions_)
-    {
-      const auto& p = s->b().properties();
-      hasNonZero = hasNonZero || !p.isZero() || !p.isConstant();
-    }
-    if ((source_->rhs() != RHS::ZERO || hasNonZero) && target_.constraintRhs() == RHS::ZERO)
-      throw std::runtime_error("Incompatible conventions: source with rhs other than ZERO "
-        "(or when using susbtitutions with non-zero vector term) "
-        "cannot be assigned to target with rhs ZERO.");
-
-    //check the sizes
-    if (source_->type() == Type::DOUBLE_SIDED)
-    {
-      if (target_.constraintType() == Type::DOUBLE_SIDED)
-      {
-        if (target_.size() != source_->size())
-          throw std::runtime_error("Size of the source and the target are not coherent with "
-            "the conventions.");
-      }
-      else
-      {
-        if (target_.size() != 2 * source_->size())
-          throw std::runtime_error("Size of the source and the target are not coherent with "
-            "the conventions.");
-      }
-    }
-    else
-    {
-      if (target_.size() != source_->size())
+      if(target_.size() != source_->size())
         throw std::runtime_error("Size of the source and the target are not coherent with "
-          "the conventions.");
+                                 "the conventions.");
+    }
+    else
+    {
+      if(target_.size() != 2 * source_->size())
+        throw std::runtime_error("Size of the source and the target are not coherent with "
+                                 "the conventions.");
     }
   }
-
-  void Assignment::checkBounds()
+  else
   {
-    if (!canBeUsedAsBound(source_, substitutedVariables_.variables(),
-      variableSubstitutions_, target_.constraintType()))
-    {
-      throw std::runtime_error("Incompatible bound conventions or properties");
-    }
+    if(target_.size() != source_->size())
+      throw std::runtime_error("Size of the source and the target are not coherent with "
+                               "the conventions.");
   }
+}
 
-  void Assignment::build(const VariableVector& variables)
+void Assignment::checkBounds()
+{
+  if(!canBeUsedAsBound(source_, substitutedVariables_.variables(), variableSubstitutions_, target_.constraintType()))
   {
-    // In this function, we split up the global assignment into atomic assignments.
-    // This is done according to the ConstraintType of both source and target
-    if (source_->type() == constraint::Type::EQUAL)
-    {
-      /*
-       *                 |  Ax = b
-       * ----------------+--------------
-       *      Cx = d     | C=A, d=b
-       *  dl <= Cx <= du | C=A, dl=du=b
-       */
+    throw std::runtime_error("Incompatible bound conventions or properties");
+  }
+}
 
-      switch (target_.constraintType())
-      {
+void Assignment::build(const VariableVector & variables)
+{
+  // In this function, we split up the global assignment into atomic assignments.
+  // This is done according to the ConstraintType of both source and target
+  if(source_->type() == constraint::Type::EQUAL)
+  {
+    /*
+     *                 |  Ax = b
+     * ----------------+--------------
+     *      Cx = d     | C=A, d=b
+     *  dl <= Cx <= du | C=A, dl=du=b
+     */
+
+    switch(target_.constraintType())
+    {
       case constraint::Type::EQUAL:
-        addAssignments(variables, &AssignmentTarget::A,
-          &LinearConstraint::e, &AssignmentTarget::b, false);
+        addAssignments(variables, &AssignmentTarget::A, &LinearConstraint::e, &AssignmentTarget::b, false);
         break;
       case constraint::Type::DOUBLE_SIDED:
-        addAssignments(variables, &AssignmentTarget::A,
-          &LinearConstraint::e, &AssignmentTarget::l,
-          &LinearConstraint::e, &AssignmentTarget::u);
+        addAssignments(variables, &AssignmentTarget::A, &LinearConstraint::e, &AssignmentTarget::l,
+                       &LinearConstraint::e, &AssignmentTarget::u);
         break;
       default:
         throw std::runtime_error("Impossible to assign source for the given target convention.");
+    }
+  }
+  else
+  {
+    /*
+     *                 |        Ax >= b        |        Ax <= b         |       bl <= Ax <= bu
+     * ----------------+-----------------------+------------------------+---------------------------
+     *     Cx >= d     | (1) C=A, d=b          | (4) C=-A, d=-b         | (7) C=[A,-A], d=[bl,-bu]
+     *     Cx <= d     | (2) C=-A, d=-b        | (5) C=A, d=b           | (8) C=[A,-A], d=[bu,-bl]
+     *  dl <= Cx <= du | (3) C=A, dl=b, du=inf | (6) C=A, dl=-inf, du=b | (9) C=A, dl = bl, du = bu
+     */
+
+    if(source_->type() == constraint::Type::DOUBLE_SIDED)
+    {
+      if(target_.constraintType() == constraint::Type::DOUBLE_SIDED)
+      {
+        // case 9
+        addAssignments(variables, &AssignmentTarget::A, &LinearConstraint::l, &AssignmentTarget::l,
+                       &LinearConstraint::u, &AssignmentTarget::u);
+      }
+      else
+      {
+        if(target_.constraintType() == constraint::Type::GREATER_THAN)
+        {
+          // case 7
+          addAssignments(variables, &AssignmentTarget::AFirstHalf, &LinearConstraint::l, &AssignmentTarget::bFirstHalf,
+                         false);
+          addAssignments(variables, &AssignmentTarget::ASecondHalf, &LinearConstraint::u,
+                         &AssignmentTarget::bSecondHalf, true);
+        }
+        else
+        {
+          // case 8
+          addAssignments(variables, &AssignmentTarget::AFirstHalf, &LinearConstraint::u, &AssignmentTarget::bFirstHalf,
+                         false);
+          addAssignments(variables, &AssignmentTarget::ASecondHalf, &LinearConstraint::l,
+                         &AssignmentTarget::bSecondHalf, true);
+        }
       }
     }
     else
     {
-      /*
-       *                 |        Ax >= b        |        Ax <= b         |       bl <= Ax <= bu
-       * ----------------+-----------------------+------------------------+---------------------------
-       *     Cx >= d     | (1) C=A, d=b          | (4) C=-A, d=-b         | (7) C=[A,-A], d=[bl,-bu]
-       *     Cx <= d     | (2) C=-A, d=-b        | (5) C=A, d=b           | (8) C=[A,-A], d=[bu,-bl]
-       *  dl <= Cx <= du | (3) C=A, dl=b, du=inf | (6) C=A, dl=-inf, du=b | (9) C=A, dl = bl, du = bu
-       */
-
-      if (source_->type() == constraint::Type::DOUBLE_SIDED)
-      {
-        if (target_.constraintType() == constraint::Type::DOUBLE_SIDED)
-        {
-          //case 9
-          addAssignments(variables, &AssignmentTarget::A,
-            &LinearConstraint::l, &AssignmentTarget::l,
-            &LinearConstraint::u, &AssignmentTarget::u);
-        }
-        else
-        {
-          if (target_.constraintType() == constraint::Type::GREATER_THAN)
-          {
-            //case 7
-            addAssignments(variables, &AssignmentTarget::AFirstHalf,
-              &LinearConstraint::l, &AssignmentTarget::bFirstHalf, false);
-            addAssignments(variables, &AssignmentTarget::ASecondHalf,
-              &LinearConstraint::u, &AssignmentTarget::bSecondHalf, true);
-          }
-          else
-          {
-            //case 8
-            addAssignments(variables, &AssignmentTarget::AFirstHalf,
-              &LinearConstraint::u, &AssignmentTarget::bFirstHalf, false);
-            addAssignments(variables, &AssignmentTarget::ASecondHalf,
-              &LinearConstraint::l, &AssignmentTarget::bSecondHalf, true);
-          }
-        }
-      }
+      // case 4 and 5 are just opposite of case 1 and 2.
+      bool flip = source_->type() == constraint::Type::LOWER_THAN;
+      RHSFunction f;
+      if(source_->type() == constraint::Type::LOWER_THAN)
+        f = &LinearConstraint::u; // for case 1 and 2
       else
-      {
-        // case 4 and 5 are just opposite of case 1 and 2.
-        bool flip = source_->type() == constraint::Type::LOWER_THAN;
-        RHSFunction f;
-        if (source_->type() == constraint::Type::LOWER_THAN)
-          f = &LinearConstraint::u;   //for case 1 and 2
-        else
-          f = &LinearConstraint::l;   //for case 4 and 5
+        f = &LinearConstraint::l; // for case 4 and 5
 
-        switch (target_.constraintType())
-        {
+      switch(target_.constraintType())
+      {
         case constraint::Type::EQUAL:
           throw std::runtime_error("Impossible to assign inequality source for equality target.");
         case constraint::Type::GREATER_THAN:
@@ -287,43 +272,43 @@ namespace tvm::scheme::internal
           addAssignments(variables, &AssignmentTarget::A, f, &AssignmentTarget::b, flip);
           break;
         case constraint::Type::LOWER_THAN:
-          //cases 2 and 5
+          // cases 2 and 5
           addAssignments(variables, &AssignmentTarget::A, f, &AssignmentTarget::b, !flip);
           break;
         case constraint::Type::DOUBLE_SIDED:
           // for case 3 and 6, the signs of A and C are the same
-          if (source_->type() == constraint::Type::GREATER_THAN)
+          if(source_->type() == constraint::Type::GREATER_THAN)
           {
-            //case 3
+            // case 3
             addAssignments(variables, &AssignmentTarget::A, f, &AssignmentTarget::l, false);
             addVectorAssignment(big_, &AssignmentTarget::u);
           }
           else
           {
-            //case 6
+            // case 6
             addAssignments(variables, &AssignmentTarget::A, f, &AssignmentTarget::u, false);
             addVectorAssignment(-big_, &AssignmentTarget::l);
           }
           break;
-        }
       }
     }
   }
+}
 
-  void Assignment::build(const VariablePtr& variable, bool first)
+void Assignment::build(const VariablePtr & variable, bool first)
+{
+  // We know that: source_ is a single-variable constraint with invertible
+  // diagonal jacobian, and that if there is a substitution it is also by a
+  // single variable with an invertible diagonal jacobian.
+  // We also know that the target is compatible with the source + substitution,
+  // and that it can't be of type EQUAL.
+
+  assert(target_.constraintType() != Type::EQUAL);
+
+  if(target_.constraintType() == Type::DOUBLE_SIDED)
   {
-    // We know that: source_ is a single-variable constraint with invertible
-    // diagonal jacobian, and that if there is a substitution it is also by a
-    // single variable with an invertible diagonal jacobian.
-    // We also know that the target is compatible with the source + substitution,
-    // and that it can't be of type EQUAL.
-
-    assert(target_.constraintType() != Type::EQUAL);
-
-    if (target_.constraintType() == Type::DOUBLE_SIDED)
+    switch(source_->type())
     {
-      switch (source_->type())
-      {
       case Type::EQUAL:
         addBounds(variable, &LinearConstraint::e, &LinearConstraint::e, first);
         break;
@@ -336,63 +321,64 @@ namespace tvm::scheme::internal
       case Type::DOUBLE_SIDED:
         addBounds(variable, &LinearConstraint::l, &LinearConstraint::u, first);
         break;
-      default: assert(false);
-      }
+      default:
+        assert(false);
     }
-    else //target is GREATER_THAN or LOWER_THAN
-    {
-      if (source_->type() == Type::GREATER_THAN)
-      {
-        addBound(variable, &LinearConstraint::l, first);
-      }
-      else //source is LOWER_THAN
-      {
-        addBound(variable, &LinearConstraint::u, first);
-      }
-    }
-    //VectorFunction l;
-    //VectorFunction u;
-    //bool flip;
-    //if (source_->jacobian(*variable).properties().isIdentity())
-    //{
-    //  l = &AssignmentTarget::l;
-    //  u = &AssignmentTarget::u;
-    //  flip = false;
-    //}
-    //else if (source_->jacobian(*variable).properties().isMinusIdentity())
-    //{
-    //  l = &AssignmentTarget::u;
-    //  u = &AssignmentTarget::l;
-    //  flip = true;
-    //}
-    //else
-    //{
-    //  throw std::runtime_error("Pure diagonal case is not implemented yet.");
-    //}
-
-    //if (first)
-    //{
-    //  assignBounds(l, u, flip);
-    //}
-    //else
-    //{
-    //  if (flip)
-    //    assignBounds<AssignType::MIN, AssignType::MAX>(l, u, flip);
-    //  else
-    //    assignBounds<AssignType::MAX, AssignType::MIN>(l, u, flip);
-    //}
   }
-
-  void Assignment::processRequirements()
+  else // target is GREATER_THAN or LOWER_THAN
   {
-    if (requirements_)
+    if(source_->type() == Type::GREATER_THAN)
     {
-      switch (requirements_->violationEvaluation().value())
-      {
+      addBound(variable, &LinearConstraint::l, first);
+    }
+    else // source is LOWER_THAN
+    {
+      addBound(variable, &LinearConstraint::u, first);
+    }
+  }
+  // VectorFunction l;
+  // VectorFunction u;
+  // bool flip;
+  // if (source_->jacobian(*variable).properties().isIdentity())
+  //{
+  //  l = &AssignmentTarget::l;
+  //  u = &AssignmentTarget::u;
+  //  flip = false;
+  //}
+  // else if (source_->jacobian(*variable).properties().isMinusIdentity())
+  //{
+  //  l = &AssignmentTarget::u;
+  //  u = &AssignmentTarget::l;
+  //  flip = true;
+  //}
+  // else
+  //{
+  //  throw std::runtime_error("Pure diagonal case is not implemented yet.");
+  //}
+
+  // if (first)
+  //{
+  //  assignBounds(l, u, flip);
+  //}
+  // else
+  //{
+  //  if (flip)
+  //    assignBounds<AssignType::MIN, AssignType::MAX>(l, u, flip);
+  //  else
+  //    assignBounds<AssignType::MAX, AssignType::MIN>(l, u, flip);
+  //}
+}
+
+void Assignment::processRequirements()
+{
+  if(requirements_)
+  {
+    switch(requirements_->violationEvaluation().value())
+    {
       case requirements::ViolationEvaluationType::L1:
         throw std::runtime_error("Unimplemented violation evaluation type.");
       case requirements::ViolationEvaluationType::L2:
-        if (requirements_->weight().isDefault() && scalarizationWeight_ == 1)
+        if(requirements_->weight().isDefault() && scalarizationWeight_ == 1)
         {
           useDefaultScalarWeight_ = true;
           data_->scalarWeight_ = 1;
@@ -404,7 +390,7 @@ namespace tvm::scheme::internal
           data_->scalarWeight_ = std::sqrt(requirements_->weight().value()) * scalarizationWeight_;
           data_->minusScalarWeight_ = -data_->scalarWeight_;
         }
-        if (requirements_->anisotropicWeight().isDefault())
+        if(requirements_->anisotropicWeight().isDefault())
         {
           useDefaultAnisotropicWeight_ = true;
         }
@@ -418,226 +404,243 @@ namespace tvm::scheme::internal
         break;
       case requirements::ViolationEvaluationType::LINF:
         throw std::runtime_error("Unimplemented violation evaluation type.");
-      }
+    }
+  }
+  else
+  {
+    useDefaultScalarWeight_ = true;
+    useDefaultAnisotropicWeight_ = true;
+  }
+}
+
+void Assignment::addMatrixAssignment(Variable & x, MatrixFunction M, const Range & range, bool flip)
+{
+  const MatrixConstRef & from = source_->jacobian(x);
+  const MatrixRef & to = (target_.*M)(range.start, range.dim);
+  auto w = createAssignment<Eigen::MatrixXd, AssignType::COPY>(from, to, flip);
+
+  matrixAssignments_.push_back({w, &x, range, M});
+}
+
+void Assignment::addMatrixSubstitutionAssignments(const VariableVector & variables,
+                                                  Variable & x,
+                                                  MatrixFunction M,
+                                                  const function::BasicLinearFunction & sub,
+                                                  bool flip)
+{
+  const auto & J = source_->jacobian(x);
+  for(const auto & xi : sub.variables())
+  {
+    Range range = xi->getMappingIn(variables);
+    const MatrixRef & to = (target_.*M)(range.start, range.dim);
+    const auto & Ai = sub.jacobian(*xi);
+    CompiledAssignmentWrapper<Eigen::MatrixXd> w;
+    if(J.properties().isIdentity())
+    {
+      if(flip)
+        w = createAssignment<Eigen::MatrixXd, SUB>(Ai, to);
+      else
+        w = createAssignment<Eigen::MatrixXd, ADD>(Ai, to);
+    }
+    else if(J.properties().isMinusIdentity())
+    {
+      if(flip)
+        w = createAssignment<Eigen::MatrixXd, ADD>(Ai, to);
+      else
+        w = createAssignment<Eigen::MatrixXd, SUB>(Ai, to);
     }
     else
     {
-      useDefaultScalarWeight_ = true;
-      useDefaultAnisotropicWeight_ = true;
-    }
-  }
-
-  void Assignment::addMatrixAssignment(Variable& x, MatrixFunction M, const Range& range, bool flip)
-  {
-    const MatrixConstRef& from = source_->jacobian(x);
-    const MatrixRef& to = (target_.*M)(range.start, range.dim);
-    auto w = createAssignment<Eigen::MatrixXd, AssignType::COPY>(from, to, flip);
-
-    matrixAssignments_.push_back({ w, &x, range, M });
-  }
-
-  void Assignment::addMatrixSubstitutionAssignments(const VariableVector& variables, Variable& x, MatrixFunction M,
-    const function::BasicLinearFunction& sub, bool flip)
-  {
-    const auto& J = source_->jacobian(x);
-    for (const auto& xi : sub.variables())
-    {
-      Range range = xi->getMappingIn(variables);
-      const MatrixRef& to = (target_.*M)(range.start, range.dim);
-      const auto& Ai = sub.jacobian(*xi);
-      CompiledAssignmentWrapper<Eigen::MatrixXd> w;
-      if (J.properties().isIdentity())
-      {
-        if (flip)
-          w = createAssignment<Eigen::MatrixXd, SUB>(Ai, to);
-        else
-          w = createAssignment<Eigen::MatrixXd, ADD>(Ai, to);
-      }
-      else if (J.properties().isMinusIdentity())
-      {
-        if (flip)
-          w = createAssignment<Eigen::MatrixXd, ADD>(Ai, to);
-        else
-          w = createAssignment<Eigen::MatrixXd, SUB>(Ai, to);
-      }
+      if(flip)
+        w = createMultiplicationAssignment<Eigen::MatrixXd, SUB>(J, to, Ai);
       else
-      {
-        if (flip)
-          w = createMultiplicationAssignment<Eigen::MatrixXd, SUB>(J, to, Ai);
-        else
-          w = createMultiplicationAssignment<Eigen::MatrixXd, ADD>(J, to, Ai);
-      }
-      //Possible optimizations:
-      // - detect more cases
-      // - use CUSTOM multiplications
-      // - in particular use the nullspace custom multiplication for variable z
-      // when appropriate.
-      matrixSubstitutionAssignments_.push_back({ w, xi.get(), range, M });
+        w = createMultiplicationAssignment<Eigen::MatrixXd, ADD>(J, to, Ai);
     }
+    // Possible optimizations:
+    // - detect more cases
+    // - use CUSTOM multiplications
+    // - in particular use the nullspace custom multiplication for variable z
+    // when appropriate.
+    matrixSubstitutionAssignments_.push_back({w, xi.get(), range, M});
   }
+}
 
-  void Assignment::addVectorSubstitutionAssignments(const function::BasicLinearFunction& sub,
-    VectorFunction v, Variable& x, bool flip)
+void Assignment::addVectorSubstitutionAssignments(const function::BasicLinearFunction & sub,
+                                                  VectorFunction v,
+                                                  Variable & x,
+                                                  bool flip)
+{
+  bool useSource = !sub.b().properties().isConstant() || !sub.b().properties().isZero();
+  if(useSource)
   {
-    bool useSource = !sub.b().properties().isConstant() || !sub.b().properties().isZero();
-    if (useSource)
+    // The constraint has the form A x op b and we replace x by C y + d. We thus
+    // want to add -Ad to b.
+    // So far, the sign flip has been deduced only from the ConstraintType of the source
+    // and the target. We still need to take into account the convention of the target.
+    if(target_.constraintRhs() == RHS::AS_GIVEN)
+      flip = !flip;
+
+    const VectorRef & to = (target_.*v)();
+    const VectorConstRef & from = sub.b();
+    const auto & A = source_->jacobian(x);
+
+    CompiledAssignmentWrapper<Eigen::VectorXd> w;
+    if(A.properties().isIdentity())
     {
-      // The constraint has the form A x op b and we replace x by C y + d. We thus
-      // want to add -Ad to b.
-      // So far, the sign flip has been deduced only from the ConstraintType of the source
-      // and the target. We still need to take into account the convention of the target.
-      if (target_.constraintRhs() == RHS::AS_GIVEN)
-        flip = !flip;
-
-      const VectorRef& to = (target_.*v)();
-      const VectorConstRef& from = sub.b();
-      const auto& A = source_->jacobian(x);
-
-      CompiledAssignmentWrapper<Eigen::VectorXd> w;
-      if (A.properties().isIdentity())
-      {
-        if (flip)
-          w = createAssignment<Eigen::VectorXd, SUB>(from, to);
-        else
-          w = createAssignment<Eigen::VectorXd, ADD>(from, to);
-      }
-      else if (A.properties().isMinusIdentity())
-      {
-        if (flip)
-          w = createAssignment<Eigen::VectorXd, ADD>(from, to);
-        else
-          w = createAssignment<Eigen::VectorXd, SUB>(from, to);
-      }
+      if(flip)
+        w = createAssignment<Eigen::VectorXd, SUB>(from, to);
       else
-      {
-        if (flip)
-          w = createMultiplicationAssignment<Eigen::VectorXd, SUB>(from, to, A);
-        else
-          w = createMultiplicationAssignment<Eigen::VectorXd, ADD>(from, to, A);
-      }
-      vectorSubstitutionAssignments_.push_back({ w, v });
+        w = createAssignment<Eigen::VectorXd, ADD>(from, to);
     }
-  }
-
-  void Assignment::addZeroAssignment(Variable& x, MatrixFunction M, const Range& range)
-  {
-    const MatrixRef& to = (target_.*M)(range.start, range.dim);
-    auto w = CompiledAssignmentWrapper<Eigen::MatrixXd>::make<COPY, NONE, IDENTITY, ZERO>(to);
-
-    matrixAssignments_.push_back({ w, &x, range, M });
-  }
-
-  void Assignment::addAssignments(const VariableVector& variables, MatrixFunction M,
-    RHSFunction f, VectorFunction v, bool flip)
-  {
-    addAssignments(variables, M, f, v, nullptr, nullptr, flip);
-  }
-
-  void Assignment::addAssignments(const VariableVector& variables, MatrixFunction M,
-    RHSFunction f1, VectorFunction v1,
-    RHSFunction f2, VectorFunction v2)
-  {
-    addAssignments(variables, M, f1, v1, f2, v2, false);
-  }
-
-  void Assignment::addAssignments(const VariableVector& variables, MatrixFunction M, RHSFunction f1, VectorFunction v1, RHSFunction f2, VectorFunction v2, bool flip)
-  {
-    const auto& xs = substitutedVariables_; //susbstituted variables
-    const auto& xc = source_->variables();  //variables of the source constraint
-
-    addVectorAssignment(f1, v1, flip);
-    if (f2)
+    else if(A.properties().isMinusIdentity())
     {
-      assert(v2);
-      addVectorAssignment(f2, v2, flip);
-    }
-
-    // For all variables that are substituted into but are not part of the source variables,
-    // we set the corresponding matrix block to zero.
-    VariableVector substitutedInto;
-    for (const auto& x : xc)
-    {
-      int i = xs.indexOf(*x);
-      if (i >= 0)  // x needs to be subsituted
-      {
-        substitutedInto.add(variableSubstitutions_[static_cast<int>(i)]->variables());
-      }
-    }
-    for (const auto& x : substitutedInto)
-    {
-      if (!xc.contains(*x))
-      {
-        Range cols = x->getMappingIn(variables);
-        addZeroAssignment(*x, M, cols);
-      }
-    }
-
-    // Each variable of xc needs to be either in variables or in xs.
-    // In the former case, we create a normal copy assignment, in the latter we
-    // need to carry out a substitution
-    for (const auto& x : xc)
-    {
-      int i = xs.indexOf(*x);
-      if (i >= 0)  // x needs to be subsituted
-      {
-        const auto& sub = *variableSubstitutions_[static_cast<int>(i)];
-        addMatrixSubstitutionAssignments(variables, *x, M, sub, flip);
-        addVectorSubstitutionAssignments(sub, v1, *x, flip);
-        if (f2)
-          addVectorSubstitutionAssignments(sub, v2, *x, flip);
-      }
-      else //usual case
-      {
-        Range cols = x->getMappingIn(variables);
-        addMatrixAssignment(*x, M, cols, flip);
-      }
-    }
-  }
-
-  void Assignment::addBound(const VariablePtr& variable, RHSFunction f, bool first)
-  {
-    const auto& J = source_->jacobian(*variable);
-    bool gt = target_.constraintType() == Type::GREATER_THAN;
-    VectorFunction v;
-
-    if (gt)
-      v = &AssignmentTarget::l;
-    else
-      v = &AssignmentTarget::u;
-
-    if (substitutedVariables_.contains(*variable))
-    {
-      throw std::runtime_error("Subsitution is not yet implemented for bounds");
+      if(flip)
+        w = createAssignment<Eigen::VectorXd, ADD>(from, to);
+      else
+        w = createAssignment<Eigen::VectorXd, SUB>(from, to);
     }
     else
     {
-      if (J.properties().isIdentity())
-      {
-        assert(target_.constraintType() == source_->type());
-        if (first)
-          addVectorAssignment(f, v, false);
-        else
-          gt ? addVectorAssignment<MAX>(f, v, false) : addVectorAssignment<MIN>(f, v, false);
-      }
-      else if (J.properties().isMinusIdentity())
-      {
-        assert(target_.constraintType() != source_->type());
-        if (J.properties().isIdentity())
-        {
-          if (first)
-            addVectorAssignment(f, v, true);
-          else
-            gt ? addVectorAssignment<MAX>(f, v, true) : addVectorAssignment<MIN>(f, v, true);
-        }
-      }
+      if(flip)
+        w = createMultiplicationAssignment<Eigen::VectorXd, SUB>(from, to, A);
       else
-      {
-        assert(J.properties().isDiagonal());
-        if (first)
-          addVectorAssignment(f, v, J, false);
-        else
-          gt ? addVectorAssignment<MAX>(f, v, J, false) : addVectorAssignment<MIN>(f, v, J, false);
-      }
+        w = createMultiplicationAssignment<Eigen::VectorXd, ADD>(from, to, A);
+    }
+    vectorSubstitutionAssignments_.push_back({w, v});
+  }
+}
+
+void Assignment::addZeroAssignment(Variable & x, MatrixFunction M, const Range & range)
+{
+  const MatrixRef & to = (target_.*M)(range.start, range.dim);
+  auto w = CompiledAssignmentWrapper<Eigen::MatrixXd>::make<COPY, NONE, IDENTITY, ZERO>(to);
+
+  matrixAssignments_.push_back({w, &x, range, M});
+}
+
+void Assignment::addAssignments(const VariableVector & variables,
+                                MatrixFunction M,
+                                RHSFunction f,
+                                VectorFunction v,
+                                bool flip)
+{
+  addAssignments(variables, M, f, v, nullptr, nullptr, flip);
+}
+
+void Assignment::addAssignments(const VariableVector & variables,
+                                MatrixFunction M,
+                                RHSFunction f1,
+                                VectorFunction v1,
+                                RHSFunction f2,
+                                VectorFunction v2)
+{
+  addAssignments(variables, M, f1, v1, f2, v2, false);
+}
+
+void Assignment::addAssignments(const VariableVector & variables,
+                                MatrixFunction M,
+                                RHSFunction f1,
+                                VectorFunction v1,
+                                RHSFunction f2,
+                                VectorFunction v2,
+                                bool flip)
+{
+  const auto & xs = substitutedVariables_; // susbstituted variables
+  const auto & xc = source_->variables(); // variables of the source constraint
+
+  addVectorAssignment(f1, v1, flip);
+  if(f2)
+  {
+    assert(v2);
+    addVectorAssignment(f2, v2, flip);
+  }
+
+  // For all variables that are substituted into but are not part of the source variables,
+  // we set the corresponding matrix block to zero.
+  VariableVector substitutedInto;
+  for(const auto & x : xc)
+  {
+    int i = xs.indexOf(*x);
+    if(i >= 0) // x needs to be subsituted
+    {
+      substitutedInto.add(variableSubstitutions_[static_cast<int>(i)]->variables());
+    }
+  }
+  for(const auto & x : substitutedInto)
+  {
+    if(!xc.contains(*x))
+    {
+      Range cols = x->getMappingIn(variables);
+      addZeroAssignment(*x, M, cols);
+    }
+  }
+
+  // Each variable of xc needs to be either in variables or in xs.
+  // In the former case, we create a normal copy assignment, in the latter we
+  // need to carry out a substitution
+  for(const auto & x : xc)
+  {
+    int i = xs.indexOf(*x);
+    if(i >= 0) // x needs to be subsituted
+    {
+      const auto & sub = *variableSubstitutions_[static_cast<int>(i)];
+      addMatrixSubstitutionAssignments(variables, *x, M, sub, flip);
+      addVectorSubstitutionAssignments(sub, v1, *x, flip);
+      if(f2)
+        addVectorSubstitutionAssignments(sub, v2, *x, flip);
+    }
+    else // usual case
+    {
+      Range cols = x->getMappingIn(variables);
+      addMatrixAssignment(*x, M, cols, flip);
     }
   }
 }
+
+void Assignment::addBound(const VariablePtr & variable, RHSFunction f, bool first)
+{
+  const auto & J = source_->jacobian(*variable);
+  bool gt = target_.constraintType() == Type::GREATER_THAN;
+  VectorFunction v;
+
+  if(gt)
+    v = &AssignmentTarget::l;
+  else
+    v = &AssignmentTarget::u;
+
+  if(substitutedVariables_.contains(*variable))
+  {
+    throw std::runtime_error("Subsitution is not yet implemented for bounds");
+  }
+  else
+  {
+    if(J.properties().isIdentity())
+    {
+      assert(target_.constraintType() == source_->type());
+      if(first)
+        addVectorAssignment(f, v, false);
+      else
+        gt ? addVectorAssignment<MAX>(f, v, false) : addVectorAssignment<MIN>(f, v, false);
+    }
+    else if(J.properties().isMinusIdentity())
+    {
+      assert(target_.constraintType() != source_->type());
+      if(J.properties().isIdentity())
+      {
+        if(first)
+          addVectorAssignment(f, v, true);
+        else
+          gt ? addVectorAssignment<MAX>(f, v, true) : addVectorAssignment<MIN>(f, v, true);
+      }
+    }
+    else
+    {
+      assert(J.properties().isDiagonal());
+      if(first)
+        addVectorAssignment(f, v, J, false);
+      else
+        gt ? addVectorAssignment<MAX>(f, v, J, false) : addVectorAssignment<MIN>(f, v, J, false);
+    }
+  }
+}
+} // namespace tvm::scheme::internal

--- a/src/scheme/AssignmentTarget.cpp
+++ b/src/scheme/AssignmentTarget.cpp
@@ -15,8 +15,7 @@ namespace internal
 
 AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, constraint::Type ct)
 : AssignmentTarget(range, A, Eigen::Map<Eigen::VectorXd>(nullptr, 0), ct, constraint::RHS::ZERO)
-{
-}
+{}
 
 AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, VectorRef b, constraint::Type ct, constraint::RHS cr)
 : targetType_(TargetType::Linear), cstrType_(ct), constraintRhs_(cr), range_(range), A_(A), b_(b)
@@ -37,8 +36,7 @@ AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, VectorRef l, Vec
 AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef l, VectorRef u)
 : targetType_(TargetType::Linear), cstrType_(constraint::Type::DOUBLE_SIDED), constraintRhs_(constraint::RHS::AS_GIVEN),
   range_(range), l_(l), u_(u)
-{
-}
+{}
 
 AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef lu, constraint::Type ct)
 : targetType_(TargetType::Linear), cstrType_(ct), range_(range), b_(lu)
@@ -52,8 +50,7 @@ AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef lu, constraint::Typ
 
 AssignmentTarget::AssignmentTarget(MatrixRef Q, VectorRef q, constraint::RHS cr)
 : targetType_(TargetType::Quadratic), constraintRhs_(cr), Q_(Q), q_(q)
-{
-}
+{}
 
 TargetType AssignmentTarget::targetType() const { return targetType_; }
 

--- a/src/scheme/AssignmentTarget.cpp
+++ b/src/scheme/AssignmentTarget.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/scheme/internal/AssignmentTarget.h>
 
@@ -40,207 +40,187 @@ namespace scheme
 namespace internal
 {
 
-  AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, constraint::Type ct)
-    : AssignmentTarget(range, A, Eigen::Map<Eigen::VectorXd>(nullptr, 0), ct, constraint::RHS::ZERO)
+AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, constraint::Type ct)
+: AssignmentTarget(range, A, Eigen::Map<Eigen::VectorXd>(nullptr, 0), ct, constraint::RHS::ZERO)
+{
+}
+
+AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, VectorRef b, constraint::Type ct, constraint::RHS cr)
+: targetType_(TargetType::Linear), cstrType_(ct), constraintRhs_(cr), range_(range), A_(A), b_(b)
+{
+  if(ct == constraint::Type::DOUBLE_SIDED)
+    throw std::runtime_error("This constructor is only for single-sided constraints.");
+}
+
+AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, VectorRef l, VectorRef u, constraint::RHS cr)
+: targetType_(TargetType::Linear), cstrType_(constraint::Type::DOUBLE_SIDED), constraintRhs_(cr), range_(range), A_(A),
+  l_(l), u_(u)
+{
+  if(cr == constraint::RHS::ZERO)
+    throw std::runtime_error("constraint::RHS::ZERO is not a valid input for this constructor. Please use the "
+                             "constructor for Ax=0, Ax<=0 and Ax>=0 instead.");
+}
+
+AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef l, VectorRef u)
+: targetType_(TargetType::Linear), cstrType_(constraint::Type::DOUBLE_SIDED), constraintRhs_(constraint::RHS::AS_GIVEN),
+  range_(range), l_(l), u_(u)
+{
+}
+
+AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef lu, constraint::Type ct)
+: targetType_(TargetType::Linear), cstrType_(ct), range_(range), b_(lu)
+{
+  if(!(ct == constraint::Type::GREATER_THAN || ct == constraint::Type::LOWER_THAN))
   {
+    throw std::runtime_error(
+        "This constructor is for simple-bound constraint, only GREATER_THAN or LOWER_THAN are valid options.");
   }
+}
 
-  AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, VectorRef b, constraint::Type ct, constraint::RHS cr)
-    : targetType_(TargetType::Linear), cstrType_(ct), constraintRhs_(cr), range_(range), A_(A), b_(b)
+AssignmentTarget::AssignmentTarget(MatrixRef Q, VectorRef q, constraint::RHS cr)
+: targetType_(TargetType::Quadratic), constraintRhs_(cr), Q_(Q), q_(q)
+{
+}
+
+TargetType AssignmentTarget::targetType() const { return targetType_; }
+
+constraint::Type AssignmentTarget::constraintType() const { return cstrType_; }
+
+constraint::RHS AssignmentTarget::constraintRhs() const { return constraintRhs_; }
+
+int AssignmentTarget::size() const { return range_->dim; }
+
+Range & AssignmentTarget::range() { return *range_; }
+
+const Range & AssignmentTarget::range() const { return *range_; }
+
+MatrixRef AssignmentTarget::A(int colStart, int colDim) const
+{
+  // return MatrixRef(const_cast<AssignmentTarget*>(this)->A_.block(range_->start, colStart, range_->dim, colDim));
+  return MatrixRef(static_cast<MatrixRef>(A_).block(range_->start, colStart, range_->dim, colDim));
+}
+
+MatrixRef AssignmentTarget::Q() const { return Q_; }
+
+VectorRef AssignmentTarget::l() const
+{
+  return VectorRef(static_cast<VectorRef>(l_).segment(range_->start, range_->dim));
+}
+
+VectorRef AssignmentTarget::u() const
+{
+  return VectorRef(static_cast<VectorRef>(u_).segment(range_->start, range_->dim));
+}
+
+VectorRef AssignmentTarget::b() const
+{
+  return VectorRef(static_cast<VectorRef>(b_).segment(range_->start, range_->dim));
+}
+
+VectorRef AssignmentTarget::q() const { return q_; }
+
+MatrixRef AssignmentTarget::AFirstHalf(int colStart, int colDim) const
+{
+  const int half = range_->dim / 2;
+  return MatrixRef(static_cast<MatrixRef>(A_).block(range_->start, colStart, half, colDim));
+}
+
+MatrixRef AssignmentTarget::ASecondHalf(int colStart, int colDim) const
+{
+  const int half = range_->dim / 2;
+  return MatrixRef(static_cast<MatrixRef>(A_).block(range_->start + half, colStart, half, colDim));
+}
+
+VectorRef AssignmentTarget::bFirstHalf() const
+{
+  const int half = range_->dim / 2;
+  return VectorRef(static_cast<VectorRef>(b_).segment(range_->start, half));
+}
+
+VectorRef AssignmentTarget::bSecondHalf() const
+{
+  const int half = range_->dim / 2;
+  return VectorRef(static_cast<VectorRef>(b_).segment(range_->start + half, half));
+}
+
+AssignmentTarget & AssignmentTarget::setA(MatrixRef A)
+{
+  assert(targetType_ == TargetType::Linear);
+  new(&A_) MatrixRef(A);
+  return *this;
+}
+
+AssignmentTarget & AssignmentTarget::setQ(MatrixRef Q)
+{
+  assert(targetType_ == TargetType::Quadratic);
+  new(&Q_) MatrixRef(Q);
+  return *this;
+}
+
+AssignmentTarget & AssignmentTarget::setl(VectorRef l)
+{
+  assert(targetType_ == TargetType::Linear);
+  assert(cstrType_ == constraint::Type::DOUBLE_SIDED);
+  assert(constraintRhs_ != constraint::RHS::ZERO);
+  new(&l_) VectorRef(l);
+  return *this;
+}
+
+AssignmentTarget & AssignmentTarget::setu(VectorRef u)
+{
+  assert(targetType_ == TargetType::Linear);
+  assert(cstrType_ == constraint::Type::DOUBLE_SIDED);
+  assert(constraintRhs_ != constraint::RHS::ZERO);
+  new(&u_) VectorRef(u);
+  return *this;
+}
+
+AssignmentTarget & AssignmentTarget::setb(VectorRef b)
+{
+  assert(targetType_ == TargetType::Linear);
+  assert(cstrType_ != constraint::Type::DOUBLE_SIDED);
+  assert(constraintRhs_ != constraint::RHS::ZERO);
+  new(&b_) VectorRef(b);
+  return *this;
+}
+
+AssignmentTarget & AssignmentTarget::setq(VectorRef q)
+{
+  assert(targetType_ == TargetType::Quadratic);
+  assert(constraintRhs_ != constraint::RHS::ZERO);
+  new(&q_) VectorRef(q);
+  return *this;
+}
+
+void AssignmentTarget::changeData(MatrixRef AQ, VectorRef bq)
+{
+  if(targetType_ == TargetType::Linear)
   {
-    if (ct == constraint::Type::DOUBLE_SIDED)
-      throw std::runtime_error("This constructor is only for single-sided constraints.");
+    setA(AQ);
+    setb(bq);
   }
-
-  AssignmentTarget::AssignmentTarget(RangePtr range, MatrixRef A, VectorRef l, VectorRef u, constraint::RHS cr)
-    : targetType_(TargetType::Linear), cstrType_(constraint::Type::DOUBLE_SIDED), constraintRhs_(cr), range_(range), A_(A), l_(l), u_(u)
+  else
   {
-    if (cr == constraint::RHS::ZERO)
-      throw std::runtime_error("constraint::RHS::ZERO is not a valid input for this constructor. Please use the constructor for Ax=0, Ax<=0 and Ax>=0 instead.");
+    setQ(AQ);
+    setq(bq);
   }
+}
 
-  AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef l, VectorRef u)
-    : targetType_(TargetType::Linear), cstrType_(constraint::Type::DOUBLE_SIDED), constraintRhs_(constraint::RHS::AS_GIVEN), range_(range), l_(l), u_(u)
-  {
-  }
+void AssignmentTarget::changeData(MatrixRef A, VectorRef l, VectorRef u)
+{
+  setA(A);
+  setl(l);
+  setu(u);
+}
 
-  AssignmentTarget::AssignmentTarget(RangePtr range, VectorRef lu, constraint::Type ct)
-    : targetType_(TargetType::Linear), cstrType_(ct), range_(range), b_(lu)
-  {
-    if (!(ct == constraint::Type::GREATER_THAN || ct == constraint::Type::LOWER_THAN))
-    {
-      throw std::runtime_error("This constructor is for simple-bound constraint, only GREATER_THAN or LOWER_THAN are valid options.");
-    }
-  }
+void AssignmentTarget::changeData(VectorRef l, VectorRef u)
+{
+  setl(l);
+  setu(u);
+}
 
-  AssignmentTarget::AssignmentTarget(MatrixRef Q, VectorRef q, constraint::RHS cr)
-    : targetType_(TargetType::Quadratic), constraintRhs_(cr), Q_(Q), q_(q)
-  {
-  }
+} // namespace internal
 
-  TargetType AssignmentTarget::targetType() const
-  {
-    return targetType_;
-  }
+} // namespace scheme
 
-  constraint::Type AssignmentTarget::constraintType() const
-  {
-    return cstrType_;
-  }
-
-  constraint::RHS AssignmentTarget::constraintRhs() const
-  {
-    return constraintRhs_;
-  }
-
-  int AssignmentTarget::size() const
-  {
-    return range_->dim;
-  }
-
-  Range& AssignmentTarget::range()
-  {
-    return *range_;
-  }
-
-  const Range& AssignmentTarget::range() const
-  {
-    return *range_;
-  }
-
-  MatrixRef AssignmentTarget::A(int colStart, int colDim) const
-  {
-    //return MatrixRef(const_cast<AssignmentTarget*>(this)->A_.block(range_->start, colStart, range_->dim, colDim));
-    return MatrixRef(static_cast<MatrixRef>(A_).block(range_->start, colStart, range_->dim, colDim));
-  }
-
-  MatrixRef AssignmentTarget::Q() const
-  {
-    return Q_;
-  }
-
-  VectorRef AssignmentTarget::l() const
-  {
-    return VectorRef(static_cast<VectorRef>(l_).segment(range_->start, range_->dim));
-  }
-
-  VectorRef AssignmentTarget::u() const
-  {
-    return VectorRef(static_cast<VectorRef>(u_).segment(range_->start, range_->dim));
-  }
-
-  VectorRef AssignmentTarget::b() const
-  {
-    return VectorRef(static_cast<VectorRef>(b_).segment(range_->start, range_->dim));
-  }
-
-  VectorRef AssignmentTarget::q() const
-  {
-    return q_;
-  }
-
-  MatrixRef AssignmentTarget::AFirstHalf(int colStart, int colDim) const
-  {
-    const int half = range_->dim / 2;
-    return MatrixRef(static_cast<MatrixRef>(A_).block(range_->start, colStart, half, colDim));
-  }
-
-  MatrixRef AssignmentTarget::ASecondHalf(int colStart, int colDim) const
-  {
-    const int half = range_->dim / 2;
-    return MatrixRef(static_cast<MatrixRef>(A_).block(range_->start+half, colStart, half, colDim));
-  }
-
-  VectorRef AssignmentTarget::bFirstHalf() const
-  {
-    const int half = range_->dim / 2;
-    return VectorRef(static_cast<VectorRef>(b_).segment(range_->start, half));
-  }
-
-  VectorRef AssignmentTarget::bSecondHalf() const
-  {
-    const int half = range_->dim / 2;
-    return VectorRef(static_cast<VectorRef>(b_).segment(range_->start + half, half));
-  }
-
-  AssignmentTarget& AssignmentTarget::setA(MatrixRef A)
-  {
-    assert(targetType_ == TargetType::Linear);
-    new(&A_) MatrixRef(A);
-    return *this;
-  }
-
-  AssignmentTarget& AssignmentTarget::setQ(MatrixRef Q)
-  {
-    assert(targetType_ == TargetType::Quadratic);
-    new(&Q_) MatrixRef(Q);
-    return *this;
-  }
-
-  AssignmentTarget& AssignmentTarget::setl(VectorRef l)
-  {
-    assert(targetType_ == TargetType::Linear);
-    assert(cstrType_ == constraint::Type::DOUBLE_SIDED);
-    assert(constraintRhs_ != constraint::RHS::ZERO);
-    new (&l_) VectorRef(l);
-    return *this;
-  }
-
-  AssignmentTarget& AssignmentTarget::setu(VectorRef u)
-  {
-    assert(targetType_ == TargetType::Linear);
-    assert(cstrType_ == constraint::Type::DOUBLE_SIDED);
-    assert(constraintRhs_ != constraint::RHS::ZERO);
-    new (&u_) VectorRef(u);
-    return *this;
-  }
-
-  AssignmentTarget& AssignmentTarget::setb(VectorRef b)
-  {
-    assert(targetType_ == TargetType::Linear);
-    assert(cstrType_ != constraint::Type::DOUBLE_SIDED);
-    assert(constraintRhs_ != constraint::RHS::ZERO);
-    new (&b_) VectorRef(b);
-    return *this;
-  }
-
-  AssignmentTarget& AssignmentTarget::setq(VectorRef q)
-  {
-    assert(targetType_ == TargetType::Quadratic);
-    assert(constraintRhs_ != constraint::RHS::ZERO);
-    new (&q_) VectorRef(q);
-    return *this;
-  }
-
-  void AssignmentTarget::changeData(MatrixRef AQ, VectorRef bq)
-  {
-    if (targetType_ == TargetType::Linear)
-    {
-      setA(AQ);
-      setb(bq);
-    }
-    else
-    {
-      setQ(AQ);
-      setq(bq);
-    }
-  }
-
-  void AssignmentTarget::changeData(MatrixRef A, VectorRef l, VectorRef u)
-  {
-    setA(A);
-    setl(l);
-    setu(u);
-  }
-
-  void AssignmentTarget::changeData(VectorRef l, VectorRef u)
-  {
-    setl(l);
-    setu(u);
-  }
-
-}  // namespace internal
-
-}  // namespace scheme
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/scheme/AssignmentTarget.cpp
+++ b/src/scheme/AssignmentTarget.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/scheme/internal/AssignmentTarget.h>
 

--- a/src/scheme/MatrixAssignment.cpp
+++ b/src/scheme/MatrixAssignment.cpp
@@ -1,32 +1,35 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
-#include <tvm/scheme/internal/MatrixAssignment.h>
 #include <tvm/VariableVector.h>
+#include <tvm/scheme/internal/MatrixAssignment.h>
 
 namespace tvm::scheme::internal
 {
-  void MatrixAssignment::updateTarget(const AssignmentTarget& target)
-  {
-    assignment.to((target.*getTargetMatrix)(colRange.start, colRange.dim));
-  }
+void MatrixAssignment::updateTarget(const AssignmentTarget & target)
+{
+  assignment.to((target.*getTargetMatrix)(colRange.start, colRange.dim));
+}
 
-  void MatrixAssignment::updateMapping(const VariableVector& newVar, const AssignmentTarget& target, bool updateMatrixTarget)
+void MatrixAssignment::updateMapping(const VariableVector & newVar,
+                                     const AssignmentTarget & target,
+                                     bool updateMatrixTarget)
+{
+  if(newVar.contains(*x))
   {
-    if (newVar.contains(*x))
+    Range newRange = x->getMappingIn(newVar);
+    if(newRange != colRange)
     {
-      Range newRange = x->getMappingIn(newVar);
-      if (newRange != colRange)
-      {
-        colRange = newRange;
-      }
-      if (updateMatrixTarget)
-      {
-        updateTarget(target);
-      }
+      colRange = newRange;
     }
-    else
+    if(updateMatrixTarget)
     {
-      throw std::runtime_error("[Assignment::MatrixAssignment::updateMapping]: new variables do not include this assignment variable.");
+      updateTarget(target);
     }
+  }
+  else
+  {
+    throw std::runtime_error(
+        "[Assignment::MatrixAssignment::updateMapping]: new variables do not include this assignment variable.");
   }
 }
+} // namespace tvm::scheme::internal

--- a/src/scheme/ResolutionScheme.cpp
+++ b/src/scheme/ResolutionScheme.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/scheme/internal/ResolutionSchemeBase.h>
 
@@ -38,26 +38,22 @@ namespace scheme
 namespace internal
 {
 
-  ResolutionSchemeBase::ResolutionSchemeBase(SchemeAbilities abilities, double big)
-    : abilities_(abilities)
-    , big_number_(big)
-  {
-    assert(big > 0);
-  }
+ResolutionSchemeBase::ResolutionSchemeBase(SchemeAbilities abilities, double big)
+: abilities_(abilities), big_number_(big)
+{
+  assert(big > 0);
+}
 
-  double ResolutionSchemeBase::big_number() const
-  {
-    return big_number_;
-  }
+double ResolutionSchemeBase::big_number() const { return big_number_; }
 
-  void ResolutionSchemeBase::big_number(double big)
-  {
-    assert(big > 0);
-    big_number_ = big;
-  }
+void ResolutionSchemeBase::big_number(double big)
+{
+  assert(big > 0);
+  big_number_ = big;
+}
 
-}  // namespace abstract
+} // namespace internal
 
-}  // namespace scheme
+} // namespace scheme
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/scheme/ResolutionScheme.cpp
+++ b/src/scheme/ResolutionScheme.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/scheme/internal/ResolutionSchemeBase.h>
 

--- a/src/scheme/SchemeAbilities.cpp
+++ b/src/scheme/SchemeAbilities.cpp
@@ -18,8 +18,7 @@ namespace internal
 {
 LevelAbilities::LevelAbilities(bool inequality, const std::vector<requirements::ViolationEvaluationType> & types)
 : inequalities_(inequality), evaluationTypes_(types)
-{
-}
+{}
 
 SchemeAbilities::SchemeAbilities(int numberOfLevels,
                                  const std::map<int, LevelAbilities> & abilities,

--- a/src/scheme/SchemeAbilities.cpp
+++ b/src/scheme/SchemeAbilities.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/scheme/internal/SchemeAbilities.h>
 

--- a/src/scheme/SchemeAbilities.cpp
+++ b/src/scheme/SchemeAbilities.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/scheme/internal/SchemeAbilities.h>
 
@@ -43,49 +43,48 @@ namespace scheme
 
 namespace internal
 {
-    LevelAbilities::LevelAbilities(bool inequality, const std::vector<requirements::ViolationEvaluationType>& types)
-      : inequalities_(inequality)
-      , evaluationTypes_(types)
+LevelAbilities::LevelAbilities(bool inequality, const std::vector<requirements::ViolationEvaluationType> & types)
+: inequalities_(inequality), evaluationTypes_(types)
+{
+}
+
+SchemeAbilities::SchemeAbilities(int numberOfLevels,
+                                 const std::map<int, LevelAbilities> & abilities,
+                                 bool scalarization)
+: numberOfLevels_(numberOfLevels), scalarization_(scalarization), abilities_(abilities)
+{
+  assert(GeneralLevel < 0 && "Implementation of this class assumes that GeneralLevel is non positive.");
+  assert(GeneralLevel == NoLimit && "Implementation of this class assumes that GeneralLevel is equal to NoLimit.");
+
+  if(numberOfLevels < 0 && numberOfLevels != NoLimit)
+    throw std::runtime_error("Incorrect number of levels. This number must be nonnegative or equal to NoLimit");
+
+  if(numberOfLevels >= 0)
+  {
+    // if there is not general entry in abilities, then we check that each level has its own entry.
+    if(abilities.count(GeneralLevel) == 0)
     {
-    }
-
-    SchemeAbilities::SchemeAbilities(int numberOfLevels, const std::map<int, LevelAbilities>& abilities, bool scalarization)
-      : numberOfLevels_(numberOfLevels)
-      , scalarization_(scalarization)
-      , abilities_(abilities)
-    {
-      assert(GeneralLevel < 0 && "Implementation of this class assumes that GeneralLevel is non positive.");
-      assert(GeneralLevel == NoLimit && "Implementation of this class assumes that GeneralLevel is equal to NoLimit.");
-
-      if (numberOfLevels < 0 && numberOfLevels != NoLimit)
-        throw std::runtime_error("Incorrect number of levels. This number must be nonnegative or equal to NoLimit");
-
-      if (numberOfLevels >= 0)
+      for(int i = 0; i < numberOfLevels; ++i)
       {
-        // if there is not general entry in abilities, then we check that each level has its own entry.
-        if (abilities.count(GeneralLevel) == 0)
+        if(abilities.count(i) == 0)
         {
-          for (int i = 0; i < numberOfLevels; ++i)
-          {
-            if (abilities.count(i) == 0)
-            {
-              std::stringstream s;
-              s << "No abilities given for level " << i << "." << std::endl;
-              throw std::runtime_error(s.str());
-            }
-          }
+          std::stringstream s;
+          s << "No abilities given for level " << i << "." << std::endl;
+          throw std::runtime_error(s.str());
         }
       }
-      else
-      {
-        //we check that there is a general entry in abilities
-        if (abilities.count(GeneralLevel) == 0)
-          throw std::runtime_error("No general level abilities given.");
-      }
     }
+  }
+  else
+  {
+    // we check that there is a general entry in abilities
+    if(abilities.count(GeneralLevel) == 0)
+      throw std::runtime_error("No general level abilities given.");
+  }
+}
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace scheme
+} // namespace scheme
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -3,292 +3,303 @@
 #include <tvm/scheme/WeightedLeastSquares.h>
 
 #include <tvm/LinearizedControlProblem.h>
-#include <tvm/constraint/internal/LinearizedTaskConstraint.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
+#include <tvm/constraint/internal/LinearizedTaskConstraint.h>
 #include <tvm/solver/internal/SolverEvents.h>
 #include <tvm/utils/internal/map.h>
 
 #include <iostream>
-
 
 namespace tvm
 {
 
 namespace scheme
 {
-  using namespace internal;
-  using VET = requirements::ViolationEvaluationType;
+using namespace internal;
+using VET = requirements::ViolationEvaluationType;
 
-  const internal::SchemeAbilities WeightedLeastSquares::abilities_ = { 2, {{0, {true, {VET::L2}}}, {1,{false, {VET::L2}}}}, true };
+const internal::SchemeAbilities WeightedLeastSquares::abilities_ = {2,
+                                                                    {{0, {true, {VET::L2}}}, {1, {false, {VET::L2}}}},
+                                                                    true};
 
-  bool WeightedLeastSquares::solve_(LinearizedControlProblem& problem, internal::ProblemComputationData* data) const
+bool WeightedLeastSquares::solve_(LinearizedControlProblem & problem, internal::ProblemComputationData * data) const
+{
+  if(problem.size() > problem.substitutions().substitutions().size())
   {
-    if (problem.size()>problem.substitutions().substitutions().size())
-    {
-      Memory* memory = static_cast<Memory*>(data);
-      return memory->solver->solve();
-    }
-    else
-    {
-      problem.variables().setZero();
-      return true;
-    }
+    Memory * memory = static_cast<Memory *>(data);
+    return memory->solver->solve();
   }
-
-  void WeightedLeastSquares::updateComputationData_(LinearizedControlProblem& problem, internal::ProblemComputationData* data) const
+  else
   {
-    solver::internal::SolverEvents se;
+    problem.variables().setZero();
+    return true;
+  }
+}
 
-    if (data->hasEvents())
+void WeightedLeastSquares::updateComputationData_(LinearizedControlProblem & problem,
+                                                  internal::ProblemComputationData * data) const
+{
+  solver::internal::SolverEvents se;
+
+  if(data->hasEvents())
+  {
+    Memory * memory = static_cast<Memory *>(data);
+
+    while(memory->hasEvents())
     {
-      Memory* memory = static_cast<Memory*>(data);
-
-      while (memory->hasEvents())
+      auto e = memory->popEvent();
+      switch(e.type())
       {
-        auto e = memory->popEvent();
-        switch (e.type())
-        {
         case ProblemDefinitionEvent::Type::WeightChange:
         {
-          const auto& c = problem.constraintWithRequirements(e.emitter());
-          if (c.requirements->priorityLevel().value() == 0)
-            throw std::runtime_error("[WeightedLeastSquares::updateComputationData_] "
-              "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
+          const auto & c = problem.constraintWithRequirements(e.emitter());
+          if(c.requirements->priorityLevel().value() == 0)
+            throw std::runtime_error(
+                "[WeightedLeastSquares::updateComputationData_] "
+                "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
           se.addScalarWeigthEvent(c.constraint.get());
         }
         break;
         case ProblemDefinitionEvent::Type::AnisotropicWeightChange:
         {
-          const auto& c = problem.constraintWithRequirements(e.emitter());
-          if (c.requirements->priorityLevel().value() == 0)
-            throw std::runtime_error("[WeightedLeastSquares::updateComputationData_] "
-              "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
+          const auto & c = problem.constraintWithRequirements(e.emitter());
+          if(c.requirements->priorityLevel().value() == 0)
+            throw std::runtime_error(
+                "[WeightedLeastSquares::updateComputationData_] "
+                "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
           se.addVectorWeigthEvent(c.constraint.get());
         }
-          break;
+        break;
         case ProblemDefinitionEvent::Type::TaskAddition:
           addTask(problem, memory, e.emitter(), se);
           break;
         case ProblemDefinitionEvent::Type::TaskRemoval:
           removeTask(problem, memory, e.emitter(), se);
           break;
-        default: throw std::runtime_error("[WeightedLeastSquares::updateComputationData_] Unimplemented event handling.");
-        }
+        default:
+          throw std::runtime_error("[WeightedLeastSquares::updateComputationData_] Unimplemented event handling.");
       }
-
-      memory->solver->process(se);
     }
+
+    memory->solver->process(se);
   }
+}
 
-  std::unique_ptr<WeightedLeastSquares::Memory> WeightedLeastSquares::createComputationData_(const LinearizedControlProblem& problem) const
+std::unique_ptr<WeightedLeastSquares::Memory> WeightedLeastSquares::createComputationData_(
+    const LinearizedControlProblem & problem) const
+{
+  auto memory = std::unique_ptr<Memory>(new Memory(id(), solverFactory_->createSolver()));
+  auto & solver = *memory->solver;
+
+  const auto & constraints = problem.constraints();
+  const auto & subs = problem.substitutions();
+  memory->addConstraints(problem.constraintMap());
+
+  std::vector<LinearConstraintWithRequirements> constr;
+  std::vector<LinearConstraintWithRequirements> bounds;
+
+  // scanning constraints
+  int nEq = 0;
+  int nIneq = 0;
+  int nObj = 0;
+  int maxp = 0;
+  for(const auto & c : constraints)
   {
-    auto memory = std::unique_ptr<Memory>(new Memory(id(), solverFactory_->createSolver()));
-    auto& solver = *memory->solver;
+    // If the constraint is used for the substitutions, we skip it.
+    if(subs.uses(c.constraint))
+      continue;
+    abilities_.check(c.constraint, c.requirements); // FIXME: should be done in a parent class
+    for(const auto & xi : c.constraint->variables())
+      memory->addVariable(subs.substitute(xi));
 
-    const auto& constraints = problem.constraints();
-    const auto& subs = problem.substitutions();
-    memory->addConstraints(problem.constraintMap());
-
-    std::vector<LinearConstraintWithRequirements> constr;
-    std::vector<LinearConstraintWithRequirements> bounds;
-
-    //scanning constraints
-    int nEq = 0;
-    int nIneq = 0;
-    int nObj = 0;
-    int maxp = 0;
-    for (const auto& c : constraints)
+    int p = c.requirements->priorityLevel().value();
+    if(canBeUsedAsBound(c.constraint, subs, constraint::Type::DOUBLE_SIDED) && p == 0)
+      bounds.push_back(c);
+    else
     {
-      // If the constraint is used for the substitutions, we skip it.
-      if (subs.uses(c.constraint))
-        continue;
-      abilities_.check(c.constraint, c.requirements); //FIXME: should be done in a parent class
-      for (const auto& xi: c.constraint->variables())
-        memory->addVariable(subs.substitute(xi));
-
-      int p = c.requirements->priorityLevel().value();
-      if (canBeUsedAsBound(c.constraint, subs, constraint::Type::DOUBLE_SIDED)
-          && p == 0)
-        bounds.push_back(c);
-      else
+      if(p == 0)
       {
-        if (p == 0)
-        {
-          if (c.constraint->isEquality())
-            nEq += solver.constraintSize(*c.constraint);
-          else
-            nIneq += solver.constraintSize(*c.constraint);
-        }
+        if(c.constraint->isEquality())
+          nEq += solver.constraintSize(*c.constraint);
         else
-        {
-          if (c.constraint->type() != constraint::Type::EQUAL)
-            throw std::runtime_error("This scheme do not handle inequality constraints with priority level > 0.");
-          nObj += c.constraint->size();  //note: we cannot have double sided constraints at this level.
-          maxp = std::max(maxp, p);
-        }
-        constr.push_back(c);
-      }
-    }
-    // we need to add the additional constraints due to the substitutions.
-    // They are added at level 0
-    for (const auto& c : subs.additionalConstraints())
-    {
-      nEq += c->size();
-      constr.push_back({ c, std::make_shared<requirements::SolvingRequirementsWithCallbacks>(requirements::PriorityLevel(0)), false });
-    }
-
-    bool autoMinNorm = false;
-    if (nObj == 0 && options_.autoDamping().value())
-    {
-      nObj = memory->variables().totalSize();
-      autoMinNorm = true;
-    }
-
-    // configure assignments. FIXME: can we find a better way ?
-    Assignment::big_ = big_number_;
-
-    //allocating memory for the solver
-    solver.startBuild(memory->variables(), nObj, nEq, nIneq, bounds.size() > 0, &subs);
-    //memory->assignments.reserve(constr.size() + bounds.size()); //TODO something equivalent
-
-    memory->maxp = maxp;
-
-    //assigments for general constraints
-    for (const auto& c : constr)
-    {
-      int p = c.requirements->priorityLevel().value();
-      if (p == 0)
-      {
-        //TODO check requirements
-        solver.addConstraint(c.constraint);
+          nIneq += solver.constraintSize(*c.constraint);
       }
       else
       {
-        solver.addObjective(c.constraint, c.requirements, std::pow(*options_.scalarizationWeight(), maxp - p));
+        if(c.constraint->type() != constraint::Type::EQUAL)
+          throw std::runtime_error("This scheme do not handle inequality constraints with priority level > 0.");
+        nObj += c.constraint->size(); // note: we cannot have double sided constraints at this level.
+        maxp = std::max(maxp, p);
       }
+      constr.push_back(c);
     }
-
-    if (autoMinNorm)
-      solver.setMinimumNorm();
-
-    //assigments for bounds
-    for (const auto& b : bounds)
-    {
-      const auto& xi = b.constraint->variables()[0];
-      int p = b.requirements->priorityLevel().value();
-      if (p == 0)
-      {
-        //TODO check requirements
-        solver.addBound(b.constraint);
-      }
-      else
-      {
-        throw std::runtime_error("This scheme do not handle inequality constraints with priority level > 0.");
-      }
-    }
-
-    solver.finalizeBuild();
-
-    return memory;
+  }
+  // we need to add the additional constraints due to the substitutions.
+  // They are added at level 0
+  for(const auto & c : subs.additionalConstraints())
+  {
+    nEq += c->size();
+    constr.push_back(
+        {c, std::make_shared<requirements::SolvingRequirementsWithCallbacks>(requirements::PriorityLevel(0)), false});
   }
 
-  void WeightedLeastSquares::addTask(LinearizedControlProblem& problem, Memory* memory, TaskWithRequirements* task, solver::internal::SolverEvents& se) const
+  bool autoMinNorm = false;
+  if(nObj == 0 && options_.autoDamping().value())
   {
-    // We add a task that is not in the computation data. We get the constraint from problem.
-    // However this task might have been removed from problem after being added (but before
-    // the computation data have been updated). If this is the case, we skip the addition.
-    auto optc = problem.constraintWithRequirementsNoThrow(task);
-    if (!optc) return;
+    nObj = memory->variables().totalSize();
+    autoMinNorm = true;
+  }
 
-    // If there is really a task to be added, we need to record the mapping in memory
-    auto c = optc->get();
-    memory->addConstraint(task, c);
-    const auto& subs = problem.substitutions();
+  // configure assignments. FIXME: can we find a better way ?
+  Assignment::big_ = big_number_;
 
-    abilities_.check(c.constraint, c.requirements);
-    for (const auto& xi : c.constraint->variables())
+  // allocating memory for the solver
+  solver.startBuild(memory->variables(), nObj, nEq, nIneq, bounds.size() > 0, &subs);
+  // memory->assignments.reserve(constr.size() + bounds.size()); //TODO something equivalent
+
+  memory->maxp = maxp;
+
+  // assigments for general constraints
+  for(const auto & c : constr)
+  {
+    int p = c.requirements->priorityLevel().value();
+    if(p == 0)
     {
-      auto s = subs.substitute(xi);
-      for (const auto& si : s)
-      {
-        if (memory->addVariable(si))
-          se.addVariable(si);
-      }
-    }
-
-    int p = task->requirements.priorityLevel().value();
-    if ((p == 0) && canBeUsedAsBound(c.constraint, subs, constraint::Type::DOUBLE_SIDED))
-    {
-      se.addBound(c.constraint);
+      // TODO check requirements
+      solver.addConstraint(c.constraint);
     }
     else
     {
-      if (p == 0)
-      {
-        se.addConstraint(c.constraint);
-      }
-      else
-      {
-        // We dont adapt maxp, meaning that a constraint with priority level p>max_p will get a weight<1
-        se.addObjective({ c.constraint, c.requirements, std::pow(*options_.scalarizationWeight(), memory->maxp - p )});
-      }
+      solver.addObjective(c.constraint, c.requirements, std::pow(*options_.scalarizationWeight(), maxp - p));
     }
   }
 
-  void WeightedLeastSquares::removeTask(LinearizedControlProblem& problem, Memory* memory, TaskWithRequirements* task, solver::internal::SolverEvents& se) const
+  if(autoMinNorm)
+    solver.setMinimumNorm();
+
+  // assigments for bounds
+  for(const auto & b : bounds)
   {
-    // We need to remove the constraint that was last added for the task.
-    // We get this info from memory. It the task is not present, it's because we
-    // skipped its addition in addTask before, so wee skip the removal as well.
-    auto optc = memory->constraintNoThrow(task);
-    if (!optc) return;
-
-    const auto& c = optc->get();
-    const auto& subs = problem.substitutions();
-
-    if (subs.uses(c.constraint))
-      throw std::runtime_error("[WeightedLeastSquares::removeTask]: You cannot remove a constraint used for a substitution.");
-
-    for (const auto& xi : c.constraint->variables())
+    const auto & xi = b.constraint->variables()[0];
+    int p = b.requirements->priorityLevel().value();
+    if(p == 0)
     {
-      auto s = subs.substitute(xi);
-      for (const auto& si : s)
-      {
-        if (memory->removeVariable(si.get()))
-          se.removeVariable(si);
-      }
-    }
-
-    int p = task->requirements.priorityLevel().value();
-    if ((p == 0) && canBeUsedAsBound(c.constraint, subs, constraint::Type::DOUBLE_SIDED))
-    {
-      se.removeBound(c.constraint);
+      // TODO check requirements
+      solver.addBound(b.constraint);
     }
     else
     {
-      if (p == 0)
-      {
-        se.removeConstraint(c.constraint);
-      }
-      else
-      {
-        se.removeObjective(c.constraint);
-      }
+      throw std::runtime_error("This scheme do not handle inequality constraints with priority level > 0.");
     }
-    memory->removeConstraint(task);
   }
 
-  WeightedLeastSquares::Memory::Memory(int solverId, std::unique_ptr<solver::abstract::LeastSquareSolver> solver)
-    : LinearizedProblemComputationData(solverId)
-    , solver(std::move(solver))
+  solver.finalizeBuild();
+
+  return memory;
+}
+
+void WeightedLeastSquares::addTask(LinearizedControlProblem & problem,
+                                   Memory * memory,
+                                   TaskWithRequirements * task,
+                                   solver::internal::SolverEvents & se) const
+{
+  // We add a task that is not in the computation data. We get the constraint from problem.
+  // However this task might have been removed from problem after being added (but before
+  // the computation data have been updated). If this is the case, we skip the addition.
+  auto optc = problem.constraintWithRequirementsNoThrow(task);
+  if(!optc)
+    return;
+
+  // If there is really a task to be added, we need to record the mapping in memory
+  auto c = optc->get();
+  memory->addConstraint(task, c);
+  const auto & subs = problem.substitutions();
+
+  abilities_.check(c.constraint, c.requirements);
+  for(const auto & xi : c.constraint->variables())
   {
+    auto s = subs.substitute(xi);
+    for(const auto & si : s)
+    {
+      if(memory->addVariable(si))
+        se.addVariable(si);
+    }
   }
 
-  void WeightedLeastSquares::Memory::setVariablesToSolution_(VariableVector& x)
+  int p = task->requirements.priorityLevel().value();
+  if((p == 0) && canBeUsedAsBound(c.constraint, subs, constraint::Type::DOUBLE_SIDED))
   {
-    x.value(solver->result());
+    se.addBound(c.constraint);
+  }
+  else
+  {
+    if(p == 0)
+    {
+      se.addConstraint(c.constraint);
+    }
+    else
+    {
+      // We dont adapt maxp, meaning that a constraint with priority level p>max_p will get a weight<1
+      se.addObjective({c.constraint, c.requirements, std::pow(*options_.scalarizationWeight(), memory->maxp - p)});
+    }
+  }
+}
+
+void WeightedLeastSquares::removeTask(LinearizedControlProblem & problem,
+                                      Memory * memory,
+                                      TaskWithRequirements * task,
+                                      solver::internal::SolverEvents & se) const
+{
+  // We need to remove the constraint that was last added for the task.
+  // We get this info from memory. It the task is not present, it's because we
+  // skipped its addition in addTask before, so wee skip the removal as well.
+  auto optc = memory->constraintNoThrow(task);
+  if(!optc)
+    return;
+
+  const auto & c = optc->get();
+  const auto & subs = problem.substitutions();
+
+  if(subs.uses(c.constraint))
+    throw std::runtime_error(
+        "[WeightedLeastSquares::removeTask]: You cannot remove a constraint used for a substitution.");
+
+  for(const auto & xi : c.constraint->variables())
+  {
+    auto s = subs.substitute(xi);
+    for(const auto & si : s)
+    {
+      if(memory->removeVariable(si.get()))
+        se.removeVariable(si);
+    }
   }
 
-}  // namespace scheme
+  int p = task->requirements.priorityLevel().value();
+  if((p == 0) && canBeUsedAsBound(c.constraint, subs, constraint::Type::DOUBLE_SIDED))
+  {
+    se.removeBound(c.constraint);
+  }
+  else
+  {
+    if(p == 0)
+    {
+      se.removeConstraint(c.constraint);
+    }
+    else
+    {
+      se.removeObjective(c.constraint);
+    }
+  }
+  memory->removeConstraint(task);
+}
 
-}  // namespace tvm
+WeightedLeastSquares::Memory::Memory(int solverId, std::unique_ptr<solver::abstract::LeastSquareSolver> solver)
+: LinearizedProblemComputationData(solverId), solver(std::move(solver))
+{
+}
+
+void WeightedLeastSquares::Memory::setVariablesToSolution_(VariableVector & x) { x.value(solver->result()); }
+
+} // namespace scheme
+
+} // namespace tvm

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -50,8 +50,7 @@ void WeightedLeastSquares::updateComputationData_(LinearizedControlProblem & pro
       auto e = memory->popEvent();
       switch(e.type())
       {
-        case ProblemDefinitionEvent::Type::WeightChange:
-        {
+        case ProblemDefinitionEvent::Type::WeightChange: {
           const auto & c = problem.constraintWithRequirements(e.emitter());
           if(c.requirements->priorityLevel().value() == 0)
             throw std::runtime_error(
@@ -60,8 +59,7 @@ void WeightedLeastSquares::updateComputationData_(LinearizedControlProblem & pro
           se.addScalarWeigthEvent(c.constraint.get());
         }
         break;
-        case ProblemDefinitionEvent::Type::AnisotropicWeightChange:
-        {
+        case ProblemDefinitionEvent::Type::AnisotropicWeightChange: {
           const auto & c = problem.constraintWithRequirements(e.emitter());
           if(c.requirements->priorityLevel().value() == 0)
             throw std::runtime_error(
@@ -295,8 +293,7 @@ void WeightedLeastSquares::removeTask(LinearizedControlProblem & problem,
 
 WeightedLeastSquares::Memory::Memory(int solverId, std::unique_ptr<solver::abstract::LeastSquareSolver> solver)
 : LinearizedProblemComputationData(solverId), solver(std::move(solver))
-{
-}
+{}
 
 void WeightedLeastSquares::Memory::setVariablesToSolution_(VariableVector & x) { x.value(solver->result()); }
 

--- a/src/scheme/helpers.cpp
+++ b/src/scheme/helpers.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/constraint/abstract/Constraint.h>
 #include <tvm/hint/internal/Substitutions.h>

--- a/src/scheme/helpers.cpp
+++ b/src/scheme/helpers.cpp
@@ -1,161 +1,179 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <tvm/scheme/internal/helpers.h>
 #include <tvm/constraint/abstract/Constraint.h>
 #include <tvm/hint/internal/Substitutions.h>
+#include <tvm/scheme/internal/helpers.h>
 
 namespace tvm
 {
 
-  namespace scheme
+namespace scheme
+{
+
+namespace internal
+{
+
+bool isBound(const ConstraintPtr & c)
+{
+  const auto & vars = c->variables();
+  if(vars.numberOfVariables() == 0)
+    return false;
+  const auto & p = c->jacobian(*vars[0]).properties();
+  return (c->linearIn(*vars[0]) && vars.numberOfVariables() == 1 && p.isDiagonal() && p.isInvertible());
+}
+
+bool isBound(const ConstraintPtr & c, const hint::internal::Substitutions & subs)
+{
+  return isBound(c, subs.variables(), subs.variableSubstitutions());
+}
+
+bool TVM_DLLAPI isBound(const ConstraintPtr & c,
+                        const std::vector<VariablePtr> & x,
+                        const std::vector<std::shared_ptr<function::BasicLinearFunction>> & xsub)
+{
+  if(isBound(c))
   {
-
-    namespace internal
+    auto it = std::find(x.begin(), x.end(), c->variables()[0]);
+    if(it == x.end())
     {
+      // There is no susbtitution, this is a bound
+      return true;
+    }
+    else
+    {
+      const auto & sub = xsub[static_cast<size_t>(it - x.begin())];
+      const auto & v = sub->variables();
+      if(v.numberOfVariables() != 1)
+        return false;
+      const auto & p = sub->jacobian(*v[0]).properties();
+      // There could be 0 variables in sub. In that case we have a trivial
+      // constraint that we do not consider as a bound.
+      return (p.isDiagonal() && p.isInvertible());
+    }
+  }
+  else
+  {
+    // We do not consider substitutions that would make a non-bound constraint
+    // become a bound. So if the original constraint is not a bound we return
+    // false.
+    return false;
+  }
+}
 
-      bool isBound(const ConstraintPtr& c)
-      {
-        const auto& vars = c->variables();
-        if (vars.numberOfVariables() == 0) return false;
-        const auto& p = c->jacobian(*vars[0]).properties();
-        return (c->linearIn(*vars[0]) && vars.numberOfVariables() == 1
-                && p.isDiagonal() && p.isInvertible());
-      }
+bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr & c,
+                                 const hint::internal::Substitutions & subs,
+                                 constraint::Type targetConvention)
+{
+  return canBeUsedAsBound(c, subs.variables(), subs.variableSubstitutions(), targetConvention);
+}
 
-      bool isBound(const ConstraintPtr& c, const hint::internal::Substitutions& subs)
-      {
-        return isBound(c, subs.variables(), subs.variableSubstitutions());
-      }
+bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr & c,
+                                 const std::vector<VariablePtr> & x,
+                                 const std::vector<std::shared_ptr<function::BasicLinearFunction>> & xsub,
+                                 constraint::Type targetConvention)
+{
+  using constraint::Type;
+  if(isBound(c, x, xsub))
+  {
+    // We have the following cases (row: constraint convention, col: target
+    // convention):
+    //     |  =  |  >= |  <= |  <<
+    // ----+-----+-----+-----+-----
+    //  =  |  NO |  NO |  NO |  OK
+    //  >= |  NO |  1  |  2  |  OK
+    //  <= |  NO |  2  |  1  |  OK
+    //  << |  NO |  NO |  NO |  OK
+    // with = : EQUAL, >= : GREATER_THAN, <= : LOWER_THAN, << : DOUBLE_SIDED
+    // NO: case note possible, OK: case possible without particular
+    // positiveness properties of the matrix/matrices
+    // 1: possible if diagonal matrix is positive definite or both the
+    // the constraint matrix and the matrix is in the substitutions are
+    // negative definite,
+    // 2: possible if diagonal matrix is negative definite or both the
+    // the constraint matrix and the matrix is in the substitutions are
+    // positive definite.
+    // We do not consider the case where both matrices are undefinite but
+    // their product would be positive or negative definite.
 
-      bool TVM_DLLAPI isBound(const ConstraintPtr & c, const std::vector<VariablePtr>& x, const std::vector<std::shared_ptr<function::BasicLinearFunction>>& xsub)
-      {
-        if (isBound(c))
-        {
-          auto it = std::find(x.begin(), x.end(), c->variables()[0]);
-          if (it == x.end())
-          {
-            // There is no susbtitution, this is a bound
-            return true;
-          }
-          else
-          {
-            const auto& sub = xsub[static_cast<size_t>(it - x.begin())];
-            const auto& v = sub->variables();
-            if (v.numberOfVariables() != 1) return false;
-            const auto& p = sub->jacobian(*v[0]).properties();
-            // There could be 0 variables in sub. In that case we have a trivial
-            // constraint that we do not consider as a bound.
-            return (p.isDiagonal() && p.isInvertible());
-          }
-        }
+    bool case1 = false;
+    switch(targetConvention)
+    {
+      case Type::EQUAL:
+        return false;
+      case Type::GREATER_THAN:
+        if(c->type() == Type::GREATER_THAN)
+          case1 = true;
+        else if(c->type() == Type::LOWER_THAN)
+          case1 = false;
         else
-        {
-          // We do not consider substitutions that would make a non-bound constraint
-          // become a bound. So if the original constraint is not a bound we return
-          // false.
           return false;
-        }
-      }
-
-      bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr& c, const hint::internal::Substitutions& subs,
-                                       constraint::Type targetConvention)
-      {
-        return canBeUsedAsBound(c, subs.variables(), subs.variableSubstitutions(), targetConvention);
-      }
-
-      bool TVM_DLLAPI canBeUsedAsBound(const ConstraintPtr& c, const std::vector<VariablePtr>& x,
-                                       const std::vector<std::shared_ptr<function::BasicLinearFunction>>& xsub,
-                                       constraint::Type targetConvention)
-      {
-        using constraint::Type;
-        if (isBound(c, x, xsub))
-        {
-          // We have the following cases (row: constraint convention, col: target
-          // convention):
-          //     |  =  |  >= |  <= |  << 
-          // ----+-----+-----+-----+-----
-          //  =  |  NO |  NO |  NO |  OK
-          //  >= |  NO |  1  |  2  |  OK 
-          //  <= |  NO |  2  |  1  |  OK 
-          //  << |  NO |  NO |  NO |  OK 
-          // with = : EQUAL, >= : GREATER_THAN, <= : LOWER_THAN, << : DOUBLE_SIDED
-          // NO: case note possible, OK: case possible without particular
-          // positiveness properties of the matrix/matrices
-          // 1: possible if diagonal matrix is positive definite or both the
-          // the constraint matrix and the matrix is in the substitutions are
-          // negative definite,
-          // 2: possible if diagonal matrix is negative definite or both the
-          // the constraint matrix and the matrix is in the substitutions are
-          // positive definite.
-          // We do not consider the case where both matrices are undefinite but
-          // their product would be positive or negative definite.
-
-          bool case1 = false;
-          switch (targetConvention)
-          {
-          case Type::EQUAL:         return false;
-          case Type::GREATER_THAN:  
-            if (c->type() == Type::GREATER_THAN) case1 = true;
-            else if (c->type() == Type::LOWER_THAN) case1 = false;
-            else return false;
-          case Type::LOWER_THAN:
-            if (c->type() == Type::GREATER_THAN) case1 = false;
-            else if (c->type() == Type::LOWER_THAN) case1 = true;
-            else return false;
-          case Type::DOUBLE_SIDED: return true;
-          default: assert(false);
-          }
-
-          const auto& p = c->jacobian(*c->variables()[0]).properties();
-          auto it = std::find(x.begin(), x.end(), c->variables()[0]);
-          if (it == x.end())
-          {
-            if (case1) return p.isPositiveDefinite();
-            else       return p.isNegativeDefinite();
-          }
-          else
-          {
-            const auto& sub = xsub[static_cast<size_t>(it - x.begin())];
-            const auto& v = sub->variables();
-            const auto& ps = sub->jacobian(*x[0]).properties();
-            if (case1) return (p*ps).isPositiveDefinite();
-            else       return (p*ps).isNegativeDefinite();
-          }
-        }
+      case Type::LOWER_THAN:
+        if(c->type() == Type::GREATER_THAN)
+          case1 = false;
+        else if(c->type() == Type::LOWER_THAN)
+          case1 = true;
         else
-        {
           return false;
-        }
-      }
+      case Type::DOUBLE_SIDED:
+        return true;
+      default:
+        assert(false);
     }
 
+    const auto & p = c->jacobian(*c->variables()[0]).properties();
+    auto it = std::find(x.begin(), x.end(), c->variables()[0]);
+    if(it == x.end())
+    {
+      if(case1)
+        return p.isPositiveDefinite();
+      else
+        return p.isNegativeDefinite();
+    }
+    else
+    {
+      const auto & sub = xsub[static_cast<size_t>(it - x.begin())];
+      const auto & v = sub->variables();
+      const auto & ps = sub->jacobian(*x[0]).properties();
+      if(case1)
+        return (p * ps).isPositiveDefinite();
+      else
+        return (p * ps).isNegativeDefinite();
+    }
   }
-
+  else
+  {
+    return false;
+  }
 }
+} // namespace internal
+
+} // namespace scheme
+
+} // namespace tvm

--- a/src/solver/LSSOLLeastSquareSolver.cpp
+++ b/src/solver/LSSOLLeastSquareSolver.cpp
@@ -8,226 +8,224 @@
 
 #include <iostream>
 
-
 namespace tvm
 {
 
 namespace solver
 {
-  LSSOLLeastSquareSolver::LSSOLLeastSquareSolver(const LSSOLLSSolverOptions& options)
-    : LeastSquareSolver(options.verbose().value())
-    , cl_(l_.tail(0))
-    , cu_(u_.tail(0))
-    , big_number_(options.big_number().value())
-    , autoMinNorm_(false)
-  {
-    TVM_PROCESS_OPTION(crashTol,           ls_)
-    TVM_PROCESS_OPTION(feasibilityMaxIter, ls_)
-    TVM_PROCESS_OPTION(feasibilityTol,     ls_)
-    TVM_PROCESS_OPTION(infiniteBnd,        ls_)
-    TVM_PROCESS_OPTION(infiniteStep,       ls_)
-    TVM_PROCESS_OPTION(optimalityMaxIter,  ls_)
-    TVM_PROCESS_OPTION(persistence,        ls_)
-    TVM_PROCESS_OPTION(printLevel,         ls_)
-    TVM_PROCESS_OPTION(rankTol,            ls_)
-    TVM_PROCESS_OPTION(warm,               ls_)
-    TVM_PROCESS_OPTION(crashTol,           fp_)
-    TVM_PROCESS_OPTION(feasibilityMaxIter, fp_)
-    TVM_PROCESS_OPTION(feasibilityTol,     fp_)
-    TVM_PROCESS_OPTION(infiniteBnd,        fp_)
-    TVM_PROCESS_OPTION(infiniteStep,       fp_)
-    TVM_PROCESS_OPTION(optimalityMaxIter,  fp_)
-    TVM_PROCESS_OPTION(persistence,        fp_)
-    TVM_PROCESS_OPTION(printLevel,         fp_)
-    TVM_PROCESS_OPTION(rankTol,            fp_)
-    TVM_PROCESS_OPTION(warm,               fp_)
-  }
+LSSOLLeastSquareSolver::LSSOLLeastSquareSolver(const LSSOLLSSolverOptions & options)
+: LeastSquareSolver(options.verbose().value()), cl_(l_.tail(0)), cu_(u_.tail(0)),
+  big_number_(options.big_number().value()), autoMinNorm_(false)
+{
+  TVM_PROCESS_OPTION(crashTol, ls_)
+  TVM_PROCESS_OPTION(feasibilityMaxIter, ls_)
+  TVM_PROCESS_OPTION(feasibilityTol, ls_)
+  TVM_PROCESS_OPTION(infiniteBnd, ls_)
+  TVM_PROCESS_OPTION(infiniteStep, ls_)
+  TVM_PROCESS_OPTION(optimalityMaxIter, ls_)
+  TVM_PROCESS_OPTION(persistence, ls_)
+  TVM_PROCESS_OPTION(printLevel, ls_)
+  TVM_PROCESS_OPTION(rankTol, ls_)
+  TVM_PROCESS_OPTION(warm, ls_)
+  TVM_PROCESS_OPTION(crashTol, fp_)
+  TVM_PROCESS_OPTION(feasibilityMaxIter, fp_)
+  TVM_PROCESS_OPTION(feasibilityTol, fp_)
+  TVM_PROCESS_OPTION(infiniteBnd, fp_)
+  TVM_PROCESS_OPTION(infiniteStep, fp_)
+  TVM_PROCESS_OPTION(optimalityMaxIter, fp_)
+  TVM_PROCESS_OPTION(persistence, fp_)
+  TVM_PROCESS_OPTION(printLevel, fp_)
+  TVM_PROCESS_OPTION(rankTol, fp_)
+  TVM_PROCESS_OPTION(warm, fp_)
+}
 
-  void LSSOLLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool)
-  {
-    resize_(nObj, nEq, nIneq, true);
+void LSSOLLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool)
+{
+  resize_(nObj, nEq, nIneq, true);
 
-    autoMinNorm_ = false;
-  }
+  autoMinNorm_ = false;
+}
 
-  LSSOLLeastSquareSolver::ImpactFromChanges LSSOLLeastSquareSolver::resize_(int nObj, int nEq, int nIneq, bool)
-  {
-    int n = variables().totalSize();
-    int nCstr = nEq + nIneq;
-    ImpactFromChanges impact;
+LSSOLLeastSquareSolver::ImpactFromChanges LSSOLLeastSquareSolver::resize_(int nObj, int nEq, int nIneq, bool)
+{
+  int n = variables().totalSize();
+  int nCstr = nEq + nIneq;
+  ImpactFromChanges impact;
 
-    impact.objectives_ = ImpactFromChanges::willReallocate(A_, nObj, n);
-    A_.resize(nObj, n);
+  impact.objectives_ = ImpactFromChanges::willReallocate(A_, nObj, n);
+  A_.resize(nObj, n);
+  A_.setZero();
+  b_.resize(nObj);
+  b_.setZero();
+  impact.equalityConstraints_ = ImpactFromChanges::willReallocate(C_, nCstr, n);
+  C_.resize(nCstr, n);
+  C_.setZero();
+  impact.bounds_ = ImpactFromChanges::willReallocate(l_, nCstr + n);
+  l_ = Eigen::VectorXd::Constant(nCstr + n, -big_number_);
+  u_ = Eigen::VectorXd::Constant(nCstr + n, +big_number_);
+  new(&cl_) VectorXdTail(l_.tail(nCstr));
+  new(&cu_) VectorXdTail(u_.tail(nCstr));
+  if(nObj > 0)
+    ls_.resize(n, nCstr, Eigen::lssol::eType::LS1);
+  else
+    fp_.resize(n, nCstr);
+
+  impact.inequalityConstraints_ = impact.equalityConstraints_;
+  impact.bounds_ = impact.bounds_ || impact.inequalityConstraints_;
+  return impact;
+}
+
+void LSSOLLeastSquareSolver::addBound_(LinearConstraintPtr bound, RangePtr range, bool first)
+{
+  scheme::internal::AssignmentTarget target(range, l_, u_);
+  addAssignement(bound, target, bound->variables()[0], first);
+}
+
+void LSSOLLeastSquareSolver::addEqualityConstraint_(LinearConstraintPtr cstr)
+{
+  RangePtr r = std::make_shared<Range>(nextEqualityConstraintRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, C_, cl_, cu_, constraint::RHS::AS_GIVEN);
+  addAssignement(cstr, nullptr, target, variables(), substitutions());
+}
+
+void LSSOLLeastSquareSolver::addIneqalityConstraint_(LinearConstraintPtr cstr)
+{
+  RangePtr r = std::make_shared<Range>(nextInequalityConstraintRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, C_, cl_, cu_, constraint::RHS::AS_GIVEN);
+  addAssignement(cstr, nullptr, target, variables(), substitutions());
+}
+
+void LSSOLLeastSquareSolver::addObjective_(LinearConstraintPtr cstr,
+                                           SolvingRequirementsPtr req,
+                                           double additionalWeight)
+{
+  RangePtr r = std::make_shared<Range>(nextObjectiveRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, A_, b_, constraint::Type::EQUAL, constraint::RHS::AS_GIVEN);
+  addAssignement(cstr, req, target, variables(), substitutions(), additionalWeight);
+}
+
+void LSSOLLeastSquareSolver::setMinimumNorm_()
+{
+  autoMinNorm_ = true;
+  b_.setZero();
+}
+
+void LSSOLLeastSquareSolver::preAssignmentProcess_()
+{
+  // LSSOL is overwritting A during the resolution.
+  // We need to make sure that A is clean before assignments are carried out.
+  if(!autoMinNorm_)
     A_.setZero();
-    b_.resize(nObj);
-    b_.setZero();
-    impact.equalityConstraints_ = ImpactFromChanges::willReallocate(C_, nCstr, n);
-    C_.resize(nCstr, n);
-    C_.setZero();
-    impact.bounds_ = ImpactFromChanges::willReallocate(l_, nCstr + n);
-    l_ = Eigen::VectorXd::Constant(nCstr + n, -big_number_);
-    u_ = Eigen::VectorXd::Constant(nCstr + n, +big_number_);
-    new(&cl_) VectorXdTail(l_.tail(nCstr));
-    new(&cu_) VectorXdTail(u_.tail(nCstr));
-    if (nObj > 0)
-      ls_.resize(n, nCstr, Eigen::lssol::eType::LS1);
-    else
-      fp_.resize(n, nCstr);
-    
-    impact.inequalityConstraints_ = impact.equalityConstraints_;
-    impact.bounds_ = impact.bounds_ || impact.inequalityConstraints_;
-    return impact;
-  }
+}
 
-  void LSSOLLeastSquareSolver::addBound_(LinearConstraintPtr bound, RangePtr range, bool first)
-  {
-    scheme::internal::AssignmentTarget target(range, l_, u_);
-    addAssignement(bound, target, bound->variables()[0], first);
-  }
+void LSSOLLeastSquareSolver::postAssignmentProcess_()
+{
+  if(autoMinNorm_)
+    A_.setIdentity();
+}
 
-  void LSSOLLeastSquareSolver::addEqualityConstraint_(LinearConstraintPtr cstr)
-  {
-    RangePtr r = std::make_shared<Range>(nextEqualityConstraintRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, C_, cl_, cu_, constraint::RHS::AS_GIVEN);
-    addAssignement(cstr, nullptr, target, variables(), substitutions());
-  }
+bool LSSOLLeastSquareSolver::solve_()
+{
+  if(nObj_ > 0)
+    return ls_.solve(A_, b_, C_, l_, u_);
+  else
+    return fp_.solve(C_, l_, u_);
+}
 
-  void LSSOLLeastSquareSolver::addIneqalityConstraint_(LinearConstraintPtr cstr)
-  {
-    RangePtr r = std::make_shared<Range>(nextInequalityConstraintRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, C_, cl_, cu_, constraint::RHS::AS_GIVEN);
-    addAssignement(cstr, nullptr, target, variables(), substitutions());
-  }
+const Eigen::VectorXd & LSSOLLeastSquareSolver::result_() const
+{
+  if(nObj_ > 0)
+    return ls_.result();
+  else
+    return fp_.result();
+}
 
-  void LSSOLLeastSquareSolver::addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight)
-  {
-    RangePtr r = std::make_shared<Range>(nextObjectiveRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, A_, b_, constraint::Type::EQUAL, constraint::RHS::AS_GIVEN);
-    addAssignement(cstr, req, target, variables(), substitutions(), additionalWeight);
-  }
+Range LSSOLLeastSquareSolver::nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {eqSize_ + ineqSize_, cstr.size()};
+}
 
-  void LSSOLLeastSquareSolver::setMinimumNorm_()
-  {
-    autoMinNorm_ = true;
-    b_.setZero();
-  }
+Range LSSOLLeastSquareSolver::nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {eqSize_ + ineqSize_, cstr.size()};
+}
 
-  void LSSOLLeastSquareSolver::preAssignmentProcess_()
-  {
-    // LSSOL is overwritting A during the resolution.
-    // We need to make sure that A is clean before assignments are carried out.
-    if (!autoMinNorm_)
-      A_.setZero();
-  }
+Range LSSOLLeastSquareSolver::nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {objSize_, cstr.size()};
+}
 
-  void LSSOLLeastSquareSolver::postAssignmentProcess_()
-  {
-    if (autoMinNorm_)
-      A_.setIdentity();
-  }
+void LSSOLLeastSquareSolver::removeBounds_(const Range & r)
+{
+  l_.segment(r.start, r.dim).setConstant(-big_number_);
+  u_.segment(r.start, r.dim).setConstant(+big_number_);
+}
 
-  bool LSSOLLeastSquareSolver::solve_()
-  {
-    if (nObj_ > 0)
-      return ls_.solve(A_, b_, C_, l_, u_);
-    else
-      return fp_.solve(C_, l_, u_);
-  }
+void LSSOLLeastSquareSolver::updateEqualityTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(C_, cl_, cu_);
+}
 
-  const Eigen::VectorXd& LSSOLLeastSquareSolver::result_() const
-  {
-    if (nObj_ > 0)
-      return ls_.result();
-    else
-      return fp_.result();
-  }
+void LSSOLLeastSquareSolver::updateInequalityTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(C_, cl_, cu_);
+}
 
-  Range LSSOLLeastSquareSolver::nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { eqSize_ + ineqSize_, cstr.size() };
-  }
+void LSSOLLeastSquareSolver::updateBoundTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(VectorRef(l_), u_);
+}
 
-  Range LSSOLLeastSquareSolver::nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { eqSize_ + ineqSize_, cstr.size() };
-  }
+void LSSOLLeastSquareSolver::updateObjectiveTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(A_, b_);
+}
 
-  Range LSSOLLeastSquareSolver::nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { objSize_, cstr.size() };
-  }
+void LSSOLLeastSquareSolver::applyImpactLogic(ImpactFromChanges & impact)
+{
+  if(impact.equalityConstraints_)
+    impact.inequalityConstraints_ = true;
+  if(impact.inequalityConstraints_)
+    impact.equalityConstraints_ = true;
+}
 
-  void LSSOLLeastSquareSolver::removeBounds_(const Range& r)
-  {
-    l_.segment(r.start, r.dim).setConstant(-big_number_);
-    u_.segment(r.start, r.dim).setConstant(+big_number_);
-  }
+void LSSOLLeastSquareSolver::printProblemData_() const
+{
+  std::cout << "A =\n" << A_ << std::endl;
+  std::cout << "b = " << b_.transpose() << std::endl;
+  std::cout << "C =\n" << C_ << std::endl;
+  std::cout << "l = " << l_.transpose() << std::endl;
+  std::cout << "u = " << u_.transpose() << std::endl;
+}
 
-  void LSSOLLeastSquareSolver::updateEqualityTargetData(scheme::internal::AssignmentTarget& target)
+void LSSOLLeastSquareSolver::printDiagnostic_() const
+{
+  if(nObj_)
   {
-    target.changeData(C_, cl_, cu_);
+    std::cout << ls_.inform() << std::endl;
+    ls_.print_inform();
   }
-
-  void LSSOLLeastSquareSolver::updateInequalityTargetData(scheme::internal::AssignmentTarget& target)
+  else
   {
-    target.changeData(C_, cl_, cu_);
-  }
-
-  void LSSOLLeastSquareSolver::updateBoundTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(VectorRef(l_), u_);
-  }
-
-  void LSSOLLeastSquareSolver::updateObjectiveTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(A_, b_);
-  }
-
-  void LSSOLLeastSquareSolver::applyImpactLogic(ImpactFromChanges& impact)
-  {
-    if (impact.equalityConstraints_) impact.inequalityConstraints_ = true;
-    if (impact.inequalityConstraints_) impact.equalityConstraints_ = true;
-  }
-
-  void LSSOLLeastSquareSolver::printProblemData_() const
-  {
-    std::cout << "A =\n" << A_ << std::endl;
-    std::cout << "b = " << b_.transpose() << std::endl;
-    std::cout << "C =\n" << C_ << std::endl;
-    std::cout << "l = " << l_.transpose() << std::endl;
-    std::cout << "u = " << u_.transpose() << std::endl;
-  }
-
-  void LSSOLLeastSquareSolver::printDiagnostic_() const
-  {
-    if (nObj_)
-    {
-      std::cout << ls_.inform() << std::endl;
-      ls_.print_inform();
-    }
-    else
-    {
-      std::cout << fp_.inform() << std::endl;
-      fp_.print_inform();
-    }
-  }
-
-
-  LSSOLLSSolverFactory::LSSOLLSSolverFactory(const LSSOLLSSolverOptions& options)
-    : LSSolverFactory("lssol")
-    , options_(options)
-  {
-  }
-  
-  std::unique_ptr<abstract::LSSolverFactory> LSSOLLSSolverFactory::clone() const
-  {
-    return std::make_unique<LSSOLLSSolverFactory>(*this);
-  }
-
-  std::unique_ptr<abstract::LeastSquareSolver> LSSOLLSSolverFactory::createSolver() const
-  {
-    return std::make_unique<LSSOLLeastSquareSolver>(options_);
+    std::cout << fp_.inform() << std::endl;
+    fp_.print_inform();
   }
 }
 
+LSSOLLSSolverFactory::LSSOLLSSolverFactory(const LSSOLLSSolverOptions & options)
+: LSSolverFactory("lssol"), options_(options)
+{
 }
+
+std::unique_ptr<abstract::LSSolverFactory> LSSOLLSSolverFactory::clone() const
+{
+  return std::make_unique<LSSOLLSSolverFactory>(*this);
+}
+
+std::unique_ptr<abstract::LeastSquareSolver> LSSOLLSSolverFactory::createSolver() const
+{
+  return std::make_unique<LSSOLLeastSquareSolver>(options_);
+}
+} // namespace solver
+
+} // namespace tvm

--- a/src/solver/LSSOLLeastSquareSolver.cpp
+++ b/src/solver/LSSOLLeastSquareSolver.cpp
@@ -214,8 +214,7 @@ void LSSOLLeastSquareSolver::printDiagnostic_() const
 
 LSSOLLSSolverFactory::LSSOLLSSolverFactory(const LSSOLLSSolverOptions & options)
 : LSSolverFactory("lssol"), options_(options)
-{
-}
+{}
 
 std::unique_ptr<abstract::LSSolverFactory> LSSOLLSSolverFactory::clone() const
 {

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -226,24 +226,26 @@ void LeastSquareSolver::process(const internal::SolverEvents & se)
     objSize_ = 0;
 
   if(impact.equalityConstraints_)
-    updateTargetRange(equalityConstraintToAssignments_, eqSize_,
-                      [&](const auto & c) { return nextEqualityConstraintRange_(c); },
-                      [&](const auto & c) { return constraintSize(c); });
+    updateTargetRange(
+        equalityConstraintToAssignments_, eqSize_, [&](const auto & c) { return nextEqualityConstraintRange_(c); },
+        [&](const auto & c) { return constraintSize(c); });
 
   if(impact.inequalityConstraints_)
-    updateTargetRange(inequalityConstraintToAssignments_, ineqSize_,
-                      [&](const auto & c) { return nextInequalityConstraintRange_(c); },
-                      [&](const auto & c) { return constraintSize(c); });
+    updateTargetRange(
+        inequalityConstraintToAssignments_, ineqSize_,
+        [&](const auto & c) { return nextInequalityConstraintRange_(c); },
+        [&](const auto & c) { return constraintSize(c); });
 
   int dummy;
   if(impact.bounds_ || needMappingUpdate) // needMappingUpdate because a variable might have been added or removed
-    updateTargetRange(boundToAssignments_, dummy,
-                      [&](const auto & b) { return b.variables()[0]->getMappingIn(variables()); },
-                      [](const auto & b) { return 0; });
+    updateTargetRange(
+        boundToAssignments_, dummy, [&](const auto & b) { return b.variables()[0]->getMappingIn(variables()); },
+        [](const auto & b) { return 0; });
 
   if(impact.objectives_)
-    updateTargetRange(objectiveToAssignments_, objSize_, [&](const auto & c) { return nextObjectiveRange_(c); },
-                      [&](const auto & c) { return c.size(); });
+    updateTargetRange(
+        objectiveToAssignments_, objSize_, [&](const auto & c) { return nextObjectiveRange_(c); },
+        [&](const auto & c) { return c.size(); });
 
   // Update the matrices and vectors of the target when needed
   auto updateTargetData = [](const auto & map, auto updateFn) {

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -255,7 +255,7 @@ void LeastSquareSolver::process(const internal::SolverEvents & se)
   };
 
   impact.orAssign(impactResize); // There are case where no resize are necessary (e.g. a constraint was removed and
-  applyImpactLogic(impact); // another added with same size) but the target need to change.
+  applyImpactLogic(impact);      // another added with same size) but the target need to change.
   if(impact.equalityConstraints_)
     updateTargetData(equalityConstraintToAssignments_, [&](auto & target) { updateEqualityTargetData(target); });
 

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -1,494 +1,493 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
-#include <tvm/solver/abstract/LeastSquareSolver.h>
 #include <tvm/VariableVector.h>
+#include <tvm/solver/abstract/LeastSquareSolver.h>
 
 #include <iostream>
 
-
 namespace
 {
-  using namespace tvm;
-  using namespace tvm::solver::abstract;
-  /** Helper class relying on RAII to update automatically the map from a constraint to
-    * the corresponding assignments
-    */
-  class AutoMap
+using namespace tvm;
+using namespace tvm::solver::abstract;
+/** Helper class relying on RAII to update automatically the map from a constraint to
+ * the corresponding assignments
+ */
+class AutoMap
+{
+public:
+  /** Upon destruction of this object, pointers to all new elements in \a observed since
+   * calling this constructor will be added to \a target[cstr.get()].
+   */
+  AutoMap(LinearConstraintPtr cstr,
+          LeastSquareSolver::AssignmentVector & observed,
+          LeastSquareSolver::MapToAssignment & target)
+  : observedSize_(observed.size()), observed_(observed), target_(target[cstr.get()])
   {
-  public:
-    /** Upon destruction of this object, pointers to all new elements in \a observed since
-      * calling this constructor will be added to \a target[cstr.get()].
-      */
-    AutoMap(LinearConstraintPtr cstr, LeastSquareSolver::AssignmentVector& observed, LeastSquareSolver::MapToAssignment& target)
-      : observedSize_(observed.size()), observed_(observed), target_(target[cstr.get()]) {}
-    ~AutoMap()
-    {
-      for (size_t i = observedSize_; i < observed_.size(); ++i)
-        target_.push_back(observed_[i].get());
-    }
+  }
+  ~AutoMap()
+  {
+    for(size_t i = observedSize_; i < observed_.size(); ++i)
+      target_.push_back(observed_[i].get());
+  }
 
-  private:
-    size_t observedSize_;
-    LeastSquareSolver::AssignmentVector& observed_;
-    LeastSquareSolver::AssignmentPtrVector& target_;
-  };
-}
+private:
+  size_t observedSize_;
+  LeastSquareSolver::AssignmentVector & observed_;
+  LeastSquareSolver::AssignmentPtrVector & target_;
+};
+} // namespace
 
 namespace tvm::solver::abstract
 {
-  LeastSquareSolver::LeastSquareSolver(bool verbose)
-    : objSize_(-1)
-    , eqSize_(-1)
-    , ineqSize_(-1)
-    , buildInProgress_(false)
-    , subs_(nullptr)
-    , verbose_(verbose)
-    , variables_(nullptr)
+LeastSquareSolver::LeastSquareSolver(bool verbose)
+: objSize_(-1), eqSize_(-1), ineqSize_(-1), buildInProgress_(false), subs_(nullptr), verbose_(verbose),
+  variables_(nullptr)
+{
+}
+
+void LeastSquareSolver::startBuild(const VariableVector & x,
+                                   int nObj,
+                                   int nEq,
+                                   int nIneq,
+                                   bool useBounds,
+                                   const hint::internal::Substitutions * const subs)
+{
+  assert(nObj >= 0);
+  assert(nEq >= 0);
+  assert(nIneq >= 0);
+
+  buildInProgress_ = true;
+  variables_ = &x;
+  boundsOrder_.clear();
+  for(const auto & xi : variables())
   {
+    boundsOrder_[xi.get()] = {};
   }
 
-  void LeastSquareSolver::startBuild(const VariableVector& x, int nObj, int nEq, int nIneq, bool useBounds, const hint::internal::Substitutions* const subs)
+  objectiveToAssignments_.clear();
+  equalityConstraintToAssignments_.clear();
+  inequalityConstraintToAssignments_.clear();
+  boundToAssignments_.clear();
+  assignments_.clear();
+
+  subs_ = subs;
+
+  initializeBuild_(nObj, nEq, nIneq, useBounds);
+  nEq_ = nEq;
+  nIneq_ = nIneq;
+  nObj_ = nObj;
+  objSize_ = 0;
+  eqSize_ = 0;
+  ineqSize_ = 0;
+}
+
+void LeastSquareSolver::finalizeBuild()
+{
+  assert(nObj_ == objSize_);
+  assert(nEq_ == eqSize_);
+  assert(nIneq_ == ineqSize_);
+  buildInProgress_ = false;
+}
+
+void LeastSquareSolver::addBound(LinearConstraintPtr bound)
+{
+  assert(buildInProgress_ && "Attempting to add a bound without calling startBuild first");
+  assert(bound->variables().numberOfVariables() == 1 && "A bound constraint can be only on one variable.");
+  const auto & xi = bound->variables()[0];
+  RangePtr range = std::make_shared<Range>(xi->getMappingIn(variables()));
+
+  AutoMap autoMap(bound, assignments_, boundToAssignments_);
+  auto & first = boundsOrder_[xi.get()];
+  addBound_(bound, range, first.empty());
+  first.push_back(bound.get());
+}
+
+void LeastSquareSolver::addConstraint(LinearConstraintPtr cstr)
+{
+  assert(buildInProgress_ && "Attempting to add a constraint without calling startBuild first");
+
+  if(cstr->isEquality())
   {
-    assert(nObj >= 0);
-    assert(nEq >= 0);
-    assert(nIneq >= 0);
-
-    buildInProgress_ = true;
-    variables_ = &x;
-    boundsOrder_.clear();
-    for (const auto& xi : variables())
-    {
-      boundsOrder_[xi.get()] = {};
-    }
-
-    objectiveToAssignments_.clear();
-    equalityConstraintToAssignments_.clear();
-    inequalityConstraintToAssignments_.clear();
-    boundToAssignments_.clear();
-    assignments_.clear();
-
-    subs_ = subs;
-
-    initializeBuild_(nObj, nEq, nIneq, useBounds);
-    nEq_ = nEq;
-    nIneq_ = nIneq;
-    nObj_ = nObj;
-    objSize_ = 0;
-    eqSize_ = 0;
-    ineqSize_ = 0;
+    AutoMap autoMap(cstr, assignments_, equalityConstraintToAssignments_);
+    addEqualityConstraint_(cstr);
+    eqSize_ += constraintSize(*cstr);
   }
-
-  void LeastSquareSolver::finalizeBuild()
+  else
   {
-    assert(nObj_ == objSize_);
-    assert(nEq_ == eqSize_);
-    assert(nIneq_ == ineqSize_);
-    buildInProgress_ = false;
-  }
-
-  void LeastSquareSolver::addBound(LinearConstraintPtr bound)
-  {
-    assert(buildInProgress_ && "Attempting to add a bound without calling startBuild first");
-    assert(bound->variables().numberOfVariables() == 1 && "A bound constraint can be only on one variable.");
-    const auto& xi = bound->variables()[0];
-    RangePtr range = std::make_shared<Range>(xi->getMappingIn(variables()));
-
-    AutoMap autoMap(bound, assignments_, boundToAssignments_);
-    auto& first = boundsOrder_[xi.get()];
-    addBound_(bound, range, first.empty());
-    first.push_back(bound.get());
-  }
-
-  void LeastSquareSolver::addConstraint(LinearConstraintPtr cstr)
-  {
-    assert(buildInProgress_ && "Attempting to add a constraint without calling startBuild first");
-
-    if (cstr->isEquality())
-    {
-      AutoMap autoMap(cstr, assignments_, equalityConstraintToAssignments_);
-      addEqualityConstraint_(cstr);
-      eqSize_ += constraintSize(*cstr);
-    }
-    else
-    {
-      AutoMap autoMap(cstr, assignments_, inequalityConstraintToAssignments_);
-      addIneqalityConstraint_(cstr);
-      ineqSize_ += constraintSize(*cstr);
-    }
-  }
-
-  void LeastSquareSolver::addObjective(LinearConstraintPtr obj, SolvingRequirementsPtr req, double additionalWeight)
-  {
-    assert(req->priorityLevel().value() != 0);
-    assert(buildInProgress_ && "Attempting to add an objective without calling startBuild first");
-    
-    if (req->violationEvaluation().value() != requirements::ViolationEvaluationType::L2)
-    {
-      throw std::runtime_error("[LeastSquareSolver::addObjective]: least-squares only support L2 norm for violation evaluation");
-    }
-    AutoMap autoMap(obj, assignments_, objectiveToAssignments_);
-    addObjective_(obj, req, additionalWeight);
-    objSize_ += obj->size();
-  }
-
-
-  void LeastSquareSolver::setMinimumNorm()
-  {
-    assert(nObj_ == variables().totalSize());
-    if (!buildInProgress_)
-    {
-      throw std::runtime_error("[LeastSquareSolver]: attempting to add an objective without calling startBuild first");
-    }
-    setMinimumNorm_();
-  }
-
-  bool LeastSquareSolver::solve()
-  {
-    if (buildInProgress_)
-    {
-      throw std::runtime_error("[LeastSquareSolver]: attempting to solve while in build mode");
-    }
-
-    preAssignmentProcess_();
-    for (auto& a : assignments_)
-      a->assignment.run();
-    postAssignmentProcess_();
-
-    if (verbose_)
-      printProblemData_();
-
-    bool b = solve_();
-
-    if (verbose_ || !b)
-    {
-      printDiagnostic_();
-      if (verbose_)
-      {
-        std::cout << "[LeastSquareSolver::solve] solution: " << result_().transpose() << std::endl;
-      }
-    }
-
-    return b;
-  }
-
-  const Eigen::VectorXd& LeastSquareSolver::result() const
-  {
-    return result_();
-  }
-
-  int LeastSquareSolver::constraintSize(const constraint::abstract::LinearConstraint& c) const
-  {
-    if (c.type() != constraint::Type::DOUBLE_SIDED || handleDoubleSidedConstraint_())
-    {
-      return c.size();
-    }
-    else
-    {
-      return 2 * c.size();
-    }
-  }
-
-  void LeastSquareSolver::process(const internal::SolverEvents& se)
-  {
-    updateWeights(se);
-    auto impactRemove = processRemovedConstraints(se);
-    bool needMappingUpdate = updateVariables(se);
-    auto impactAdd = previewAddedConstraints(se);
-    auto impactResize = resize_(nObj_, nEq_, nIneq_, boundToAssignments_.size()>0 || se.addedBounds().size()>0);
-
-    if (needMappingUpdate)
-    {
-      for (auto& a : assignments_)
-        a->assignment.onUpdatedMapping(variables(), false);
-    }
-
-    // Update the target ranges when needed.
-    // We could be much more fine grain as added constraints could be placed last,
-    // and not update existing constraints if only constraints are added but this
-    // makes things much more complex.
-    auto impact = impactRemove || impactAdd;
-    auto updateTargetRange = [](const auto& map, int& cumSize, auto rangeProvider, auto sizeProvider)
-    {
-      for (const auto& ca : map)
-      {
-        Range r = rangeProvider(*ca.first);
-        for (auto& a : ca.second)
-          a->assignment.target().range().start = r.start;
-        cumSize += sizeProvider(*ca.first);
-      }
-    };
-
-    // We first reset all necessary size accumulators, as they can be used together for deciding ranges.
-    if (impact.equalityConstraints_) eqSize_ = 0;
-    if (impact.inequalityConstraints_) ineqSize_ = 0;
-    if (impact.objectives_) objSize_ = 0;
-
-    if (impact.equalityConstraints_)
-      updateTargetRange(equalityConstraintToAssignments_,
-                        eqSize_,
-                        [&](const auto& c) { return nextEqualityConstraintRange_(c); },
-                        [&](const auto& c) { return constraintSize(c); });
-
-    if (impact.inequalityConstraints_)
-      updateTargetRange(inequalityConstraintToAssignments_,
-                        ineqSize_,
-                        [&](const auto& c) { return nextInequalityConstraintRange_(c); },
-                        [&](const auto& c) { return constraintSize(c); });
-
-    int dummy;
-    if (impact.bounds_ || needMappingUpdate) // needMappingUpdate because a variable might have been added or removed
-      updateTargetRange(boundToAssignments_, 
-                        dummy, 
-                        [&](const auto& b) { return b.variables()[0]->getMappingIn(variables()); },
-                        [](const auto& b) { return 0; });
-
-    if (impact.objectives_)
-      updateTargetRange(objectiveToAssignments_,
-                        objSize_,
-                        [&](const auto& c) { return nextObjectiveRange_(c); },
-                        [&](const auto& c) { return c.size(); });
-
-    // Update the matrices and vectors of the target when needed
-    auto updateTargetData = [](const auto& map, auto updateFn)
-    {
-      for (const auto& ca : map)
-      {
-        for (auto& a : ca.second)
-          updateFn(a->assignment.target());
-      }
-    };
-
-    impact.orAssign(impactResize); // There are case where no resize are necessary (e.g. a constraint was removed and
-    applyImpactLogic(impact);      // another added with same size) but the target need to change. 
-    if (impact.equalityConstraints_)
-      updateTargetData(equalityConstraintToAssignments_, [&](auto& target) { updateEqualityTargetData(target); });
-
-    if (impact.inequalityConstraints_)
-      updateTargetData(inequalityConstraintToAssignments_, [&](auto& target) { updateInequalityTargetData(target); });
-
-    if (impact.bounds_)
-      updateTargetData(boundToAssignments_, [&](auto& target) { updateBoundTargetData(target); });
-
-    if (impact.objectives_)
-      updateTargetData(objectiveToAssignments_, [&](auto& target) { updateObjectiveTargetData(target); });
-
-    // Final update of the impacted mappings
-    if (needMappingUpdate)
-    {
-      for (auto& a : assignments_)
-        a->assignment.onUpdatedTarget(); // onUpdateTarget also takes into account the mapping change due to variable.
-    }
-    else
-    {
-      auto updateMapping = [](const auto& map)
-      {
-        for (const auto& ca : map)
-        {
-          for (auto& a : ca.second)
-            a->assignment.onUpdatedTarget();
-        }
-      };
-
-      if (impact.equalityConstraints_) updateMapping(equalityConstraintToAssignments_);
-      if (impact.inequalityConstraints_) updateMapping(inequalityConstraintToAssignments_);
-      if (impact.bounds_) updateMapping(boundToAssignments_);
-      if (impact.objectives_) updateMapping(objectiveToAssignments_);
-    }
-
-    processAddedConstraints(se);
-  }
-
-  void LeastSquareSolver::updateWeights(const internal::SolverEvents& se)
-  {
-    const auto& we = se.weightEvents();
-
-    for (const auto& e : we)
-    {
-      auto [c, scalar, vector] = e;
-
-      // We might have change of weights on constraints that were not added yet (because process of
-      // of weight arise before processing added constraints - if we'd process the weight after, we
-      // could have change of weight on removed constraints). Therefore we need to ignore constraints
-      // that were not found in the map.
-      auto it = objectiveToAssignments_.find(c);
-      if (it == objectiveToAssignments_.end()) continue;
-      auto& assignments = it->second;
-
-      for (auto& a : assignments)
-      {
-        bool needReprocess = (scalar && !a->assignment.changeScalarWeightIsAllowed())
-                          || (vector && !a->assignment.changeVectorWeightIsAllowed());
-        if (needReprocess)
-        {
-          a->assignment = tvm::scheme::internal::Assignment::reprocess(a->assignment, variables(), substitutions());
-        }
-        else
-        {
-          a->assignment.onUpdateWeights(scalar, vector);
-        }
-      }
-    }
-  }
-
-  bool LeastSquareSolver::updateVariables(const internal::SolverEvents& se)
-  {
-    for (const auto& v : se.removedVariables())
-    {
-      boundsOrder_.erase(v.get());
-    }
-    for (const auto& v : se.addedVariables())
-    {
-      boundsOrder_[v.get()] = {};
-    }
-    return (!(se.removedVariables().empty() && se.addedVariables().empty())) || se.hasHiddenVariableChange();
-  }
-
-  LeastSquareSolver::ImpactFromChanges LeastSquareSolver::processRemovedConstraints(const internal::SolverEvents& se)
-  {
-    for (const auto& c: se.removedConstraints())
-    {
-      if (c->isEquality())
-      {
-        nEq_ -= constraintSize(*c);
-        const auto& assignments = equalityConstraintToAssignments_[c.get()];
-        for (auto& a : assignments)
-          a->markedForRemoval = true;
-        equalityConstraintToAssignments_.erase(c.get());
-      }
-      else
-      {
-        nIneq_ -= constraintSize(*c);
-        const auto& assignments = inequalityConstraintToAssignments_[c.get()];
-        for (auto& a : assignments)
-          a->markedForRemoval = true;
-        inequalityConstraintToAssignments_.erase(c.get());
-      }
-    }
-
-    for (const auto& o : se.removedObjectives())
-    {
-      nObj_ -= o->size();
-      const auto& assignments = objectiveToAssignments_[o.get()];
-      for (auto& a : assignments)
-        a->markedForRemoval = true;
-      objectiveToAssignments_.erase(o.get());
-    }
-
-    for (const auto& b : se.removedBounds())
-    {
-      Variable* xb = b->variables()[0].get();
-      assert(boundsOrder_.find(xb) != boundsOrder_.end());
-      auto& first = boundsOrder_[xb];
-      if (first[0] == b.get() && variables().contains(*xb))
-      {
-        // We need to remove the bound that appears first, and the associated variable
-        // is still present in the variable vector. 
-        if (first.size() == 1)
-        {
-          // There will be no more bounds on xb.
-          auto& boundAssignment = boundToAssignments_[b.get()];
-          assert(boundAssignment.size() == 1);
-          // We retrieve the range on the bounds from the assignment because the variable
-          // mapping may have changed already but the assignment were not.
-          removeBounds_(boundAssignment[0]->assignment.target().range());
-        }
-        else
-        {
-          // We make the next bound constraint as first.
-          auto nextBound = first[1];
-          auto& nextBoundAssignments = boundToAssignments_[nextBound];
-          for (auto& a : nextBoundAssignments)
-            a->assignment = tvm::scheme::internal::Assignment::reprocess(a->assignment, b->variables()[0], true);
-        }
-        first.erase(first.begin());
-      }
-      else
-      {
-        auto it = std::find(first.begin(), first.end(), b.get());
-        first.erase(it);
-      }
-
-      const auto& assignments = boundToAssignments_[b.get()];
-      for (auto& a : assignments)
-        a->markedForRemoval = true;
-      boundToAssignments_.erase(b.get());
-    }
-
-    //clear assignements
-    auto it = std::remove_if(assignments_.begin(), assignments_.end(), [](const auto& it) {return it->markedForRemoval; });
-    assignments_.erase(it, assignments_.end());
-
-    ImpactFromChanges impact = { !se.removedConstraints().empty(), !se.removedConstraints().empty(), !se.removedBounds().empty(), !se.removedObjectives().empty() };
-    applyImpactLogic(impact);
-    return impact;
-  }
-
-  LeastSquareSolver::ImpactFromChanges LeastSquareSolver::previewAddedConstraints(const internal::SolverEvents& se)
-  {
-    // When used as part of process, the following code will generate target ranges
-    // outside of the matrices bounds. It relies on the fact that the mapping of the
-    // assignment is updated after.
-    eqSize_ = nEq_;
-    ineqSize_ = nIneq_;
-    objSize_ = nObj_;
-    for (const auto& c : se.addedConstraints())
-    {
-      if (c->isEquality())
-        nEq_ += constraintSize(*c);
-      else
-        nIneq_ += constraintSize(*c);
-    }
-
-    for (const auto& o : se.addedObjectives())
-      nObj_ += o.c->size();
-
-    ImpactFromChanges impact = { nEq_ != eqSize_, nIneq_ != ineqSize_, false, !se.addedObjectives().empty() };
-    applyImpactLogic(impact);
-    return impact;
-  }
-
-  void LeastSquareSolver::processAddedConstraints(const internal::SolverEvents& se)
-  {
-    buildInProgress_ = true;
-    for (const auto& c : se.addedConstraints())
-      addConstraint(c);
-
-    for (const auto& b : se.addedBounds())
-      addBound(b);
-
-    for (const auto& o : se.addedObjectives())
-      addObjective(o.c, o.req, o.scalarizationWeight);
-
-    assert(nObj_ == objSize_);
-    assert(nEq_ == eqSize_);
-    assert(nIneq_ == ineqSize_);
-    buildInProgress_ = false;
-  }
-
-  LeastSquareSolver::ImpactFromChanges LeastSquareSolver::ImpactFromChanges::operator||(bool b)
-  {
-    return { this->equalityConstraints_ || b,
-             this->inequalityConstraints_ || b,
-             this->bounds_ || b,
-             this->objectives_ || b };
-  }
-
-  LeastSquareSolver::ImpactFromChanges LeastSquareSolver::ImpactFromChanges::operator||(const ImpactFromChanges& other)
-  {
-    return { this->equalityConstraints_ || other.equalityConstraints_,
-             this->inequalityConstraints_ || other.inequalityConstraints_,
-             this->bounds_ || other.bounds_,
-             this->objectives_ || other.objectives_ };
-  }
-
-  LeastSquareSolver::ImpactFromChanges& LeastSquareSolver::ImpactFromChanges::orAssign(const ImpactFromChanges& other)
-  {
-    *this = *this || other;
-    return *this;
-  }
-
-  void LeastSquareSolver::applyImpactLogic(ImpactFromChanges& impact)
-  {
-    // do nothing;
+    AutoMap autoMap(cstr, assignments_, inequalityConstraintToAssignments_);
+    addIneqalityConstraint_(cstr);
+    ineqSize_ += constraintSize(*cstr);
   }
 }
+
+void LeastSquareSolver::addObjective(LinearConstraintPtr obj, SolvingRequirementsPtr req, double additionalWeight)
+{
+  assert(req->priorityLevel().value() != 0);
+  assert(buildInProgress_ && "Attempting to add an objective without calling startBuild first");
+
+  if(req->violationEvaluation().value() != requirements::ViolationEvaluationType::L2)
+  {
+    throw std::runtime_error(
+        "[LeastSquareSolver::addObjective]: least-squares only support L2 norm for violation evaluation");
+  }
+  AutoMap autoMap(obj, assignments_, objectiveToAssignments_);
+  addObjective_(obj, req, additionalWeight);
+  objSize_ += obj->size();
+}
+
+void LeastSquareSolver::setMinimumNorm()
+{
+  assert(nObj_ == variables().totalSize());
+  if(!buildInProgress_)
+  {
+    throw std::runtime_error("[LeastSquareSolver]: attempting to add an objective without calling startBuild first");
+  }
+  setMinimumNorm_();
+}
+
+bool LeastSquareSolver::solve()
+{
+  if(buildInProgress_)
+  {
+    throw std::runtime_error("[LeastSquareSolver]: attempting to solve while in build mode");
+  }
+
+  preAssignmentProcess_();
+  for(auto & a : assignments_)
+    a->assignment.run();
+  postAssignmentProcess_();
+
+  if(verbose_)
+    printProblemData_();
+
+  bool b = solve_();
+
+  if(verbose_ || !b)
+  {
+    printDiagnostic_();
+    if(verbose_)
+    {
+      std::cout << "[LeastSquareSolver::solve] solution: " << result_().transpose() << std::endl;
+    }
+  }
+
+  return b;
+}
+
+const Eigen::VectorXd & LeastSquareSolver::result() const { return result_(); }
+
+int LeastSquareSolver::constraintSize(const constraint::abstract::LinearConstraint & c) const
+{
+  if(c.type() != constraint::Type::DOUBLE_SIDED || handleDoubleSidedConstraint_())
+  {
+    return c.size();
+  }
+  else
+  {
+    return 2 * c.size();
+  }
+}
+
+void LeastSquareSolver::process(const internal::SolverEvents & se)
+{
+  updateWeights(se);
+  auto impactRemove = processRemovedConstraints(se);
+  bool needMappingUpdate = updateVariables(se);
+  auto impactAdd = previewAddedConstraints(se);
+  auto impactResize = resize_(nObj_, nEq_, nIneq_, boundToAssignments_.size() > 0 || se.addedBounds().size() > 0);
+
+  if(needMappingUpdate)
+  {
+    for(auto & a : assignments_)
+      a->assignment.onUpdatedMapping(variables(), false);
+  }
+
+  // Update the target ranges when needed.
+  // We could be much more fine grain as added constraints could be placed last,
+  // and not update existing constraints if only constraints are added but this
+  // makes things much more complex.
+  auto impact = impactRemove || impactAdd;
+  auto updateTargetRange = [](const auto & map, int & cumSize, auto rangeProvider, auto sizeProvider) {
+    for(const auto & ca : map)
+    {
+      Range r = rangeProvider(*ca.first);
+      for(auto & a : ca.second)
+        a->assignment.target().range().start = r.start;
+      cumSize += sizeProvider(*ca.first);
+    }
+  };
+
+  // We first reset all necessary size accumulators, as they can be used together for deciding ranges.
+  if(impact.equalityConstraints_)
+    eqSize_ = 0;
+  if(impact.inequalityConstraints_)
+    ineqSize_ = 0;
+  if(impact.objectives_)
+    objSize_ = 0;
+
+  if(impact.equalityConstraints_)
+    updateTargetRange(equalityConstraintToAssignments_, eqSize_,
+                      [&](const auto & c) { return nextEqualityConstraintRange_(c); },
+                      [&](const auto & c) { return constraintSize(c); });
+
+  if(impact.inequalityConstraints_)
+    updateTargetRange(inequalityConstraintToAssignments_, ineqSize_,
+                      [&](const auto & c) { return nextInequalityConstraintRange_(c); },
+                      [&](const auto & c) { return constraintSize(c); });
+
+  int dummy;
+  if(impact.bounds_ || needMappingUpdate) // needMappingUpdate because a variable might have been added or removed
+    updateTargetRange(boundToAssignments_, dummy,
+                      [&](const auto & b) { return b.variables()[0]->getMappingIn(variables()); },
+                      [](const auto & b) { return 0; });
+
+  if(impact.objectives_)
+    updateTargetRange(objectiveToAssignments_, objSize_, [&](const auto & c) { return nextObjectiveRange_(c); },
+                      [&](const auto & c) { return c.size(); });
+
+  // Update the matrices and vectors of the target when needed
+  auto updateTargetData = [](const auto & map, auto updateFn) {
+    for(const auto & ca : map)
+    {
+      for(auto & a : ca.second)
+        updateFn(a->assignment.target());
+    }
+  };
+
+  impact.orAssign(impactResize); // There are case where no resize are necessary (e.g. a constraint was removed and
+  applyImpactLogic(impact); // another added with same size) but the target need to change.
+  if(impact.equalityConstraints_)
+    updateTargetData(equalityConstraintToAssignments_, [&](auto & target) { updateEqualityTargetData(target); });
+
+  if(impact.inequalityConstraints_)
+    updateTargetData(inequalityConstraintToAssignments_, [&](auto & target) { updateInequalityTargetData(target); });
+
+  if(impact.bounds_)
+    updateTargetData(boundToAssignments_, [&](auto & target) { updateBoundTargetData(target); });
+
+  if(impact.objectives_)
+    updateTargetData(objectiveToAssignments_, [&](auto & target) { updateObjectiveTargetData(target); });
+
+  // Final update of the impacted mappings
+  if(needMappingUpdate)
+  {
+    for(auto & a : assignments_)
+      a->assignment.onUpdatedTarget(); // onUpdateTarget also takes into account the mapping change due to variable.
+  }
+  else
+  {
+    auto updateMapping = [](const auto & map) {
+      for(const auto & ca : map)
+      {
+        for(auto & a : ca.second)
+          a->assignment.onUpdatedTarget();
+      }
+    };
+
+    if(impact.equalityConstraints_)
+      updateMapping(equalityConstraintToAssignments_);
+    if(impact.inequalityConstraints_)
+      updateMapping(inequalityConstraintToAssignments_);
+    if(impact.bounds_)
+      updateMapping(boundToAssignments_);
+    if(impact.objectives_)
+      updateMapping(objectiveToAssignments_);
+  }
+
+  processAddedConstraints(se);
+}
+
+void LeastSquareSolver::updateWeights(const internal::SolverEvents & se)
+{
+  const auto & we = se.weightEvents();
+
+  for(const auto & e : we)
+  {
+    auto [c, scalar, vector] = e;
+
+    // We might have change of weights on constraints that were not added yet (because process of
+    // of weight arise before processing added constraints - if we'd process the weight after, we
+    // could have change of weight on removed constraints). Therefore we need to ignore constraints
+    // that were not found in the map.
+    auto it = objectiveToAssignments_.find(c);
+    if(it == objectiveToAssignments_.end())
+      continue;
+    auto & assignments = it->second;
+
+    for(auto & a : assignments)
+    {
+      bool needReprocess = (scalar && !a->assignment.changeScalarWeightIsAllowed())
+                           || (vector && !a->assignment.changeVectorWeightIsAllowed());
+      if(needReprocess)
+      {
+        a->assignment = tvm::scheme::internal::Assignment::reprocess(a->assignment, variables(), substitutions());
+      }
+      else
+      {
+        a->assignment.onUpdateWeights(scalar, vector);
+      }
+    }
+  }
+}
+
+bool LeastSquareSolver::updateVariables(const internal::SolverEvents & se)
+{
+  for(const auto & v : se.removedVariables())
+  {
+    boundsOrder_.erase(v.get());
+  }
+  for(const auto & v : se.addedVariables())
+  {
+    boundsOrder_[v.get()] = {};
+  }
+  return (!(se.removedVariables().empty() && se.addedVariables().empty())) || se.hasHiddenVariableChange();
+}
+
+LeastSquareSolver::ImpactFromChanges LeastSquareSolver::processRemovedConstraints(const internal::SolverEvents & se)
+{
+  for(const auto & c : se.removedConstraints())
+  {
+    if(c->isEquality())
+    {
+      nEq_ -= constraintSize(*c);
+      const auto & assignments = equalityConstraintToAssignments_[c.get()];
+      for(auto & a : assignments)
+        a->markedForRemoval = true;
+      equalityConstraintToAssignments_.erase(c.get());
+    }
+    else
+    {
+      nIneq_ -= constraintSize(*c);
+      const auto & assignments = inequalityConstraintToAssignments_[c.get()];
+      for(auto & a : assignments)
+        a->markedForRemoval = true;
+      inequalityConstraintToAssignments_.erase(c.get());
+    }
+  }
+
+  for(const auto & o : se.removedObjectives())
+  {
+    nObj_ -= o->size();
+    const auto & assignments = objectiveToAssignments_[o.get()];
+    for(auto & a : assignments)
+      a->markedForRemoval = true;
+    objectiveToAssignments_.erase(o.get());
+  }
+
+  for(const auto & b : se.removedBounds())
+  {
+    Variable * xb = b->variables()[0].get();
+    assert(boundsOrder_.find(xb) != boundsOrder_.end());
+    auto & first = boundsOrder_[xb];
+    if(first[0] == b.get() && variables().contains(*xb))
+    {
+      // We need to remove the bound that appears first, and the associated variable
+      // is still present in the variable vector.
+      if(first.size() == 1)
+      {
+        // There will be no more bounds on xb.
+        auto & boundAssignment = boundToAssignments_[b.get()];
+        assert(boundAssignment.size() == 1);
+        // We retrieve the range on the bounds from the assignment because the variable
+        // mapping may have changed already but the assignment were not.
+        removeBounds_(boundAssignment[0]->assignment.target().range());
+      }
+      else
+      {
+        // We make the next bound constraint as first.
+        auto nextBound = first[1];
+        auto & nextBoundAssignments = boundToAssignments_[nextBound];
+        for(auto & a : nextBoundAssignments)
+          a->assignment = tvm::scheme::internal::Assignment::reprocess(a->assignment, b->variables()[0], true);
+      }
+      first.erase(first.begin());
+    }
+    else
+    {
+      auto it = std::find(first.begin(), first.end(), b.get());
+      first.erase(it);
+    }
+
+    const auto & assignments = boundToAssignments_[b.get()];
+    for(auto & a : assignments)
+      a->markedForRemoval = true;
+    boundToAssignments_.erase(b.get());
+  }
+
+  // clear assignements
+  auto it =
+      std::remove_if(assignments_.begin(), assignments_.end(), [](const auto & it) { return it->markedForRemoval; });
+  assignments_.erase(it, assignments_.end());
+
+  ImpactFromChanges impact = {!se.removedConstraints().empty(), !se.removedConstraints().empty(),
+                              !se.removedBounds().empty(), !se.removedObjectives().empty()};
+  applyImpactLogic(impact);
+  return impact;
+}
+
+LeastSquareSolver::ImpactFromChanges LeastSquareSolver::previewAddedConstraints(const internal::SolverEvents & se)
+{
+  // When used as part of process, the following code will generate target ranges
+  // outside of the matrices bounds. It relies on the fact that the mapping of the
+  // assignment is updated after.
+  eqSize_ = nEq_;
+  ineqSize_ = nIneq_;
+  objSize_ = nObj_;
+  for(const auto & c : se.addedConstraints())
+  {
+    if(c->isEquality())
+      nEq_ += constraintSize(*c);
+    else
+      nIneq_ += constraintSize(*c);
+  }
+
+  for(const auto & o : se.addedObjectives())
+    nObj_ += o.c->size();
+
+  ImpactFromChanges impact = {nEq_ != eqSize_, nIneq_ != ineqSize_, false, !se.addedObjectives().empty()};
+  applyImpactLogic(impact);
+  return impact;
+}
+
+void LeastSquareSolver::processAddedConstraints(const internal::SolverEvents & se)
+{
+  buildInProgress_ = true;
+  for(const auto & c : se.addedConstraints())
+    addConstraint(c);
+
+  for(const auto & b : se.addedBounds())
+    addBound(b);
+
+  for(const auto & o : se.addedObjectives())
+    addObjective(o.c, o.req, o.scalarizationWeight);
+
+  assert(nObj_ == objSize_);
+  assert(nEq_ == eqSize_);
+  assert(nIneq_ == ineqSize_);
+  buildInProgress_ = false;
+}
+
+LeastSquareSolver::ImpactFromChanges LeastSquareSolver::ImpactFromChanges::operator||(bool b)
+{
+  return {this->equalityConstraints_ || b, this->inequalityConstraints_ || b, this->bounds_ || b,
+          this->objectives_ || b};
+}
+
+LeastSquareSolver::ImpactFromChanges LeastSquareSolver::ImpactFromChanges::operator||(const ImpactFromChanges & other)
+{
+  return {this->equalityConstraints_ || other.equalityConstraints_,
+          this->inequalityConstraints_ || other.inequalityConstraints_, this->bounds_ || other.bounds_,
+          this->objectives_ || other.objectives_};
+}
+
+LeastSquareSolver::ImpactFromChanges & LeastSquareSolver::ImpactFromChanges::orAssign(const ImpactFromChanges & other)
+{
+  *this = *this || other;
+  return *this;
+}
+
+void LeastSquareSolver::applyImpactLogic(ImpactFromChanges & impact)
+{
+  // do nothing;
+}
+} // namespace tvm::solver::abstract

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -22,8 +22,7 @@ public:
           LeastSquareSolver::AssignmentVector & observed,
           LeastSquareSolver::MapToAssignment & target)
   : observedSize_(observed.size()), observed_(observed), target_(target[cstr.get()])
-  {
-  }
+  {}
   ~AutoMap()
   {
     for(size_t i = observedSize_; i < observed_.size(); ++i)
@@ -42,8 +41,7 @@ namespace tvm::solver::abstract
 LeastSquareSolver::LeastSquareSolver(bool verbose)
 : objSize_(-1), eqSize_(-1), ineqSize_(-1), buildInProgress_(false), subs_(nullptr), verbose_(verbose),
   variables_(nullptr)
-{
-}
+{}
 
 void LeastSquareSolver::startBuild(const VariableVector & x,
                                    int nObj,

--- a/src/solver/QLDLeastSquareSolver.cpp
+++ b/src/solver/QLDLeastSquareSolver.cpp
@@ -15,8 +15,7 @@ QLDLeastSquareSolver::QLDLeastSquareSolver(const QLDLSSolverOptions & options)
 : LeastSquareSolver(options.verbose().value()), Aineq_(A_.bottomRows(0)), bineq_(b_.tail(0)),
   big_number_(options.big_number().value()), cholesky_(options.cholesky().value()),
   choleskyDamping_(options.choleskyDamping().value()), eps_(options.eps().value()), autoMinNorm_(false)
-{
-}
+{}
 
 void QLDLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool)
 {
@@ -225,8 +224,7 @@ std::unique_ptr<abstract::LSSolverFactory> QLDLSSolverFactory::clone() const
 }
 
 QLDLSSolverFactory::QLDLSSolverFactory(const QLDLSSolverOptions & options) : LSSolverFactory("qld"), options_(options)
-{
-}
+{}
 
 std::unique_ptr<abstract::LeastSquareSolver> QLDLSSolverFactory::createSolver() const
 {

--- a/src/solver/QLDLeastSquareSolver.cpp
+++ b/src/solver/QLDLeastSquareSolver.cpp
@@ -11,245 +11,228 @@ namespace tvm
 
 namespace solver
 {
-  QLDLeastSquareSolver::QLDLeastSquareSolver(const QLDLSSolverOptions& options)
-    : LeastSquareSolver(options.verbose().value())
-    , Aineq_(A_.bottomRows(0))
-    , bineq_(b_.tail(0))
-    , big_number_(options.big_number().value())
-    , cholesky_(options.cholesky().value())
-    , choleskyDamping_(options.choleskyDamping().value())
-    , eps_(options.eps().value())
-    , autoMinNorm_(false)
+QLDLeastSquareSolver::QLDLeastSquareSolver(const QLDLSSolverOptions & options)
+: LeastSquareSolver(options.verbose().value()), Aineq_(A_.bottomRows(0)), bineq_(b_.tail(0)),
+  big_number_(options.big_number().value()), cholesky_(options.cholesky().value()),
+  choleskyDamping_(options.choleskyDamping().value()), eps_(options.eps().value()), autoMinNorm_(false)
+{
+}
+
+void QLDLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool)
+{
+  resize_(nObj, nEq, nIneq, true);
+
+  autoMinNorm_ = false;
+}
+
+QLDLeastSquareSolver::ImpactFromChanges QLDLeastSquareSolver::resize_(int nObj, int nEq, int nIneq, bool)
+{
+  int n = variables().totalSize();
+  int nCstr = nEq + nIneq;
+  underspecifiedObj_ = nObj < n;
+  ImpactFromChanges impact;
+
+  if(cholesky_ && underspecifiedObj_)
   {
+    impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj + n, n);
+    D_.resize(nObj + n, n);
+    D_.setZero();
+    D_.bottomRows(n).diagonal().setConstant(choleskyDamping_);
+  }
+  else
+  {
+    impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj, n);
+    D_.resize(nObj, n);
+    D_.setZero();
+  }
+  e_.resize(nObj);
+  if(!cholesky_)
+    Q_.resize(n, n);
+  c_.resize(n);
+  impact.equalityConstraints_ = ImpactFromChanges::willReallocate(A_, nCstr, n);
+  A_.resize(nCstr, n);
+  A_.setZero();
+  b_.resize(nCstr);
+  impact.bounds_ = ImpactFromChanges::willReallocate(xl_, n);
+  xl_ = Eigen::VectorXd::Constant(n, -big_number_);
+  xu_ = Eigen::VectorXd::Constant(n, +big_number_);
+  new(&Aineq_) MatrixXdBottom(A_.bottomRows(nIneq));
+  new(&bineq_) VectorXdTail(b_.tail(nIneq));
+  if(underspecifiedObj_)
+    qld_.problem(n, nEq, nIneq, n + nObj);
+  else
+    qld_.problem(n, nEq, nIneq, cholesky_ ? nObj : n);
+  if(cholesky_)
+  {
+    if(underspecifiedObj_)
+      new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj + n, n);
+    else
+      new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj, n);
   }
 
-  void QLDLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool)
+  impact.inequalityConstraints_ = impact.equalityConstraints_;
+  return impact;
+}
+
+void QLDLeastSquareSolver::addBound_(LinearConstraintPtr bound, RangePtr range, bool first)
+{
+  scheme::internal::AssignmentTarget target(range, xl_, xu_);
+  addAssignement(bound, target, bound->variables()[0], first);
+}
+
+void QLDLeastSquareSolver::addEqualityConstraint_(LinearConstraintPtr cstr)
+{
+  RangePtr r = std::make_shared<Range>(nextEqualityConstraintRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, A_, b_, constraint::Type::EQUAL, constraint::RHS::OPPOSITE);
+  addAssignement(cstr, nullptr, target, variables(), substitutions());
+}
+
+void QLDLeastSquareSolver::addIneqalityConstraint_(LinearConstraintPtr cstr)
+{
+  RangePtr r = std::make_shared<Range>(nextInequalityConstraintRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, Aineq_, bineq_, constraint::Type::GREATER_THAN,
+                                            constraint::RHS::OPPOSITE);
+  addAssignement(cstr, nullptr, target, variables(), substitutions());
+}
+
+void QLDLeastSquareSolver::addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight)
+{
+  RangePtr r = std::make_shared<Range>(nextObjectiveRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, D_, e_, constraint::Type::EQUAL, constraint::RHS::OPPOSITE);
+  addAssignement(cstr, req, target, variables(), substitutions(), additionalWeight);
+}
+
+void QLDLeastSquareSolver::setMinimumNorm_()
+{
+  autoMinNorm_ = true;
+  Q_.setIdentity();
+  c_.setZero();
+}
+
+void QLDLeastSquareSolver::preAssignmentProcess_() {}
+
+void QLDLeastSquareSolver::postAssignmentProcess_()
+{
+  // QLD does not solve least-square cost, but quadratic cost.
+  // We then either need to form the quadratic cost, or to get the Cholesky
+  // decomposition of this quadratic cost.
+  if(!autoMinNorm_)
   {
-    resize_(nObj, nEq, nIneq, true);
+    // c = D^T e
+    c_.noalias() = D_.topRows(nObj_).transpose() * e_;
 
-    autoMinNorm_ = false;
+    if(cholesky_)
+    {
+      // The cholesky decomposition of Q = D^T D is given by the R factor of
+      // the QR decomposition of D: if D = U R with U orthogonal, D^T D = R^T R.
+      qr_.compute(D_);
+    }
+    else
+    {
+      // Q = D^T D
+      Q_.noalias() = D_.transpose() * D_; // TODO check if this can be optimized: QLD might need only half the matrix
+    }
   }
+}
 
-  QLDLeastSquareSolver::ImpactFromChanges QLDLeastSquareSolver::resize_(int nObj, int nEq, int nIneq, bool)
+bool QLDLeastSquareSolver::solve_()
+{
+  if(cholesky_ && !autoMinNorm_)
   {
     int n = variables().totalSize();
-    int nCstr = nEq + nIneq;
-    underspecifiedObj_ = nObj < n;
-    ImpactFromChanges impact;
-
-    if (cholesky_ && underspecifiedObj_)
-    {
-      impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj + n, n);
-      D_.resize(nObj + n, n);
-      D_.setZero();
-      D_.bottomRows(n).diagonal().setConstant(choleskyDamping_);
-    }
-    else
-    {
-      impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj, n);
-      D_.resize(nObj, n);
-      D_.setZero();
-    }
-    e_.resize(nObj);
-    if (!cholesky_)
-      Q_.resize(n, n);
-    c_.resize(n);
-    impact.equalityConstraints_ = ImpactFromChanges::willReallocate(A_, nCstr, n);
-    A_.resize(nCstr, n);
-    A_.setZero();
-    b_.resize(nCstr);
-    impact.bounds_ = ImpactFromChanges::willReallocate(xl_, n);
-    xl_ = Eigen::VectorXd::Constant(n, -big_number_);
-    xu_ = Eigen::VectorXd::Constant(n, +big_number_);
-    new(&Aineq_) MatrixXdBottom(A_.bottomRows(nIneq));
-    new(&bineq_) VectorXdTail(b_.tail(nIneq));
-    if (underspecifiedObj_)
-      qld_.problem(n, nEq, nIneq, n + nObj);
-    else
-      qld_.problem(n, nEq, nIneq, cholesky_?nObj:n);
-    if (cholesky_)
-    {
-      if (underspecifiedObj_)
-        new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj + n, n);
-      else
-        new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj, n);
-    }
-
-    impact.inequalityConstraints_ = impact.equalityConstraints_;
-    return impact;
+    return qld_.solve(qr_.matrixQR().topRows(n), c_, A_, b_, xl_, xu_, nEq_, true, eps_);
   }
-
-  void QLDLeastSquareSolver::addBound_(LinearConstraintPtr bound, RangePtr range, bool first)
+  else
   {
-    scheme::internal::AssignmentTarget target(range, xl_, xu_);
-    addAssignement(bound, target, bound->variables()[0], first);
+    return qld_.solve(Q_, c_, A_, b_, xl_, xu_, nEq_, false, eps_);
   }
-
-  void QLDLeastSquareSolver::addEqualityConstraint_(LinearConstraintPtr cstr)
-  {
-    RangePtr r = std::make_shared<Range>(nextEqualityConstraintRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, A_, b_, constraint::Type::EQUAL, constraint::RHS::OPPOSITE);
-    addAssignement(cstr, nullptr, target, variables(), substitutions());
-  }
-
-  void QLDLeastSquareSolver::addIneqalityConstraint_(LinearConstraintPtr cstr)
-  {
-    RangePtr r = std::make_shared<Range>(nextInequalityConstraintRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, Aineq_, bineq_, constraint::Type::GREATER_THAN, constraint::RHS::OPPOSITE);
-    addAssignement(cstr, nullptr, target, variables(), substitutions());
-  }
-
-  void QLDLeastSquareSolver::addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight)
-  {
-    RangePtr r = std::make_shared<Range>(nextObjectiveRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, D_, e_, constraint::Type::EQUAL, constraint::RHS::OPPOSITE);
-    addAssignement(cstr, req, target, variables(), substitutions(), additionalWeight);
-  }
-
-  void QLDLeastSquareSolver::setMinimumNorm_()
-  {
-    autoMinNorm_ = true;
-    Q_.setIdentity();
-    c_.setZero();
-  }
-
-  void QLDLeastSquareSolver::preAssignmentProcess_()
-  {
-  }
-
-  void QLDLeastSquareSolver::postAssignmentProcess_()
-  {
-    // QLD does not solve least-square cost, but quadratic cost.
-    // We then either need to form the quadratic cost, or to get the Cholesky
-    // decomposition of this quadratic cost.
-    if (!autoMinNorm_)
-    {
-      // c = D^T e
-      c_.noalias() = D_.topRows(nObj_).transpose() * e_;
-
-      if (cholesky_)
-      {
-        // The cholesky decomposition of Q = D^T D is given by the R factor of
-        // the QR decomposition of D: if D = U R with U orthogonal, D^T D = R^T R.
-        qr_.compute(D_);
-      }
-      else
-      {
-        // Q = D^T D
-        Q_.noalias() = D_.transpose() * D_;   //TODO check if this can be optimized: QLD might need only half the matrix
-      }
-    }
-  }
-
-  bool QLDLeastSquareSolver::solve_()
-  {
-    if (cholesky_ && !autoMinNorm_)
-    {
-      int n = variables().totalSize();
-      return qld_.solve(qr_.matrixQR().topRows(n), c_,
-                        A_, b_,
-                        xl_, xu_,
-                        nEq_,
-                        true, eps_);
-    }
-    else
-    {
-      return qld_.solve(Q_, c_,
-                        A_, b_,
-                        xl_, xu_,
-                        nEq_,
-                        false, eps_);
-    }
-  }
-
-  const Eigen::VectorXd& QLDLeastSquareSolver::result_() const
-  {
-    return qld_.result();
-  }
-
-  Range QLDLeastSquareSolver::nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { eqSize_, cstr.size() };
-  }
-
-  Range QLDLeastSquareSolver::nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { ineqSize_, constraintSize(cstr) };
-  }
-
-  Range QLDLeastSquareSolver::nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { objSize_, cstr.size() };
-  }
-
-  void QLDLeastSquareSolver::removeBounds_(const Range& range)
-  {
-    xl_.segment(range.start, range.dim).setConstant(-big_number_);
-    xu_.segment(range.start, range.dim).setConstant(+big_number_);
-  }
-
-  void QLDLeastSquareSolver::updateEqualityTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(A_, b_);
-  }
-
-  void QLDLeastSquareSolver::updateInequalityTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(Aineq_, bineq_);
-  }
-
-  void QLDLeastSquareSolver::updateBoundTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(VectorRef(xl_), xu_);
-  }
-
-  void QLDLeastSquareSolver::updateObjectiveTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(D_, e_);
-  }
-
-  void QLDLeastSquareSolver::applyImpactLogic(ImpactFromChanges& impact)
-  {
-    if (impact.equalityConstraints_) impact.inequalityConstraints_ = true;
-  }
-
-  void QLDLeastSquareSolver::printProblemData_() const
-  {
-    if (cholesky_)
-    {
-      int n = variables().totalSize();
-      std::cout << "R =\n" << qr_.matrixQR().topRows(n).template triangularView<Eigen::Upper>().toDenseMatrix() << std::endl;
-    }
-    else
-      std::cout << "Q =\n" << Q_ << std::endl;
-    std::cout << "c = " << c_.transpose() << std::endl;
-    std::cout << "A =\n" << A_ << std::endl;
-    std::cout << "b = " << b_.transpose() << std::endl;
-    std::cout << "xl = " << xl_.transpose() << std::endl;
-    std::cout << "xu = " << xu_.transpose() << std::endl;
-  }
-
-  void QLDLeastSquareSolver::printDiagnostic_() const
-  {
-    std::cout << "QLD fail code = " << qld_.fail() << " (0 is success)" << std::endl;
-  }
-
-  std::unique_ptr<abstract::LSSolverFactory> QLDLSSolverFactory::clone() const
-  {
-    return std::make_unique<QLDLSSolverFactory>(*this);
-  }
-
-  QLDLSSolverFactory::QLDLSSolverFactory(const QLDLSSolverOptions& options)
-    : LSSolverFactory("qld")
-    , options_(options)
-  {
-  }
-
-  std::unique_ptr<abstract::LeastSquareSolver> QLDLSSolverFactory::createSolver() const
-  {
-    return std::make_unique<QLDLeastSquareSolver>(options_);
-  }
-
 }
 
+const Eigen::VectorXd & QLDLeastSquareSolver::result_() const { return qld_.result(); }
+
+Range QLDLeastSquareSolver::nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {eqSize_, cstr.size()};
 }
+
+Range QLDLeastSquareSolver::nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {ineqSize_, constraintSize(cstr)};
+}
+
+Range QLDLeastSquareSolver::nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {objSize_, cstr.size()};
+}
+
+void QLDLeastSquareSolver::removeBounds_(const Range & range)
+{
+  xl_.segment(range.start, range.dim).setConstant(-big_number_);
+  xu_.segment(range.start, range.dim).setConstant(+big_number_);
+}
+
+void QLDLeastSquareSolver::updateEqualityTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(A_, b_);
+}
+
+void QLDLeastSquareSolver::updateInequalityTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(Aineq_, bineq_);
+}
+
+void QLDLeastSquareSolver::updateBoundTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(VectorRef(xl_), xu_);
+}
+
+void QLDLeastSquareSolver::updateObjectiveTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(D_, e_);
+}
+
+void QLDLeastSquareSolver::applyImpactLogic(ImpactFromChanges & impact)
+{
+  if(impact.equalityConstraints_)
+    impact.inequalityConstraints_ = true;
+}
+
+void QLDLeastSquareSolver::printProblemData_() const
+{
+  if(cholesky_)
+  {
+    int n = variables().totalSize();
+    std::cout << "R =\n"
+              << qr_.matrixQR().topRows(n).template triangularView<Eigen::Upper>().toDenseMatrix() << std::endl;
+  }
+  else
+    std::cout << "Q =\n" << Q_ << std::endl;
+  std::cout << "c = " << c_.transpose() << std::endl;
+  std::cout << "A =\n" << A_ << std::endl;
+  std::cout << "b = " << b_.transpose() << std::endl;
+  std::cout << "xl = " << xl_.transpose() << std::endl;
+  std::cout << "xu = " << xu_.transpose() << std::endl;
+}
+
+void QLDLeastSquareSolver::printDiagnostic_() const
+{
+  std::cout << "QLD fail code = " << qld_.fail() << " (0 is success)" << std::endl;
+}
+
+std::unique_ptr<abstract::LSSolverFactory> QLDLSSolverFactory::clone() const
+{
+  return std::make_unique<QLDLSSolverFactory>(*this);
+}
+
+QLDLSSolverFactory::QLDLSSolverFactory(const QLDLSSolverOptions & options) : LSSolverFactory("qld"), options_(options)
+{
+}
+
+std::unique_ptr<abstract::LeastSquareSolver> QLDLSSolverFactory::createSolver() const
+{
+  return std::make_unique<QLDLeastSquareSolver>(options_);
+}
+
+} // namespace solver
+
+} // namespace tvm

--- a/src/solver/QuadprogLeastSquareSolver.cpp
+++ b/src/solver/QuadprogLeastSquareSolver.cpp
@@ -8,299 +8,294 @@
 
 #include <iostream>
 
-
 namespace tvm
 {
 
 namespace solver
 {
-  QuadprogLeastSquareSolver::QuadprogLeastSquareSolver(const QuadprogLSSolverOptions& options)
-    : LeastSquareSolver(options.verbose().value())
-    , Aineq_(A_.middleRows(0,0))
-    , bineq_(b_.segment(0, 0))
-    , xl_(b_.segment(0, 0))
-    , xu_(b_.segment(0, 0))
-    , big_number_(options.big_number().value())
-    , cholesky_(options.cholesky().value())
-    , choleskyDamping_(options.choleskyDamping().value())
-    , damping_(options.damping().value())
-    , autoMinNorm_(false)
+QuadprogLeastSquareSolver::QuadprogLeastSquareSolver(const QuadprogLSSolverOptions & options)
+: LeastSquareSolver(options.verbose().value()), Aineq_(A_.middleRows(0, 0)), bineq_(b_.segment(0, 0)),
+  xl_(b_.segment(0, 0)), xu_(b_.segment(0, 0)), big_number_(options.big_number().value()),
+  cholesky_(options.cholesky().value()), choleskyDamping_(options.choleskyDamping().value()),
+  damping_(options.damping().value()), autoMinNorm_(false)
+{
+}
+
+void QuadprogLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds)
+{
+  resize_(nObj, nEq, nIneq, useBounds);
+
+  autoMinNorm_ = false;
+}
+
+QuadprogLeastSquareSolver::ImpactFromChanges QuadprogLeastSquareSolver::resize_(int nObj,
+                                                                                int nEq,
+                                                                                int nIneq,
+                                                                                bool useBounds)
+{
+  int n = variables().totalSize();
+  int nCstr = nEq + nIneq;
+  underspecifiedObj_ = nObj < n;
+  ImpactFromChanges impact;
+
+  if(cholesky_ && underspecifiedObj_)
   {
+    impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj + n, n);
+    D_.resize(nObj + n, n);
+    D_.setZero();
+    D_.bottomRows(n).diagonal().setConstant(choleskyDamping_);
+  }
+  else
+  {
+    impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj, n);
+    D_.resize(nObj, n);
+    D_.setZero();
+  }
+  e_.resize(nObj);
+  if(!cholesky_)
+    Q_.resize(n, n);
+  c_.resize(n);
+  if(useBounds)
+  {
+    //               | A_cstr |
+    // A needs to be |   -I   | with A_cstr = |  A_eq  |
+    //               |   I    |               | A_ineq |
+    impact.equalityConstraints_ = ImpactFromChanges::willReallocate(A_, nCstr + 2 * n, n);
+    nIneqInclBounds_ = nIneq + 2 * n;
+    A_.resize(nCstr + 2 * n, n);
+    A_.setZero();
+    b_.resize(nCstr + 2 * n);
+    A_.middleRows(nCstr, n).diagonal().setConstant(-1);
+    A_.bottomRows(n).diagonal().setConstant(1);
+    new(&xl_) VectorXdSeg(b_.segment(nCstr, n));
+    new(&xu_) VectorXdSeg(b_.segment(nCstr + n, n));
+    xl_.setConstant(-big_number_);
+    xu_.setConstant(+big_number_);
+  }
+  else
+  {
+    impact.equalityConstraints_ = ImpactFromChanges::willReallocate(A_, nCstr, n);
+    nIneqInclBounds_ = nIneq;
+    A_.resize(nCstr, n);
+    A_.setZero();
+    b_.resize(nCstr);
+    new(&xl_) VectorXdSeg(b_.segment(nCstr, 0));
+    new(&xu_) VectorXdSeg(b_.segment(nCstr, 0));
+  }
+  new(&Aineq_) MatrixXdRows(A_.middleRows(nEq, nIneq));
+  new(&bineq_) VectorXdSeg(b_.segment(nEq, nIneq));
+  if(useBounds)
+    qpd_.problem(n, nEq, nIneq + 2 * n);
+  else
+    qpd_.problem(n, nEq, nIneq);
+  if(cholesky_)
+  {
+    if(underspecifiedObj_)
+      new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj + n, n);
+    else
+      new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj, n);
   }
 
-  void QuadprogLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds)
+  impact.inequalityConstraints_ = impact.equalityConstraints_;
+  impact.bounds_ = impact.equalityConstraints_;
+  return impact;
+}
+
+void QuadprogLeastSquareSolver::addBound_(LinearConstraintPtr bound, RangePtr range, bool first)
+{
+  // We would like to write the lower bound as -x <= -xl, which means that xl_ should be
+  // filled with -xl, but there is currently no path in Assignment to do that properly.
+  // Instead, we fill xl_ as if we wanted xl <= x <= xu, and change the sign of xl_ in
+  // postAssignmentProcess_(). The -x comes from the corresponding rows of A being set
+  // to -I in initializeBuild_
+  // TODO: extend Assignment for that.
+  scheme::internal::AssignmentTarget target(range, xl_, xu_);
+  addAssignement(bound, target, bound->variables()[0], first);
+}
+
+void QuadprogLeastSquareSolver::addEqualityConstraint_(LinearConstraintPtr cstr)
+{
+  RangePtr r = std::make_shared<Range>(nextEqualityConstraintRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, A_, b_, constraint::Type::EQUAL, constraint::RHS::AS_GIVEN);
+  addAssignement(cstr, nullptr, target, variables(), substitutions());
+}
+
+void QuadprogLeastSquareSolver::addIneqalityConstraint_(LinearConstraintPtr cstr)
+{
+  RangePtr r = std::make_shared<Range>(nextInequalityConstraintRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, Aineq_, bineq_, constraint::Type::LOWER_THAN, constraint::RHS::AS_GIVEN);
+  addAssignement(cstr, nullptr, target, variables(), substitutions());
+}
+
+void QuadprogLeastSquareSolver::addObjective_(LinearConstraintPtr cstr,
+                                              SolvingRequirementsPtr req,
+                                              double additionalWeight)
+{
+  RangePtr r = std::make_shared<Range>(nextObjectiveRange_(*cstr));
+  scheme::internal::AssignmentTarget target(r, D_, e_, constraint::Type::EQUAL, constraint::RHS::OPPOSITE);
+  addAssignement(cstr, req, target, variables(), substitutions(), additionalWeight);
+}
+
+void QuadprogLeastSquareSolver::setMinimumNorm_()
+{
+  autoMinNorm_ = true;
+  Q_.setIdentity();
+  c_.setZero();
+}
+
+void QuadprogLeastSquareSolver::preAssignmentProcess_()
+{
+  // Some variables may be unbounded, which means no assignement will set the bounds to
+  // the correct value. Since the signs on xl will be flipped later, we need to reset this
+  // correct value.
+  xl_.setConstant(-big_number_);
+
+  // In some instance, D is overwritten, we need to reset it.
+  if(!autoMinNorm_ && cholesky_)
   {
-    resize_(nObj, nEq, nIneq, useBounds);
-
-    autoMinNorm_ = false;
-  }
-
-  QuadprogLeastSquareSolver::ImpactFromChanges QuadprogLeastSquareSolver::resize_(int nObj, int nEq, int nIneq, bool useBounds)
-  {
-    int n = variables().totalSize();
-    int nCstr = nEq + nIneq;
-    underspecifiedObj_ = nObj < n;
-    ImpactFromChanges impact;
-
-    if (cholesky_ && underspecifiedObj_)
+    D_.setZero();
+    if(underspecifiedObj_)
     {
-      impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj + n, n);
-      D_.resize(nObj + n, n);
-      D_.setZero();
+      int n = variables().totalSize();
       D_.bottomRows(n).diagonal().setConstant(choleskyDamping_);
     }
-    else
-    {
-      impact.objectives_ = ImpactFromChanges::willReallocate(D_, nObj, n);
-      D_.resize(nObj, n);
-      D_.setZero();
-    }
-    e_.resize(nObj);
-    if (!cholesky_)
-      Q_.resize(n, n);
-    c_.resize(n);
-    if (useBounds)
-    {
-      //               | A_cstr |
-      // A needs to be |   -I   | with A_cstr = |  A_eq  |
-      //               |   I    |               | A_ineq |
-      impact.equalityConstraints_ = ImpactFromChanges::willReallocate(A_, nCstr + 2 * n, n);
-      nIneqInclBounds_ = nIneq + 2 * n;
-      A_.resize(nCstr + 2 * n, n);
-      A_.setZero();
-      b_.resize(nCstr + 2 * n);
-      A_.middleRows(nCstr, n).diagonal().setConstant(-1);
-      A_.bottomRows(n).diagonal().setConstant(1);
-      new(&xl_) VectorXdSeg(b_.segment(nCstr, n));
-      new(&xu_) VectorXdSeg(b_.segment(nCstr + n, n));
-      xl_.setConstant(-big_number_);
-      xu_.setConstant(+big_number_);
-    }
-    else
-    {
-      impact.equalityConstraints_ = ImpactFromChanges::willReallocate(A_, nCstr, n);
-      nIneqInclBounds_ = nIneq;
-      A_.resize(nCstr, n);
-      A_.setZero();
-      b_.resize(nCstr);
-      new(&xl_) VectorXdSeg(b_.segment(nCstr, 0));
-      new(&xu_) VectorXdSeg(b_.segment(nCstr, 0));
-    }
-    new(&Aineq_) MatrixXdRows(A_.middleRows(nEq, nIneq));
-    new(&bineq_) VectorXdSeg(b_.segment(nEq, nIneq));
-    if (useBounds)
-      qpd_.problem(n, nEq, nIneq + 2 * n);
-    else
-      qpd_.problem(n, nEq, nIneq);
-    if (cholesky_)
-    {
-      if (underspecifiedObj_)
-        new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj + n, n);
-      else
-        new(&qr_) Eigen::HouseholderQR<Eigen::MatrixXd>(nObj, n);
-    }
-
-    impact.inequalityConstraints_ = impact.equalityConstraints_;
-    impact.bounds_ = impact.equalityConstraints_;
-    return impact;
-  }
-
-  void QuadprogLeastSquareSolver::addBound_(LinearConstraintPtr bound, RangePtr range, bool first)
-  {
-    // We would like to write the lower bound as -x <= -xl, which means that xl_ should be
-    // filled with -xl, but there is currently no path in Assignment to do that properly.
-    // Instead, we fill xl_ as if we wanted xl <= x <= xu, and change the sign of xl_ in
-    // postAssignmentProcess_(). The -x comes from the corresponding rows of A being set
-    // to -I in initializeBuild_
-    // TODO: extend Assignment for that.
-    scheme::internal::AssignmentTarget target(range, xl_, xu_);
-    addAssignement(bound, target, bound->variables()[0], first);
-  }
-
-  void QuadprogLeastSquareSolver::addEqualityConstraint_(LinearConstraintPtr cstr)
-  {
-    RangePtr r = std::make_shared<Range>(nextEqualityConstraintRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, A_, b_, constraint::Type::EQUAL, constraint::RHS::AS_GIVEN);
-    addAssignement(cstr, nullptr, target, variables(), substitutions());
-  }
-
-  void QuadprogLeastSquareSolver::addIneqalityConstraint_(LinearConstraintPtr cstr)
-  {
-    RangePtr r = std::make_shared<Range>(nextInequalityConstraintRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, Aineq_, bineq_, constraint::Type::LOWER_THAN, constraint::RHS::AS_GIVEN);
-    addAssignement(cstr, nullptr, target, variables(), substitutions());
-  }
-
-  void QuadprogLeastSquareSolver::addObjective_(LinearConstraintPtr cstr, SolvingRequirementsPtr req, double additionalWeight)
-  {
-    RangePtr r = std::make_shared<Range>(nextObjectiveRange_(*cstr));
-    scheme::internal::AssignmentTarget target(r, D_, e_, constraint::Type::EQUAL, constraint::RHS::OPPOSITE);
-    addAssignement(cstr, req, target, variables(), substitutions(), additionalWeight);
-  }
-
-  void QuadprogLeastSquareSolver::setMinimumNorm_()
-  {
-    autoMinNorm_ = true;
-    Q_.setIdentity();
-    c_.setZero();
-  }
-
-  void QuadprogLeastSquareSolver::preAssignmentProcess_()
-  {
-    // Some variables may be unbounded, which means no assignement will set the bounds to
-    // the correct value. Since the signs on xl will be flipped later, we need to reset this
-    // correct value.
-    xl_.setConstant(-big_number_);
-
-    // In some instance, D is overwritten, we need to reset it.
-    if (!autoMinNorm_ && cholesky_)
-    {
-      D_.setZero();
-      if (underspecifiedObj_)
-      { 
-        int n = variables().totalSize();
-        D_.bottomRows(n).diagonal().setConstant(choleskyDamping_);
-      }
-    }
-  }
-
-  void QuadprogLeastSquareSolver::postAssignmentProcess_()
-  {
-    // we need to flip the signs for xl
-    xl_ = -xl_;
-
-    // Quadprog does not solve least-square cost, but quadratic cost.
-    // We then either need to form the quadratic cost, or to get the Cholesky
-    // decomposition of this quadratic cost.
-    if (!autoMinNorm_)
-    {
-      // c = D^T e
-      c_.noalias() = D_.topRows(nObj_).transpose() * e_;
-
-      if (cholesky_)
-      {
-        // The cholesky decomposition of Q = D^T D is given by the R factor of
-        // the QR decomposition of D: if D = U R with U orthogonal, D^T D = R^T R.
-        int n = variables().totalSize();
-        qr_.compute(D_);
-        // we put R^{-1} in D
-        D_.topRows(n).setIdentity();
-        qr_.matrixQR().topRows(n).template triangularView<Eigen::Upper>().solveInPlace(D_.topRows(n));
-      }
-      else
-      {
-        // Q = D^T D
-        Q_.noalias() = D_.transpose() * D_;   //TODO check if this can be optimized: Quadprog might need only half the matrix
-        Q_.diagonal().array() += damping_;
-      }
-    }
-  }
-
-  bool QuadprogLeastSquareSolver::solve_()
-  {
-    if (cholesky_ && !autoMinNorm_)
-    {
-      int n = variables().totalSize();
-      return qpd_.solve(D_.topRows(n), c_,
-        A_.topRows(nEq_), b_.topRows(nEq_),
-        A_.bottomRows(nIneqInclBounds_), b_.bottomRows(nIneqInclBounds_),
-        true);
-    }
-    else
-    {
-      return qpd_.solve(Q_, c_,
-        A_.topRows(nEq_), b_.topRows(nEq_),
-        A_.bottomRows(nIneqInclBounds_), b_.bottomRows(nIneqInclBounds_),
-        false);
-    }
-  }
-
-  const Eigen::VectorXd& QuadprogLeastSquareSolver::result_() const
-  {
-    return qpd_.result();
-  }
-
-  Range QuadprogLeastSquareSolver::nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { eqSize_, cstr.size() };
-  }
-
-  Range QuadprogLeastSquareSolver::nextInequalityConstraintRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { ineqSize_, constraintSize(cstr) };
-  }
-
-  Range QuadprogLeastSquareSolver::nextObjectiveRange_(const constraint::abstract::LinearConstraint& cstr) const
-  {
-    return { objSize_, cstr.size() };
-  }
-
-  void QuadprogLeastSquareSolver::removeBounds_(const Range& range)
-  {
-    xl_.segment(range.start, range.dim).setConstant(-big_number_);
-    xu_.segment(range.start, range.dim).setConstant(+big_number_);
-  }
-
-  void QuadprogLeastSquareSolver::updateEqualityTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(A_, b_);
-  }
-
-  void QuadprogLeastSquareSolver::updateInequalityTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(Aineq_, bineq_);
-  }
-
-  void QuadprogLeastSquareSolver::updateBoundTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(VectorRef(xl_), xu_);
-  }
-
-  void QuadprogLeastSquareSolver::updateObjectiveTargetData(scheme::internal::AssignmentTarget& target)
-  {
-    target.changeData(D_, e_);
-  }
-
-  void QuadprogLeastSquareSolver::applyImpactLogic(ImpactFromChanges& impact)
-  {
-    if (impact.equalityConstraints_) impact.inequalityConstraints_ = true;
-    if (impact.inequalityConstraints_) impact.bounds_ = true;
-  }
-
-  void QuadprogLeastSquareSolver::printProblemData_() const
-  {
-    if (cholesky_)
-    {
-      int n = variables().totalSize();
-      std::cout << "R =\n" << qr_.matrixQR().topRows(n).template triangularView<Eigen::Upper>().toDenseMatrix() << std::endl;
-    }
-    else
-      std::cout << "Q =\n" << Q_ << std::endl;
-    std::cout << "c = " << c_.transpose() << std::endl;
-    std::cout << "A =\n" << A_ << std::endl;
-    std::cout << "b = " << b_.transpose() << std::endl;
-  }
-
-  void QuadprogLeastSquareSolver::printDiagnostic_() const
-  {
-    std::cout << "Quadprog fail code = " << qpd_.fail() << " (0 is success)" << std::endl;
-  }
-
-  std::unique_ptr<abstract::LSSolverFactory> QuadprogLSSolverFactory::clone() const
-  {
-    return std::make_unique<QuadprogLSSolverFactory>(*this);
-  }
-
-  QuadprogLSSolverFactory::QuadprogLSSolverFactory(const QuadprogLSSolverOptions& options)
-    : LSSolverFactory("quadprog")
-    , options_(options)
-  {
-  }
-
-  std::unique_ptr<abstract::LeastSquareSolver> QuadprogLSSolverFactory::createSolver() const
-  {
-    return std::make_unique<QuadprogLeastSquareSolver>(options_);
   }
 }
 
+void QuadprogLeastSquareSolver::postAssignmentProcess_()
+{
+  // we need to flip the signs for xl
+  xl_ = -xl_;
+
+  // Quadprog does not solve least-square cost, but quadratic cost.
+  // We then either need to form the quadratic cost, or to get the Cholesky
+  // decomposition of this quadratic cost.
+  if(!autoMinNorm_)
+  {
+    // c = D^T e
+    c_.noalias() = D_.topRows(nObj_).transpose() * e_;
+
+    if(cholesky_)
+    {
+      // The cholesky decomposition of Q = D^T D is given by the R factor of
+      // the QR decomposition of D: if D = U R with U orthogonal, D^T D = R^T R.
+      int n = variables().totalSize();
+      qr_.compute(D_);
+      // we put R^{-1} in D
+      D_.topRows(n).setIdentity();
+      qr_.matrixQR().topRows(n).template triangularView<Eigen::Upper>().solveInPlace(D_.topRows(n));
+    }
+    else
+    {
+      // Q = D^T D
+      Q_.noalias() =
+          D_.transpose() * D_; // TODO check if this can be optimized: Quadprog might need only half the matrix
+      Q_.diagonal().array() += damping_;
+    }
+  }
 }
+
+bool QuadprogLeastSquareSolver::solve_()
+{
+  if(cholesky_ && !autoMinNorm_)
+  {
+    int n = variables().totalSize();
+    return qpd_.solve(D_.topRows(n), c_, A_.topRows(nEq_), b_.topRows(nEq_), A_.bottomRows(nIneqInclBounds_),
+                      b_.bottomRows(nIneqInclBounds_), true);
+  }
+  else
+  {
+    return qpd_.solve(Q_, c_, A_.topRows(nEq_), b_.topRows(nEq_), A_.bottomRows(nIneqInclBounds_),
+                      b_.bottomRows(nIneqInclBounds_), false);
+  }
+}
+
+const Eigen::VectorXd & QuadprogLeastSquareSolver::result_() const { return qpd_.result(); }
+
+Range QuadprogLeastSquareSolver::nextEqualityConstraintRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {eqSize_, cstr.size()};
+}
+
+Range QuadprogLeastSquareSolver::nextInequalityConstraintRange_(
+    const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {ineqSize_, constraintSize(cstr)};
+}
+
+Range QuadprogLeastSquareSolver::nextObjectiveRange_(const constraint::abstract::LinearConstraint & cstr) const
+{
+  return {objSize_, cstr.size()};
+}
+
+void QuadprogLeastSquareSolver::removeBounds_(const Range & range)
+{
+  xl_.segment(range.start, range.dim).setConstant(-big_number_);
+  xu_.segment(range.start, range.dim).setConstant(+big_number_);
+}
+
+void QuadprogLeastSquareSolver::updateEqualityTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(A_, b_);
+}
+
+void QuadprogLeastSquareSolver::updateInequalityTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(Aineq_, bineq_);
+}
+
+void QuadprogLeastSquareSolver::updateBoundTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(VectorRef(xl_), xu_);
+}
+
+void QuadprogLeastSquareSolver::updateObjectiveTargetData(scheme::internal::AssignmentTarget & target)
+{
+  target.changeData(D_, e_);
+}
+
+void QuadprogLeastSquareSolver::applyImpactLogic(ImpactFromChanges & impact)
+{
+  if(impact.equalityConstraints_)
+    impact.inequalityConstraints_ = true;
+  if(impact.inequalityConstraints_)
+    impact.bounds_ = true;
+}
+
+void QuadprogLeastSquareSolver::printProblemData_() const
+{
+  if(cholesky_)
+  {
+    int n = variables().totalSize();
+    std::cout << "R =\n"
+              << qr_.matrixQR().topRows(n).template triangularView<Eigen::Upper>().toDenseMatrix() << std::endl;
+  }
+  else
+    std::cout << "Q =\n" << Q_ << std::endl;
+  std::cout << "c = " << c_.transpose() << std::endl;
+  std::cout << "A =\n" << A_ << std::endl;
+  std::cout << "b = " << b_.transpose() << std::endl;
+}
+
+void QuadprogLeastSquareSolver::printDiagnostic_() const
+{
+  std::cout << "Quadprog fail code = " << qpd_.fail() << " (0 is success)" << std::endl;
+}
+
+std::unique_ptr<abstract::LSSolverFactory> QuadprogLSSolverFactory::clone() const
+{
+  return std::make_unique<QuadprogLSSolverFactory>(*this);
+}
+
+QuadprogLSSolverFactory::QuadprogLSSolverFactory(const QuadprogLSSolverOptions & options)
+: LSSolverFactory("quadprog"), options_(options)
+{
+}
+
+std::unique_ptr<abstract::LeastSquareSolver> QuadprogLSSolverFactory::createSolver() const
+{
+  return std::make_unique<QuadprogLeastSquareSolver>(options_);
+}
+} // namespace solver
+
+} // namespace tvm

--- a/src/solver/QuadprogLeastSquareSolver.cpp
+++ b/src/solver/QuadprogLeastSquareSolver.cpp
@@ -18,8 +18,7 @@ QuadprogLeastSquareSolver::QuadprogLeastSquareSolver(const QuadprogLSSolverOptio
   xl_(b_.segment(0, 0)), xu_(b_.segment(0, 0)), big_number_(options.big_number().value()),
   cholesky_(options.cholesky().value()), choleskyDamping_(options.choleskyDamping().value()),
   damping_(options.damping().value()), autoMinNorm_(false)
-{
-}
+{}
 
 void QuadprogLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool useBounds)
 {
@@ -289,8 +288,7 @@ std::unique_ptr<abstract::LSSolverFactory> QuadprogLSSolverFactory::clone() cons
 
 QuadprogLSSolverFactory::QuadprogLSSolverFactory(const QuadprogLSSolverOptions & options)
 : LSSolverFactory("quadprog"), options_(options)
-{
-}
+{}
 
 std::unique_ptr<abstract::LeastSquareSolver> QuadprogLSSolverFactory::createSolver() const
 {

--- a/src/solver/defaultLeastSquareSolver.cpp
+++ b/src/solver/defaultLeastSquareSolver.cpp
@@ -11,8 +11,7 @@ std::unique_ptr<abstract::LSSolverFactory> DefaultLSSolverFactory::clone() const
 
 DefaultLSSolverFactory::DefaultLSSolverFactory(const DefaultLSSolverOptions & options)
 : LSSolverFactory("default"), options_(options)
-{
-}
+{}
 
 std::unique_ptr<abstract::LeastSquareSolver> DefaultLSSolverFactory::createSolver() const
 {

--- a/src/solver/defaultLeastSquareSolver.cpp
+++ b/src/solver/defaultLeastSquareSolver.cpp
@@ -1,63 +1,62 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/solver/defaultLeastSquareSolver.h>
 
 namespace tvm::solver
 {
-  std::unique_ptr<abstract::LSSolverFactory> DefaultLSSolverFactory::clone() const
-  {
-    return std::make_unique<DefaultLSSolverFactory>(*this);
-  }
-
-  DefaultLSSolverFactory::DefaultLSSolverFactory(const DefaultLSSolverOptions& options)
-    : LSSolverFactory("default")
-    , options_(options)
-  {
-  }
-
-  std::unique_ptr<abstract::LeastSquareSolver> DefaultLSSolverFactory::createSolver() const
-  {
-#ifdef TVM_USE_LSSOL
-    using SolverType = LSSOLLeastSquareSolver;
-    using SolverOption = LSSOLLSSolverOptions;
-#else
-# ifdef TVM_USE_QLD
-    using SolverType = QLDLeastSquareSolver;
-    using SolverOption = QLDLSSolverOptions;
-# else
-#   ifdef TVM_USE_QUADPROG
-    using SolverType = QuadprogLeastSquareSolver;
-    using SolverOption = QuadprogLSSolverOptions;
-#   endif
-# endif
-#endif
-    return std::make_unique<SolverType>(SolverOption().big_number(*options_.big_number()).verbose(*options_.verbose()));
-  }
+std::unique_ptr<abstract::LSSolverFactory> DefaultLSSolverFactory::clone() const
+{
+  return std::make_unique<DefaultLSSolverFactory>(*this);
 }
+
+DefaultLSSolverFactory::DefaultLSSolverFactory(const DefaultLSSolverOptions & options)
+: LSSolverFactory("default"), options_(options)
+{
+}
+
+std::unique_ptr<abstract::LeastSquareSolver> DefaultLSSolverFactory::createSolver() const
+{
+#ifdef TVM_USE_LSSOL
+  using SolverType = LSSOLLeastSquareSolver;
+  using SolverOption = LSSOLLSSolverOptions;
+#else
+#  ifdef TVM_USE_QLD
+  using SolverType = QLDLeastSquareSolver;
+  using SolverOption = QLDLSSolverOptions;
+#  else
+#    ifdef TVM_USE_QUADPROG
+  using SolverType = QuadprogLeastSquareSolver;
+  using SolverOption = QuadprogLSSolverOptions;
+#    endif
+#  endif
+#endif
+  return std::make_unique<SolverType>(SolverOption().big_number(*options_.big_number()).verbose(*options_.verbose()));
+}
+} // namespace tvm::solver

--- a/src/solver/defaultLeastSquareSolver.cpp
+++ b/src/solver/defaultLeastSquareSolver.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/solver/defaultLeastSquareSolver.h>
 

--- a/src/task_dynamics/Constant.cpp
+++ b/src/task_dynamics/Constant.cpp
@@ -9,34 +9,28 @@
 namespace tvm
 {
 
-  namespace task_dynamics
-  {
+namespace task_dynamics
+{
 
-    Constant::Constant()
-    {
-    }
+Constant::Constant() {}
 
-    std::unique_ptr<abstract::TaskDynamicsImpl> Constant::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
-    {
-      return std::make_unique<Impl>(f, t, rhs);
-    }
+std::unique_ptr<abstract::TaskDynamicsImpl> Constant::impl_(FunctionPtr f,
+                                                            constraint::Type t,
+                                                            const Eigen::VectorXd & rhs) const
+{
+  return std::make_unique<Impl>(f, t, rhs);
+}
 
-    Order Constant::order_() const
-    {
-      return Order::Zero;
-    }
+Order Constant::order_() const { return Order::Zero; }
 
-    Constant::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs)
-      : TaskDynamicsImpl(Order::Zero, f, t, rhs)
-    {
-      value_ = rhs;
-    }
+Constant::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs)
+: TaskDynamicsImpl(Order::Zero, f, t, rhs)
+{
+  value_ = rhs;
+}
 
-    void Constant::Impl::updateValue()
-    {
-      value_ = rhs();
-    }
+void Constant::Impl::updateValue() { value_ = rhs(); }
 
-  }  // namespace task_dynamics
+} // namespace task_dynamics
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/task_dynamics/Proportional.cpp
+++ b/src/task_dynamics/Proportional.cpp
@@ -30,7 +30,7 @@ Order Proportional::order_() const { return Order::One; }
 Proportional::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const Gain & kp)
 : TaskDynamicsImpl(Order::One, f, t, rhs), kp_(kp)
 {
-  if((kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() != f->size()) // Diagonal gain
+  if((kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() != f->size())   // Diagonal gain
      || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() != f->size() // Matrix gain
          && mpark::get<Eigen::MatrixXd>(kp).rows() != f->size()))
   {

--- a/src/task_dynamics/Proportional.cpp
+++ b/src/task_dynamics/Proportional.cpp
@@ -12,89 +12,76 @@ namespace tvm
 namespace task_dynamics
 {
 
-  Proportional::Proportional(double kp)
-    : kp_(kp)
+Proportional::Proportional(double kp) : kp_(kp) {}
+
+Proportional::Proportional(const Eigen::VectorXd & kp) : kp_(kp) {}
+
+Proportional::Proportional(const Eigen::MatrixXd & kp) : kp_(kp) {}
+
+std::unique_ptr<abstract::TaskDynamicsImpl> Proportional::impl_(FunctionPtr f,
+                                                                constraint::Type t,
+                                                                const Eigen::VectorXd & rhs) const
+{
+  return std::make_unique<Impl>(f, t, rhs, kp_);
+}
+
+Order Proportional::order_() const { return Order::One; }
+
+Proportional::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, const Gain & kp)
+: TaskDynamicsImpl(Order::One, f, t, rhs), kp_(kp)
+{
+  if((kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() != f->size()) // Diagonal gain
+     || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() != f->size() // Matrix gain
+         && mpark::get<Eigen::MatrixXd>(kp).rows() != f->size()))
   {
+    throw std::runtime_error("[task_dynamics::Proportional::Impl] Gain and function have incompatible sizes.");
   }
+}
 
-  Proportional::Proportional(const Eigen::VectorXd& kp)
-    : kp_(kp)
+void Proportional::Impl::updateValue()
+{
+  // \internal The code below would be cleaner using std::visit. Unfortunately
+  // this is slower because it prevents Eigen to perform some optimization.
+  switch(kp_.index())
   {
+    case 0:
+      value_ = -mpark::get<double>(kp_) * (function().value() - rhs());
+      break;
+    case 1:
+      value_.noalias() = -(mpark::get<Eigen::VectorXd>(kp_).asDiagonal() * (function().value() - rhs()));
+      break;
+    case 2:
+      value_.noalias() = -mpark::get<Eigen::MatrixXd>(kp_) * (function().value() - rhs());
+      break;
+    default:
+      assert(false);
   }
+}
 
-  Proportional::Proportional(const  Eigen::MatrixXd& kp)
-    : kp_(kp)
+void Proportional::Impl::gain(double kp) { kp_ = kp; }
+
+void Proportional::Impl::gain(const Eigen::VectorXd & kp)
+{
+  if(kp.size() != function().size())
   {
+    throw std::runtime_error("[task_dynamics::Proportional::Impl::gain] Gain and function have incompatible sizes.");
   }
+  kp_ = kp;
+}
 
-  std::unique_ptr<abstract::TaskDynamicsImpl> Proportional::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
+void Proportional::Impl::gain(const Eigen::MatrixXd & kp)
+{
+  if(kp.rows() != function().size() || kp.cols() != function().size())
   {
-    return std::make_unique<Impl>(f, t, rhs, kp_);
+    throw std::runtime_error("[task_dynamics::Proportional::Impl::gain] Gain and function have incompatible sizes.");
   }
+  kp_ = kp;
+}
 
-  Order Proportional::order_() const
-  {
-    return Order::One;
-  }
+const Proportional::Gain & Proportional::Impl::gain() const { return kp_; }
 
-  Proportional::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Gain& kp)
-    : TaskDynamicsImpl(Order::One, f, t, rhs)
-    , kp_(kp)
-  {
-    if ((kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() != f->size())   // Diagonal gain
-     || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() != f->size()    // Matrix gain
-                         && mpark::get<Eigen::MatrixXd>(kp).rows() != f->size()))
-    {
-      throw std::runtime_error("[task_dynamics::Proportional::Impl] Gain and function have incompatible sizes.");
-    }
-  }
+Proportional::Gain & Proportional::Impl::gain() { return kp_; }
 
-  void Proportional::Impl::updateValue()
-  {
-    // \internal The code below would be cleaner using std::visit. Unfortunately
-    // this is slower because it prevents Eigen to perform some optimization.
-    switch (kp_.index())
-    {
-    case 0: value_ = -mpark::get<double>(kp_) * (function().value() - rhs()); break;
-    case 1: value_.noalias() = -(mpark::get<Eigen::VectorXd>(kp_).asDiagonal() * (function().value() - rhs())); break;
-    case 2: value_.noalias() = -mpark::get<Eigen::MatrixXd>(kp_) * (function().value() - rhs()); break;
-    default: assert(false);
-    }
-  }
+} // namespace task_dynamics
 
-  void Proportional::Impl::gain(double kp)
-  {
-    kp_ = kp;
-  }
-
-  void Proportional::Impl::gain(const Eigen::VectorXd& kp)
-  {
-    if (kp.size() != function().size())
-    {
-      throw std::runtime_error("[task_dynamics::Proportional::Impl::gain] Gain and function have incompatible sizes.");
-    }
-    kp_ = kp;
-  }
-
-  void Proportional::Impl::gain(const Eigen::MatrixXd& kp)
-  {
-    if (kp.rows() != function().size() || kp.cols() != function().size())
-    {
-      throw std::runtime_error("[task_dynamics::Proportional::Impl::gain] Gain and function have incompatible sizes.");
-    }
-    kp_ = kp;
-  }
-
-  const Proportional::Gain& Proportional::Impl::gain() const
-  {
-    return kp_;
-  }
-
-  Proportional::Gain& Proportional::Impl::gain()
-  {
-    return kp_;
-  }
-
-}  // namespace task_dynamics
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/task_dynamics/ProportionalDerivative.cpp
+++ b/src/task_dynamics/ProportionalDerivative.cpp
@@ -17,13 +17,11 @@ ProportionalDerivative::ProportionalDerivative(double kp, double kv) : kp_(kp), 
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp, const Eigen::VectorXd & kv)
 : kp_(kp), kv_(kv)
-{
-}
+{}
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp, const Eigen::MatrixXd & kv)
 : kp_(kp), kv_(kv)
-{
-}
+{}
 
 ProportionalDerivative::ProportionalDerivative(double kp, const Eigen::VectorXd & kv) : kp_(kp), kv_(kv) {}
 
@@ -33,22 +31,19 @@ ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp, doubl
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp, const Eigen::MatrixXd & kv)
 : kp_(kp), kv_(kv)
-{
-}
+{}
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp, double kv) : kp_(kp), kv_(kv) {}
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp, const Eigen::VectorXd & kv)
 : kp_(kp), kv_(kv)
-{
-}
+{}
 
 ProportionalDerivative::ProportionalDerivative(double kp) : ProportionalDerivative(kp, 2 * std::sqrt(kp)) {}
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp)
 : kp_(kp), kv_(mpark::in_place_index<1>, 2 * kp.cwiseSqrt())
-{
-}
+{}
 
 ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp)
 : kp_(kp), kv_(Eigen::MatrixXd(kp.rows(), kp.cols()))

--- a/src/task_dynamics/ProportionalDerivative.cpp
+++ b/src/task_dynamics/ProportionalDerivative.cpp
@@ -4,8 +4,8 @@
 
 #include <Eigen/Eigenvalues>
 
-#include <tvm/task_dynamics/ProportionalDerivative.h>
 #include <tvm/function/abstract/Function.h>
+#include <tvm/task_dynamics/ProportionalDerivative.h>
 
 namespace tvm
 {
@@ -13,220 +13,178 @@ namespace tvm
 namespace task_dynamics
 {
 
-  ProportionalDerivative::ProportionalDerivative(double kp, double kv)
-    : kp_(kp)
-    , kv_(kv)
+ProportionalDerivative::ProportionalDerivative(double kp, double kv) : kp_(kp), kv_(kv) {}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp, const Eigen::VectorXd & kv)
+: kp_(kp), kv_(kv)
+{
+}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp, const Eigen::MatrixXd & kv)
+: kp_(kp), kv_(kv)
+{
+}
+
+ProportionalDerivative::ProportionalDerivative(double kp, const Eigen::VectorXd & kv) : kp_(kp), kv_(kv) {}
+
+ProportionalDerivative::ProportionalDerivative(double kp, const Eigen::MatrixXd & kv) : kp_(kp), kv_(kv) {}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp, double kv) : kp_(kp), kv_(kv) {}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp, const Eigen::MatrixXd & kv)
+: kp_(kp), kv_(kv)
+{
+}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp, double kv) : kp_(kp), kv_(kv) {}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp, const Eigen::VectorXd & kv)
+: kp_(kp), kv_(kv)
+{
+}
+
+ProportionalDerivative::ProportionalDerivative(double kp) : ProportionalDerivative(kp, 2 * std::sqrt(kp)) {}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd & kp)
+: kp_(kp), kv_(mpark::in_place_index<1>, 2 * kp.cwiseSqrt())
+{
+}
+
+ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd & kp)
+: kp_(kp), kv_(Eigen::MatrixXd(kp.rows(), kp.cols()))
+{
+  Eigen::RealSchur<Eigen::MatrixXd> dec(kp);
+  assert(dec.matrixT().isDiagonal(1e-8) && "kp is not symmetric.");
+  assert((dec.matrixT().diagonal().array() >= 0).all() && "kp is undefinite.");
+  kv_.emplace<2>(2 * dec.matrixU() * dec.matrixT().diagonal().asDiagonal() * dec.matrixU().transpose());
+}
+
+std::unique_ptr<abstract::TaskDynamicsImpl> ProportionalDerivative::impl_(FunctionPtr f,
+                                                                          constraint::Type t,
+                                                                          const Eigen::VectorXd & rhs) const
+{
+  return std::make_unique<Impl>(f, t, rhs, kp_, kv_);
+}
+
+Order ProportionalDerivative::order_() const { return Order::Two; }
+
+ProportionalDerivative::Impl::Impl(FunctionPtr f,
+                                   constraint::Type t,
+                                   const Eigen::VectorXd & rhs,
+                                   const Gain & kp,
+                                   const Gain & kv)
+: TaskDynamicsImpl(Order::Two, f, t, rhs), kp_(kp), kv_(kv)
+{
+  assert((kp.index() == 0 // Scalar gain
+          || (kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() == f->size()) // Diagonal gain
+          || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() == f->size() // Matrix gain
+              && mpark::get<Eigen::MatrixXd>(kp).rows() == f->size()))
+         && "Gain kp and function have incompatible sizes");
+
+  assert((kv.index() == 0 // Scalar gain
+          || (kv.index() == 1 && mpark::get<Eigen::VectorXd>(kv).size() == f->size()) // Diagonal gain
+          || (kv.index() == 2 && mpark::get<Eigen::MatrixXd>(kv).cols() == f->size() // Matrix gain
+              && mpark::get<Eigen::MatrixXd>(kv).rows() == f->size()))
+         && "Gain kv and function have incompatible sizes");
+}
+
+void ProportionalDerivative::Impl::updateValue()
+{
+  switch(kv_.index())
   {
+    case 0:
+      value_ = -mpark::get<double>(kv_) * function().velocity();
+      break;
+    case 1:
+      value_.noalias() = -(mpark::get<Eigen::VectorXd>(kv_).asDiagonal() * function().velocity());
+      break;
+    case 2:
+      value_.noalias() = -mpark::get<Eigen::MatrixXd>(kv_) * function().velocity();
+      break;
+    default:
+      assert(false);
   }
-
-  ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd& kp, const Eigen::VectorXd& kv)
-    : kp_(kp)
-    , kv_(kv)
+  switch(kp_.index())
   {
+    case 0:
+      value_ -= mpark::get<double>(kp_) * (function().value() - rhs());
+      break;
+    case 1:
+      value_.noalias() -= mpark::get<Eigen::VectorXd>(kp_).asDiagonal() * (function().value() - rhs());
+      break;
+    case 2:
+      value_.noalias() -= mpark::get<Eigen::MatrixXd>(kp_) * (function().value() - rhs());
+      break;
+    default:
+      assert(false);
   }
+}
 
-  ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd& kp, const Eigen::MatrixXd& kv)
-    : kp_(kp)
-    , kv_(kv)
+std::pair<const PD::Gain &, const PD::Gain &> ProportionalDerivative::Impl::gains() const { return {kp_, kv_}; }
+
+void ProportionalDerivative::Impl::gains(double kp, double kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(const Eigen::VectorXd & kp, const Eigen::VectorXd & kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd & kp, const Eigen::MatrixXd & kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(double kp, const Eigen::VectorXd & kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(double kp, const Eigen::MatrixXd & kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(const Eigen::VectorXd & kp, double kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(const Eigen::VectorXd & kp, const Eigen::MatrixXd & kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd & kp, double kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd & kp, const Eigen::VectorXd & kv) { gains_(kp, kv); }
+
+void ProportionalDerivative::Impl::gains(double kp)
+{
+  kp_ = kp;
+  kv_ = 2 * std::sqrt(kp);
+}
+
+void ProportionalDerivative::Impl::gains(const Eigen::VectorXd & kp)
+{
+  checkGainSize(kp);
+  kp_ = kp;
+  kv_.emplace<1>(2 * kp.cwiseSqrt());
+}
+
+void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd & kp)
+{
+  checkGainSize(kp);
+  Eigen::RealSchur<Eigen::MatrixXd> dec(kp);
+  assert(dec.matrixT().isDiagonal(1e-8) && "kp is not symmetric.");
+  assert((dec.matrixT().diagonal().array() >= 0).all() && "kp is undefinite.");
+  kv_.emplace<2>(2 * dec.matrixU() * dec.matrixT().diagonal().asDiagonal() * dec.matrixU().transpose());
+}
+
+void ProportionalDerivative::Impl::checkGainSize(double k) const
+{
+  // do nothing
+}
+
+void ProportionalDerivative::Impl::checkGainSize(const Eigen::VectorXd & k) const
+{
+  if(k.size() != function().size())
   {
+    throw std::runtime_error(
+        "[task_dynamics::ProportionalDerivative::Impl::gains] Gain and function have incompatible sizes.");
   }
+}
 
-  ProportionalDerivative::ProportionalDerivative(double kp, const Eigen::VectorXd& kv)
-    : kp_(kp)
-    , kv_(kv)
+void ProportionalDerivative::Impl::checkGainSize(const Eigen::MatrixXd & k) const
+{
+  if(k.rows() != function().size() || k.cols() != function().size())
   {
+    throw std::runtime_error(
+        "[task_dynamics::ProportionalDerivative::Impl::gains] Gain and function have incompatible sizes.");
   }
+}
 
-  ProportionalDerivative::ProportionalDerivative(double kp, const Eigen::MatrixXd& kv)
-    : kp_(kp)
-    , kv_(kv)
-  {
-  }
+} // namespace task_dynamics
 
-  ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd& kp, double kv)
-    : kp_(kp)
-    , kv_(kv)
-  {
-  }
-
-  ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd& kp, const Eigen::MatrixXd& kv)
-    : kp_(kp)
-    , kv_(kv)
-  {
-  }
-
-  ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd& kp, double kv)
-    : kp_(kp)
-    , kv_(kv)
-  {
-  }
-
-  ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd& kp, const Eigen::VectorXd& kv)
-    : kp_(kp)
-    , kv_(kv)
-  {
-  }
-
-  ProportionalDerivative::ProportionalDerivative(double kp)
-    : ProportionalDerivative(kp, 2 * std::sqrt(kp))
-  {
-  }
-
-  ProportionalDerivative::ProportionalDerivative(const Eigen::VectorXd& kp)
-    : kp_(kp)
-    , kv_(mpark::in_place_index<1>, 2*kp.cwiseSqrt())
-  {
-  }
-
-  ProportionalDerivative::ProportionalDerivative(const Eigen::MatrixXd& kp)
-    : kp_(kp)
-    , kv_(Eigen::MatrixXd(kp.rows(), kp.cols()))
-  {
-    Eigen::RealSchur<Eigen::MatrixXd> dec(kp);
-    assert(dec.matrixT().isDiagonal(1e-8) && "kp is not symmetric.");
-    assert((dec.matrixT().diagonal().array() >= 0).all() && "kp is undefinite.");
-    kv_.emplace<2>(2 * dec.matrixU() * dec.matrixT().diagonal().asDiagonal() * dec.matrixU().transpose());
-  }
-
-  std::unique_ptr<abstract::TaskDynamicsImpl> ProportionalDerivative::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
-  {
-    return std::make_unique<Impl>(f, t, rhs, kp_, kv_);
-  }
-
-  Order ProportionalDerivative::order_() const
-  {
-    return Order::Two;
-  }
-
-  ProportionalDerivative::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, const Gain& kp, const Gain& kv)
-    : TaskDynamicsImpl(Order::Two, f, t, rhs)
-    , kp_(kp)
-    , kv_(kv)
-  {
-    assert((kp.index() == 0                                           // Scalar gain
-        || (kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() == f->size())   // Diagonal gain
-        || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() == f->size()    // Matrix gain
-                            && mpark::get<Eigen::MatrixXd>(kp).rows() == f->size()))  
-      && "Gain kp and function have incompatible sizes");
-
-    assert((kv.index() == 0                                           // Scalar gain
-        || (kv.index() == 1 && mpark::get<Eigen::VectorXd>(kv).size() == f->size())   // Diagonal gain
-        || (kv.index() == 2 && mpark::get<Eigen::MatrixXd>(kv).cols() == f->size()    // Matrix gain
-                            && mpark::get<Eigen::MatrixXd>(kv).rows() == f->size()))  
-      && "Gain kv and function have incompatible sizes");
-  }
-
-  void ProportionalDerivative::Impl::updateValue()
-  {
-    switch (kv_.index())
-    {
-    case 0: value_ = -mpark::get<double>(kv_) * function().velocity(); break;
-    case 1: value_.noalias() = -(mpark::get<Eigen::VectorXd>(kv_).asDiagonal() * function().velocity()); break;
-    case 2: value_.noalias() = -mpark::get<Eigen::MatrixXd>(kv_) * function().velocity(); break;
-    default: assert(false);
-    }
-    switch (kp_.index())
-    {
-    case 0: value_ -= mpark::get<double>(kp_) * (function().value() - rhs()); break;
-    case 1: value_.noalias() -= mpark::get<Eigen::VectorXd>(kp_).asDiagonal() * (function().value() - rhs()); break;
-    case 2: value_.noalias() -= mpark::get<Eigen::MatrixXd>(kp_) * (function().value() - rhs()); break;
-    default: assert(false);
-    }
-  }
-
-  std::pair<const PD::Gain&, const PD::Gain&> ProportionalDerivative::Impl::gains() const
-  {
-    return {kp_, kv_};
-  }
-
-  void ProportionalDerivative::Impl::gains(double kp, double kv)
-  {
-    gains_(kp, kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::VectorXd& kp, const Eigen::VectorXd& kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd& kp, const Eigen::MatrixXd& kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(double kp, const Eigen::VectorXd& kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(double kp, const Eigen::MatrixXd& kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::VectorXd& kp, double kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::VectorXd& kp, const Eigen::MatrixXd& kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd& kp, double kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd& kp, const Eigen::VectorXd& kv)
-  {
-    gains_(kp,kv);
-  }
-
-  void ProportionalDerivative::Impl::gains(double kp)
-  {
-    kp_ = kp;
-    kv_ = 2 * std::sqrt(kp);
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::VectorXd& kp)
-  {
-    checkGainSize(kp);
-    kp_ = kp;
-    kv_.emplace<1>(2 * kp.cwiseSqrt());
-  }
-
-  void ProportionalDerivative::Impl::gains(const Eigen::MatrixXd& kp)
-  {
-    checkGainSize(kp);
-    Eigen::RealSchur<Eigen::MatrixXd> dec(kp);
-    assert(dec.matrixT().isDiagonal(1e-8) && "kp is not symmetric.");
-    assert((dec.matrixT().diagonal().array() >= 0).all() && "kp is undefinite.");
-    kv_.emplace<2>(2*dec.matrixU() * dec.matrixT().diagonal().asDiagonal() * dec.matrixU().transpose());
-  }
-
-  void ProportionalDerivative::Impl::checkGainSize(double k) const
-  {
-    //do nothing
-  }
-
-  void ProportionalDerivative::Impl::checkGainSize(const Eigen::VectorXd& k) const
-  {
-    if (k.size() != function().size())
-    {
-      throw std::runtime_error("[task_dynamics::ProportionalDerivative::Impl::gains] Gain and function have incompatible sizes.");
-    }
-  }
-
-  void ProportionalDerivative::Impl::checkGainSize(const Eigen::MatrixXd& k) const
-  {
-    if (k.rows() != function().size() || k.cols() != function().size())
-    {
-      throw std::runtime_error("[task_dynamics::ProportionalDerivative::Impl::gains] Gain and function have incompatible sizes.");
-    }
-  }
-
-}  // namespace task_dynamics
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/task_dynamics/ProportionalDerivative.cpp
+++ b/src/task_dynamics/ProportionalDerivative.cpp
@@ -75,15 +75,15 @@ ProportionalDerivative::Impl::Impl(FunctionPtr f,
                                    const Gain & kv)
 : TaskDynamicsImpl(Order::Two, f, t, rhs), kp_(kp), kv_(kv)
 {
-  assert((kp.index() == 0 // Scalar gain
+  assert((kp.index() == 0                                                             // Scalar gain
           || (kp.index() == 1 && mpark::get<Eigen::VectorXd>(kp).size() == f->size()) // Diagonal gain
-          || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() == f->size() // Matrix gain
+          || (kp.index() == 2 && mpark::get<Eigen::MatrixXd>(kp).cols() == f->size()  // Matrix gain
               && mpark::get<Eigen::MatrixXd>(kp).rows() == f->size()))
          && "Gain kp and function have incompatible sizes");
 
-  assert((kv.index() == 0 // Scalar gain
+  assert((kv.index() == 0                                                             // Scalar gain
           || (kv.index() == 1 && mpark::get<Eigen::VectorXd>(kv).size() == f->size()) // Diagonal gain
-          || (kv.index() == 2 && mpark::get<Eigen::MatrixXd>(kv).cols() == f->size() // Matrix gain
+          || (kv.index() == 2 && mpark::get<Eigen::MatrixXd>(kv).cols() == f->size()  // Matrix gain
               && mpark::get<Eigen::MatrixXd>(kv).rows() == f->size()))
          && "Gain kv and function have incompatible sizes");
 }

--- a/src/task_dynamics/Reference.cpp
+++ b/src/task_dynamics/Reference.cpp
@@ -9,60 +9,45 @@
 
 namespace tvm::task_dynamics
 {
-  Reference::Reference(Order order, const FunctionPtr& ref)
-    : refOrder_(order)
-    , ref_(ref)
-  {
-  }
+Reference::Reference(Order order, const FunctionPtr & ref) : refOrder_(order), ref_(ref) {}
 
-  std::unique_ptr<abstract::TaskDynamicsImpl> Reference::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
-  {
-    return std::make_unique<Impl>(f, t, rhs, refOrder_, ref_);
-  }
-
-  Order Reference::order_() const
-  {
-    return refOrder_;
-  }
-
-
-  Reference::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs, Order order, FunctionPtr ref)
-    : TaskDynamicsImpl(order, f, t, rhs)
-  {
-    setReference(ref);
-  }
-
-  void Reference::Impl::updateValue()
-  {
-    value_ = ref_->value();
-  }
-
-  void Reference::Impl::ref(const FunctionPtr& r)
-  {
-    // Changing the reference requires recomputing the computation graph
-    // We do not have the proper "event" system to handle that for now
-    throw std::runtime_error("[task_dynamics::Reference::Impl::ref] Unimplemented function");
-  }
-
-  void Reference::Impl::setReference(const FunctionPtr& ref)
-  {
-    if (!ref)
-    {
-      throw std::runtime_error("[task_dynamics::Reference::Impl] You cannot pass a nullptr as reference function.");
-    }
-
-    ref_ = ref;
-    addInput(ref, internal::FirstOrderProvider::Output::Value);
-    addInputDependency(Update::UpdateValue, ref, internal::FirstOrderProvider::Output::Value);
-  }
-
-  ReferenceVelocity::ReferenceVelocity(const FunctionPtr& ref)
-    : Reference(Order::One, ref)
-  {
-  }
-
-  ReferenceAcceleration::ReferenceAcceleration(const FunctionPtr& ref)
-    : Reference(Order::Two, ref)
-  {
-  }
+std::unique_ptr<abstract::TaskDynamicsImpl> Reference::impl_(FunctionPtr f,
+                                                             constraint::Type t,
+                                                             const Eigen::VectorXd & rhs) const
+{
+  return std::make_unique<Impl>(f, t, rhs, refOrder_, ref_);
 }
+
+Order Reference::order_() const { return refOrder_; }
+
+Reference::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, Order order, FunctionPtr ref)
+: TaskDynamicsImpl(order, f, t, rhs)
+{
+  setReference(ref);
+}
+
+void Reference::Impl::updateValue() { value_ = ref_->value(); }
+
+void Reference::Impl::ref(const FunctionPtr & r)
+{
+  // Changing the reference requires recomputing the computation graph
+  // We do not have the proper "event" system to handle that for now
+  throw std::runtime_error("[task_dynamics::Reference::Impl::ref] Unimplemented function");
+}
+
+void Reference::Impl::setReference(const FunctionPtr & ref)
+{
+  if(!ref)
+  {
+    throw std::runtime_error("[task_dynamics::Reference::Impl] You cannot pass a nullptr as reference function.");
+  }
+
+  ref_ = ref;
+  addInput(ref, internal::FirstOrderProvider::Output::Value);
+  addInputDependency(Update::UpdateValue, ref, internal::FirstOrderProvider::Output::Value);
+}
+
+ReferenceVelocity::ReferenceVelocity(const FunctionPtr & ref) : Reference(Order::One, ref) {}
+
+ReferenceAcceleration::ReferenceAcceleration(const FunctionPtr & ref) : Reference(Order::Two, ref) {}
+} // namespace tvm::task_dynamics

--- a/src/task_dynamics/TaskDynamics.cpp
+++ b/src/task_dynamics/TaskDynamics.cpp
@@ -15,19 +15,18 @@ namespace task_dynamics
 namespace abstract
 {
 
-  std::unique_ptr<TaskDynamicsImpl> TaskDynamics::impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs) const
-  {
-    auto ptr = impl_(f, t, rhs);
-    return ptr;
-  }
+std::unique_ptr<TaskDynamicsImpl> TaskDynamics::impl(FunctionPtr f,
+                                                     constraint::Type t,
+                                                     const Eigen::VectorXd & rhs) const
+{
+  auto ptr = impl_(f, t, rhs);
+  return ptr;
+}
 
-  Order TaskDynamics::order() const
-  {
-    return order_();
-  }
+Order TaskDynamics::order() const { return order_(); }
 
-}  // namespace abstract
+} // namespace abstract
 
-}  // namespace task_dynamics
+} // namespace task_dynamics
 
-}  // namespace tvm
+} // namespace tvm

--- a/src/task_dynamics/TaskDynamicsImpl.cpp
+++ b/src/task_dynamics/TaskDynamicsImpl.cpp
@@ -9,48 +9,48 @@
 namespace tvm
 {
 
-  namespace task_dynamics
+namespace task_dynamics
+{
+
+namespace abstract
+{
+
+TaskDynamicsImpl::TaskDynamicsImpl(Order order, FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs)
+: order_(order), type_(t), rhs_(rhs)
+{
+  if(f->size() != rhs.size())
   {
+    throw std::runtime_error("[TaskDynamicsImpl] rhs does not have the same size as f.");
+  }
+  if(!f->imageSpace().isEuclidean())
+    throw std::runtime_error(
+        "[TaskDynamicsImpl::TaskDynamicsImpl] Task dynamics are for function into a Euclidean space.");
+  setFunction(f);
+  registerUpdates(Update::UpdateValue, &TaskDynamicsImpl::updateValue);
+  addOutputDependency(Output::Value, Update::UpdateValue);
+}
 
-    namespace abstract
+void TaskDynamicsImpl::setFunction(FunctionPtr f)
+{
+  if(f)
+  {
+    f_ = f;
+    addInput(f, internal::FirstOrderProvider::Output::Value); // FIXME it's not great to have to resort to
+                                                              // internal::FirstOrderProvider
+    addInputDependency(Update::UpdateValue, f, internal::FirstOrderProvider::Output::Value);
+    if(order_ == Order::Two)
     {
+      addInput(f, function::abstract::Function::Output::Velocity);
+      addInputDependency(Update::UpdateValue, f, function::abstract::Function::Output::Velocity);
+    }
+    value_.resize(f->size());
+  }
+  else
+    throw std::runtime_error("You cannot pass a nullptr as a function.");
+}
 
-      TaskDynamicsImpl::TaskDynamicsImpl(Order order, FunctionPtr f, constraint::Type t, const Eigen::VectorXd& rhs)
-        : order_(order)
-        , type_(t)
-        , rhs_(rhs)
-      {
-        if (f->size() != rhs.size())
-        {
-          throw std::runtime_error("[TaskDynamicsImpl] rhs does not have the same size as f.");
-        }
-        if (!f->imageSpace().isEuclidean())
-          throw std::runtime_error("[TaskDynamicsImpl::TaskDynamicsImpl] Task dynamics are for function into a Euclidean space.");
-        setFunction(f);
-        registerUpdates(Update::UpdateValue, &TaskDynamicsImpl::updateValue);
-        addOutputDependency(Output::Value, Update::UpdateValue);
-      }
+} // namespace abstract
 
-      void TaskDynamicsImpl::setFunction(FunctionPtr f)
-      {
-        if (f)
-        {
-          f_ = f;
-          addInput(f, internal::FirstOrderProvider::Output::Value); //FIXME it's not great to have to resort to internal::FirstOrderProvider
-          addInputDependency(Update::UpdateValue, f, internal::FirstOrderProvider::Output::Value);
-          if (order_ == Order::Two)
-          {
-            addInput(f, function::abstract::Function::Output::Velocity);
-            addInputDependency(Update::UpdateValue, f, function::abstract::Function::Output::Velocity);
-          }
-          value_.resize(f->size());
-        }
-        else
-          throw std::runtime_error("You cannot pass a nullptr as a function.");
-      }
+} // namespace task_dynamics
 
-    }  // namespace abstract
-
-  }  // namespace task_dynamics
-
-}  // namespace tvm
+} // namespace tvm

--- a/src/task_dynamics/VelocityDamper.cpp
+++ b/src/task_dynamics/VelocityDamper.cpp
@@ -11,260 +11,247 @@ namespace tvm
 
 namespace task_dynamics
 {
-  VelocityDamper::Config::Config(double di, double ds, double xsi, double xsiOff)
-    : di_(di), ds_(ds), xsi_(xsi), xsiOff_(xsiOff)
+VelocityDamper::Config::Config(double di, double ds, double xsi, double xsiOff)
+: di_(di), ds_(ds), xsi_(xsi), xsiOff_(xsiOff)
+{
+  if(di_ <= ds_)
   {
-    if (di_ <= ds_)
-    {
-      throw std::runtime_error("di must be greater than ds");
-    }
-    if (ds_ < 0)
-    {
-      throw std::runtime_error("ds should be non-negative.");
-    }
-    if (xsi_ < 0)
-    {
-      throw std::runtime_error("xsi should be non-negative.");
-    }
-    if (xsiOff_ < 0)
-    {
-      throw std::runtime_error("xsiOff should be positive.");
-    }
+    throw std::runtime_error("di must be greater than ds");
   }
-
-  VelocityDamper::AnisotropicConfig::AnisotropicConfig(const VectorConstRef & di,
-                                                       const VectorConstRef & ds,
-                                                       const VectorConstRef & xsi,
-                                                       const std::optional<VectorConstRef> & xsiOff)
-  : di_(di), ds_(ds), xsi_(xsi),
-    xsiOff_(xsiOff.value_or(Eigen::VectorXd::Constant(di_.size(), 1, 0.0)))
+  if(ds_ < 0)
   {
-    if(di_.size() != ds_.size() || di_.size() != xsi_.size() || di_.size() != xsiOff_.size())
-    {
-      throw std::runtime_error("All vector components must have the same size");
-    }
-    if((di_.array() <= ds_.array()).any())
-    {
-      throw std::runtime_error("di must be greater than ds");
-    }
-    if((ds_.array() < 0).any())
-    {
-      throw std::runtime_error("ds should be non-negative.");
-    }
-    if((xsi_.array() < 0).any())
-    {
-      throw std::runtime_error("xsi should be non-negative.");
-    }
-    auto automatic = xsi_.array() == 0;
-    if(automatic.any() && !automatic.all())
-    {
-      throw std::runtime_error("Automatic damping must be enabled for all dimensions");
-    }
-    if ((xsiOff_.array() < 0).any())
-    {
-      throw std::runtime_error("xsiOff should be positive.");
-    }
+    throw std::runtime_error("ds should be non-negative.");
   }
-
-  VelocityDamper::AnisotropicConfig::AnisotropicConfig(const Config & config)
-  : AnisotropicConfig(Eigen::VectorXd::Constant(1, 1, config.di_),
-                      Eigen::VectorXd::Constant(1, 1, config.ds_),
-                      Eigen::VectorXd::Constant(1, 1, config.xsi_),
-                      Eigen::VectorXd::Constant(1, 1, config.xsiOff_))
+  if(xsi_ < 0)
   {
+    throw std::runtime_error("xsi should be non-negative.");
   }
-
-  VelocityDamper::VelocityDamper(const Config & config, double big)
-  : VelocityDamper(AnisotropicConfig{config}, big)
+  if(xsiOff_ < 0)
   {
+    throw std::runtime_error("xsiOff should be positive.");
   }
+}
 
-  VelocityDamper::VelocityDamper(const AnisotropicConfig& config, double big)
-    : dt_(0)
-    , xsi_(0)
-    , ds_(config.ds_)
-    , di_(config.di_)
-    , big_(big)
-    , autoXsi_(config.xsi_[0] == 0) // we have ensure they are either all 0 or all specified
+VelocityDamper::AnisotropicConfig::AnisotropicConfig(const VectorConstRef & di,
+                                                     const VectorConstRef & ds,
+                                                     const VectorConstRef & xsi,
+                                                     const std::optional<VectorConstRef> & xsiOff)
+: di_(di), ds_(ds), xsi_(xsi), xsiOff_(xsiOff.value_or(Eigen::VectorXd::Constant(di_.size(), 1, 0.0)))
+{
+  if(di_.size() != ds_.size() || di_.size() != xsi_.size() || di_.size() != xsiOff_.size())
   {
-    if (autoXsi_)
-    {
-      xsi_ = config.xsiOff_;
-    }
-    else
-    {
-      xsi_ = config.xsi_;
-    }
-    if (big <= 0)
-    {
-      throw std::runtime_error("big should be non-negative.");
-    }
+    throw std::runtime_error("All vector components must have the same size");
   }
-
-  VelocityDamper::VelocityDamper(double dt, const Config & config, double big)
-  : VelocityDamper(dt, AnisotropicConfig{config}, big)
+  if((di_.array() <= ds_.array()).any())
   {
+    throw std::runtime_error("di must be greater than ds");
   }
-
-  VelocityDamper::VelocityDamper(double dt, const AnisotropicConfig& config, double big)
-    : dt_(dt)
-    , xsi_(0)
-    , ds_(config.ds_)
-    , di_(config.di_)
-    , big_(big)
-    , autoXsi_(config.xsi_[0] == 0) // we have ensure they are either all 0 or all specified
+  if((ds_.array() < 0).any())
   {
-    if (autoXsi_)
-    {
-      xsi_ = config.xsiOff_;
-    }
-    else
-    {
-      xsi_ = config.xsi_;
-    }
-    if (dt <= 0)
-    {
-      throw std::runtime_error("Time increment should be non-negative.");
-    }
-    if (big <= 0)
-    {
-      throw std::runtime_error("big should be non-negative.");
-    }
+    throw std::runtime_error("ds should be non-negative.");
   }
-
-  std::unique_ptr<abstract::TaskDynamicsImpl> VelocityDamper::impl_(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs) const
+  if((xsi_.array() < 0).any())
   {
-    if (dt_ > 0)
-    {
-      return std::make_unique<Impl>(f, t, rhs, dt_, autoXsi_, di_, ds_, xsi_, big_);
-    }
-    else
-    {
-      return std::make_unique<Impl>(f, t, rhs, autoXsi_, di_, ds_, xsi_, big_);
-    }
+    throw std::runtime_error("xsi should be non-negative.");
   }
-
-  Order VelocityDamper::order_() const
+  auto automatic = xsi_.array() == 0;
+  if(automatic.any() && !automatic.all())
   {
-    return dt_ > 0 ? Order::Two : Order::One;
+    throw std::runtime_error("Automatic damping must be enabled for all dimensions");
   }
-
-  namespace
+  if((xsiOff_.array() < 0).any())
   {
-
-  static inline Eigen::VectorXd resizeParameter(const FunctionPtr & f, const Eigen::VectorXd & in, const char * desc)
-  {
-    if(in.size() == 1)
-    {
-      return Eigen::VectorXd::Constant(f->size(), 1, in[0]);
-    }
-    else if(in.size() != f->size())
-    {
-      std::string error = "Size of the " + std::string(desc) + " vector ( " + std::to_string(in.size()) + " ) does not match the function size ( " + std::to_string(f->size()) + " ) ";
-      throw std::runtime_error(error.c_str());
-    }
-    return in;
+    throw std::runtime_error("xsiOff should be positive.");
   }
+}
 
-  }
+VelocityDamper::AnisotropicConfig::AnisotropicConfig(const Config & config)
+: AnisotropicConfig(Eigen::VectorXd::Constant(1, 1, config.di_),
+                    Eigen::VectorXd::Constant(1, 1, config.ds_),
+                    Eigen::VectorXd::Constant(1, 1, config.xsi_),
+                    Eigen::VectorXd::Constant(1, 1, config.xsiOff_))
+{
+}
 
-  VelocityDamper::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, bool autoXsi, const Eigen::VectorXd & di, const Eigen::VectorXd & ds, const Eigen::VectorXd & xsi, double big)
-    : TaskDynamicsImpl(Order::One, f, t, rhs)
-    , dt_(0)
-    , ds_(resizeParameter(f, ds, "safety distance"))
-    , di_(resizeParameter(f, di, "interaction distance"))
-    , xsiOff_(0)
-    , a_(-(di_ - ds_).cwiseInverse())
-    , big_(big)
-    , autoXsi_(autoXsi)
-    , d_(f->size())
-    , axsi_(f->size())
-    , active_(f->size(), false)
+VelocityDamper::VelocityDamper(const Config & config, double big) : VelocityDamper(AnisotropicConfig{config}, big) {}
+
+VelocityDamper::VelocityDamper(const AnisotropicConfig & config, double big)
+: dt_(0), xsi_(0), ds_(config.ds_), di_(config.di_), big_(big),
+  autoXsi_(config.xsi_[0] == 0) // we have ensure they are either all 0 or all specified
+{
+  if(autoXsi_)
   {
-    if (autoXsi)
-    {
-      axsi_.setOnes();
-      xsiOff_ = resizeParameter(f, xsi, "damping offset parameter");
-      addInputDependency<TaskDynamicsImpl>(Update::UpdateValue, f, function::abstract::Function::Output::Velocity);
-    }
-    else
-    {
-      axsi_ = a_.array() * resizeParameter(f, xsi, "damping parameter").array();
-    }
+    xsi_ = config.xsiOff_;
   }
-
-  VelocityDamper::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, double dt, bool autoXsi, const Eigen::VectorXd & di, const Eigen::VectorXd & ds, const Eigen::VectorXd & xsi, double big)
-    : TaskDynamicsImpl(Order::Two, f, t, rhs)
-    , dt_(dt)
-    , ds_(resizeParameter(f, ds, "safety distance"))
-    , di_(resizeParameter(f, di, "interaction distance"))
-    , xsiOff_(0)
-    , a_(-(di_ - ds_).cwiseInverse())
-    , big_(big)
-    , autoXsi_(autoXsi)
-    , d_(f->size())
-    , axsi_(f->size())
-    , active_(f->size(), false)
+  else
   {
-    if (autoXsi)
-    {
-      axsi_.setOnes();
-      xsiOff_ = resizeParameter(f, xsi, "damping offset parameter");
-    }
-    else
-    {
-      axsi_ = a_.array() * resizeParameter(f, xsi, "damping parameter").array();
-    }
+    xsi_ = config.xsi_;
   }
-
-  void VelocityDamper::Impl::updateValue()
+  if(big <= 0)
   {
-    if (type() == constraint::Type::LOWER_THAN)
+    throw std::runtime_error("big should be non-negative.");
+  }
+}
+
+VelocityDamper::VelocityDamper(double dt, const Config & config, double big)
+: VelocityDamper(dt, AnisotropicConfig{config}, big)
+{
+}
+
+VelocityDamper::VelocityDamper(double dt, const AnisotropicConfig & config, double big)
+: dt_(dt), xsi_(0), ds_(config.ds_), di_(config.di_), big_(big),
+  autoXsi_(config.xsi_[0] == 0) // we have ensure they are either all 0 or all specified
+{
+  if(autoXsi_)
+  {
+    xsi_ = config.xsiOff_;
+  }
+  else
+  {
+    xsi_ = config.xsi_;
+  }
+  if(dt <= 0)
+  {
+    throw std::runtime_error("Time increment should be non-negative.");
+  }
+  if(big <= 0)
+  {
+    throw std::runtime_error("big should be non-negative.");
+  }
+}
+
+std::unique_ptr<abstract::TaskDynamicsImpl> VelocityDamper::impl_(FunctionPtr f,
+                                                                  constraint::Type t,
+                                                                  const Eigen::VectorXd & rhs) const
+{
+  if(dt_ > 0)
+  {
+    return std::make_unique<Impl>(f, t, rhs, dt_, autoXsi_, di_, ds_, xsi_, big_);
+  }
+  else
+  {
+    return std::make_unique<Impl>(f, t, rhs, autoXsi_, di_, ds_, xsi_, big_);
+  }
+}
+
+Order VelocityDamper::order_() const { return dt_ > 0 ? Order::Two : Order::One; }
+
+namespace
+{
+
+static inline Eigen::VectorXd resizeParameter(const FunctionPtr & f, const Eigen::VectorXd & in, const char * desc)
+{
+  if(in.size() == 1)
+  {
+    return Eigen::VectorXd::Constant(f->size(), 1, in[0]);
+  }
+  else if(in.size() != f->size())
+  {
+    std::string error = "Size of the " + std::string(desc) + " vector ( " + std::to_string(in.size())
+                        + " ) does not match the function size ( " + std::to_string(f->size()) + " ) ";
+    throw std::runtime_error(error.c_str());
+  }
+  return in;
+}
+
+} // namespace
+
+VelocityDamper::Impl::Impl(FunctionPtr f,
+                           constraint::Type t,
+                           const Eigen::VectorXd & rhs,
+                           bool autoXsi,
+                           const Eigen::VectorXd & di,
+                           const Eigen::VectorXd & ds,
+                           const Eigen::VectorXd & xsi,
+                           double big)
+: TaskDynamicsImpl(Order::One, f, t, rhs), dt_(0), ds_(resizeParameter(f, ds, "safety distance")),
+  di_(resizeParameter(f, di, "interaction distance")), xsiOff_(0), a_(-(di_ - ds_).cwiseInverse()), big_(big),
+  autoXsi_(autoXsi), d_(f->size()), axsi_(f->size()), active_(f->size(), false)
+{
+  if(autoXsi)
+  {
+    axsi_.setOnes();
+    xsiOff_ = resizeParameter(f, xsi, "damping offset parameter");
+    addInputDependency<TaskDynamicsImpl>(Update::UpdateValue, f, function::abstract::Function::Output::Velocity);
+  }
+  else
+  {
+    axsi_ = a_.array() * resizeParameter(f, xsi, "damping parameter").array();
+  }
+}
+
+VelocityDamper::Impl::Impl(FunctionPtr f,
+                           constraint::Type t,
+                           const Eigen::VectorXd & rhs,
+                           double dt,
+                           bool autoXsi,
+                           const Eigen::VectorXd & di,
+                           const Eigen::VectorXd & ds,
+                           const Eigen::VectorXd & xsi,
+                           double big)
+: TaskDynamicsImpl(Order::Two, f, t, rhs), dt_(dt), ds_(resizeParameter(f, ds, "safety distance")),
+  di_(resizeParameter(f, di, "interaction distance")), xsiOff_(0), a_(-(di_ - ds_).cwiseInverse()), big_(big),
+  autoXsi_(autoXsi), d_(f->size()), axsi_(f->size()), active_(f->size(), false)
+{
+  if(autoXsi)
+  {
+    axsi_.setOnes();
+    xsiOff_ = resizeParameter(f, xsi, "damping offset parameter");
+  }
+  else
+  {
+    axsi_ = a_.array() * resizeParameter(f, xsi, "damping parameter").array();
+  }
+}
+
+void VelocityDamper::Impl::updateValue()
+{
+  if(type() == constraint::Type::LOWER_THAN)
+  {
+    d_ = rhs() - function().value(); // turn f<=rhs into d = rhs-f >= 0
+    updateValue_(-1);
+    if(order() == Order::Two)
     {
-      d_ = rhs() - function().value(); //turn f<=rhs into d = rhs-f >= 0
-      updateValue_(-1);
-      if (order() == Order::Two)
+      value_ += function().velocity();
+      value_ /= dt_;
+    }
+    value_ = (d_.array() > di_.array()).select(big_, -value_);
+  }
+  else
+  {
+    d_ = function().value() - rhs(); // turn f>=rhs into d = f-rhs >= 0
+    updateValue_(+1);
+    if(order() == Order::Two)
+    {
+      value_ -= function().velocity();
+      value_ /= dt_;
+    }
+    value_ = (d_.array() > di_.array()).select(-big_, value_);
+  }
+}
+
+void VelocityDamper::Impl::updateValue_(double s)
+{
+  if(autoXsi_)
+  {
+    const auto & dv = function().velocity();
+    for(int i = 0; i < function().size(); ++i)
+    {
+      if(d_[i] <= di_[i] && !active_[static_cast<size_t>(i)])
       {
-        value_ += function().velocity();
-        value_ /= dt_;
+        active_[static_cast<size_t>(i)] = true;
+        axsi_[i] = a_[i] * (s * dv[i] * (ds_[i] - di_[i]) / (d_[i] - ds_[i]) + xsiOff_[i]);
       }
-      value_ = (d_.array() > di_.array()).select(big_, -value_);
-    }
-    else
-    {
-      d_ = function().value() - rhs(); //turn f>=rhs into d = f-rhs >= 0
-      updateValue_(+1);
-      if (order() == Order::Two)
+      else if(d_[i] > di_[i] && active_[static_cast<size_t>(i)])
       {
-        value_ -= function().velocity();
-        value_ /= dt_;
-      }
-      value_ = (d_.array() > di_.array()).select(-big_, value_);
-    }
-  }
-
-  void VelocityDamper::Impl::updateValue_(double s)
-  {
-    if (autoXsi_)
-    {
-      const auto& dv = function().velocity();
-      for (int i = 0; i < function().size(); ++i)
-      {
-        if (d_[i] <= di_[i] && !active_[static_cast<size_t>(i)])
-        {
-          active_[static_cast<size_t>(i)] = true;
-          axsi_[i] = a_[i] * (s * dv[i] * (ds_[i] - di_[i]) / (d_[i] - ds_[i]) + xsiOff_[i]);
-        }
-        else if (d_[i] > di_[i] && active_[static_cast<size_t>(i)])
-        {
-          active_[static_cast<size_t>(i)] = false;
-        }
+        active_[static_cast<size_t>(i)] = false;
       }
     }
-    value_.array() = d_.array() - ds_.array();
-    value_.array() *= axsi_.array();
   }
+  value_.array() = d_.array() - ds_.array();
+  value_.array() *= axsi_.array();
+}
 
-} // task_dynamics
+} // namespace task_dynamics
 
-} // tvm
+} // namespace tvm

--- a/src/task_dynamics/VelocityDamper.cpp
+++ b/src/task_dynamics/VelocityDamper.cpp
@@ -70,8 +70,7 @@ VelocityDamper::AnisotropicConfig::AnisotropicConfig(const Config & config)
                     Eigen::VectorXd::Constant(1, 1, config.ds_),
                     Eigen::VectorXd::Constant(1, 1, config.xsi_),
                     Eigen::VectorXd::Constant(1, 1, config.xsiOff_))
-{
-}
+{}
 
 VelocityDamper::VelocityDamper(const Config & config, double big) : VelocityDamper(AnisotropicConfig{config}, big) {}
 
@@ -95,8 +94,7 @@ VelocityDamper::VelocityDamper(const AnisotropicConfig & config, double big)
 
 VelocityDamper::VelocityDamper(double dt, const Config & config, double big)
 : VelocityDamper(dt, AnisotropicConfig{config}, big)
-{
-}
+{}
 
 VelocityDamper::VelocityDamper(double dt, const AnisotropicConfig & config, double big)
 : dt_(dt), xsi_(0), ds_(config.ds_), di_(config.di_), big_(big),

--- a/src/utils/UpdatelessFunction.cpp
+++ b/src/utils/UpdatelessFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/utils/UpdatelessFunction.h>
 
@@ -39,327 +39,340 @@ namespace tvm
 
 namespace utils
 {
-  UpdatelessFunction::UpdatelessFunction(FunctionPtr f)
-    : f_(f)
+UpdatelessFunction::UpdatelessFunction(FunctionPtr f) : f_(f)
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(f->isOutputEnabled(Output::Value))
   {
-    using Output = tvm::function::abstract::Function::Output;
-    if (f->isOutputEnabled(Output::Value))
-    {
-      auto valueUser = std::make_shared<graph::internal::Inputs>();
-      valueUser->addInput(f, Output::Value);
-      valueGraph_.add(valueUser);
-      valueGraph_.update();
-    }
-
-    if (f->isOutputEnabled(Output::Jacobian))
-    {
-      auto jacobianUser = std::make_shared<graph::internal::Inputs>();
-      jacobianUser->addInput(f, Output::Jacobian);
-      jacobianGraph_.add(jacobianUser);
-      jacobianGraph_.update();
-    }
-
-    if (f->isOutputEnabled(Output::Velocity))
-    {
-      auto velocityUser = std::make_shared<graph::internal::Inputs>();
-      velocityUser->addInput(f, Output::Velocity);
-      velocityGraph_.add(velocityUser);
-      velocityGraph_.update();
-    }
-
-    if (f->isOutputEnabled(Output::NormalAcceleration))
-    {
-      auto normalAccelerationUser = std::make_shared<graph::internal::Inputs>();
-      normalAccelerationUser->addInput(f, Output::NormalAcceleration);
-      normalAccelerationGraph_.add(normalAccelerationUser);
-      normalAccelerationGraph_.update();
-    }
-
-    if (f->isOutputEnabled(Output::JDot))
-    {
-      auto JDotUser = std::make_shared<graph::internal::Inputs>();
-      JDotUser->addInput(f, Output::JDot);
-      JDotGraph_.add(JDotUser);
-      JDotGraph_.update();
-    }
-
-    for (const auto& x : f_->variables())
-    {
-      dx_.push_back(dot(x));
-    }
+    auto valueUser = std::make_shared<graph::internal::Inputs>();
+    valueUser->addInput(f, Output::Value);
+    valueGraph_.add(valueUser);
+    valueGraph_.update();
   }
 
-  Eigen::VectorXd UpdatelessFunction::toVec(std::initializer_list<double> val)
+  if(f->isOutputEnabled(Output::Jacobian))
   {
-    Eigen::VectorXd v(static_cast<int>(val.size()));
-    Eigen::DenseIndex k = 0;
-    for (auto d : val)
-    {
-      v[k] = d;
-      ++k;
-    }
-    return v;
+    auto jacobianUser = std::make_shared<graph::internal::Inputs>();
+    jacobianUser->addInput(f, Output::Jacobian);
+    jacobianGraph_.add(jacobianUser);
+    jacobianGraph_.update();
   }
 
-  void UpdatelessFunction::assign(size_t i, const Eigen::VectorXd & val, bool value) const
+  if(f->isOutputEnabled(Output::Velocity))
   {
-    const auto& x = f_->variables().variables();
-    if (i >= x.size())
+    auto velocityUser = std::make_shared<graph::internal::Inputs>();
+    velocityUser->addInput(f, Output::Velocity);
+    velocityGraph_.add(velocityUser);
+    velocityGraph_.update();
+  }
+
+  if(f->isOutputEnabled(Output::NormalAcceleration))
+  {
+    auto normalAccelerationUser = std::make_shared<graph::internal::Inputs>();
+    normalAccelerationUser->addInput(f, Output::NormalAcceleration);
+    normalAccelerationGraph_.add(normalAccelerationUser);
+    normalAccelerationGraph_.update();
+  }
+
+  if(f->isOutputEnabled(Output::JDot))
+  {
+    auto JDotUser = std::make_shared<graph::internal::Inputs>();
+    JDotUser->addInput(f, Output::JDot);
+    JDotGraph_.add(JDotUser);
+    JDotGraph_.update();
+  }
+
+  for(const auto & x : f_->variables())
+  {
+    dx_.push_back(dot(x));
+  }
+}
+
+Eigen::VectorXd UpdatelessFunction::toVec(std::initializer_list<double> val)
+{
+  Eigen::VectorXd v(static_cast<int>(val.size()));
+  Eigen::DenseIndex k = 0;
+  for(auto d : val)
+  {
+    v[k] = d;
+    ++k;
+  }
+  return v;
+}
+
+void UpdatelessFunction::assign(size_t i, const Eigen::VectorXd & val, bool value) const
+{
+  const auto & x = f_->variables().variables();
+  if(i >= x.size())
+  {
+    std::stringstream s;
+    s << "Too many values provided (got " << i << ", expected " << x.size() << ")." << std::endl;
+    throw std::runtime_error(s.str());
+  }
+  if(value)
+  {
+    if(val.size() == x[i]->size())
+    {
+      x[i]->value(val);
+    }
+    else
     {
       std::stringstream s;
-      s << "Too many values provided (got " << i << ", expected " << x.size() << ")." << std::endl;
-      throw std::runtime_error(s.str());
+      s << "The size provided for the " << i << "-th variable's value (" << x[i]->name() << ") is incorrect (got"
+        << val.size() << ", expected " << x[i]->size() << ")." << std::endl;
+      throw std::runtime_error("");
     }
-    if (value)
+  }
+  else
+  {
+    auto dxi = dot(x[i]);
+    if(val.size() == dxi->size())
     {
-      if (val.size() == x[i]->size())
+      dxi->value(val);
+    }
+    else
+    {
+      std::stringstream s;
+      s << "The size provided for the " << i << "-th variable's velocity (" << x[i]->name() << ") is incorrect (got"
+        << val.size() << ", expected " << dxi->size() << ")." << std::endl;
+      throw std::runtime_error("");
+    }
+  }
+}
+
+void UpdatelessFunction::assign(Variable & x, const Eigen::VectorXd & val, bool value) const
+{
+  const auto & vars = f_->variables().variables();
+  if(vars.size() == 0)
+  {
+    throw std::runtime_error("This function has no variable.");
+  }
+
+  auto ptr = vars[0];
+  VariablePtr p(ptr, &x);
+  auto it = std::find(vars.begin(), vars.end(), p);
+  if(it != vars.end())
+  {
+    if(value)
+    {
+      if(val.size() == x.size())
       {
-        x[i]->value(val);
+        x.value(val);
       }
       else
       {
         std::stringstream s;
-        s << "The size provided for the " << i << "-th variable's value (" << x[i]->name()
-          << ") is incorrect (got" << val.size() << ", expected " << x[i]->size() << ")." << std::endl;
+        s << "The size provided for the value of variable " << x.name() << "is incorrect (got" << val.size()
+          << ", expected " << x.size() << ")." << std::endl;
         throw std::runtime_error("");
       }
     }
     else
     {
-      auto dxi = dot(x[i]);
-      if (val.size() == dxi->size())
+      auto dxi = dot(*it);
+      if(val.size() == dxi->size())
       {
         dxi->value(val);
       }
       else
       {
         std::stringstream s;
-        s << "The size provided for the " << i << "-th variable's velocity (" << x[i]->name()
-          << ") is incorrect (got" << val.size() << ", expected " << dxi->size() << ")." << std::endl;
+        s << "The size provided for the velocity of variable " << x.name() << "is incorrect (got" << val.size()
+          << ", expected " << dxi->size() << ")." << std::endl;
         throw std::runtime_error("");
       }
     }
   }
-
-  void UpdatelessFunction::assign(Variable& x, const Eigen::VectorXd & val, bool value) const
+  else
   {
-    const auto& vars = f_->variables().variables();
-    if (vars.size() == 0)
-    {
-      throw std::runtime_error("This function has no variable.");
-    }
+    throw std::runtime_error("This function does not depend on variable " + x.name());
+  }
+}
 
-    auto ptr = vars[0];
-    VariablePtr p(ptr, &x);
-    auto it = std::find(vars.begin(), vars.end(), p);
-    if (it != vars.end())
-    {
-      if (value)
-      {
-        if (val.size() == x.size())
-        {
-          x.value(val);
-        }
-        else
-        {
-          std::stringstream s;
-          s << "The size provided for the value of variable " << x.name() << "is incorrect (got" 
-            << val.size() << ", expected " << x.size() << ")." << std::endl;
-          throw std::runtime_error("");
-        }
-      }
-      else
-      {
-        auto dxi = dot(*it);
-        if (val.size() == dxi->size())
-        {
-          dxi->value(val);
-        }
-        else
-        {
-          std::stringstream s;
-          s << "The size provided for the velocity of variable " << x.name() << "is incorrect (got"
-            << val.size() << ", expected " << dxi->size() << ")." << std::endl;
-          throw std::runtime_error("");
-        }
-      }
-    }
-    else
-    {
-      throw std::runtime_error("This function does not depend on variable " + x.name());
-    }
+void UpdatelessFunction::assign(const Eigen::VectorXd & val) const
+{
+  const auto & x = f_->variables().variables();
+
+  auto s = x[0]->size();
+  for(size_t i = 1; i < x.size(); ++i)
+  {
+    s += x[i]->size();
+  }
+  if(val.size() != s)
+  {
+    throw std::runtime_error(
+        "The length of the concatenated vector does not correspond to the total length of the variables.");
   }
 
-  void UpdatelessFunction::assign(const Eigen::VectorXd & val) const
+  s = 0;
+  for(size_t i = 0; i < x.size(); ++i)
   {
-    const auto& x = f_->variables().variables();
+    auto ni = x[i]->size();
+    x[i]->value(val.segment(s, ni));
+    s += ni;
+  }
+}
 
-    auto s = x[0]->size();
-    for (size_t i = 1; i < x.size(); ++i)
-    {
-      s += x[i]->size();
-    }
-    if (val.size() != s)
-    {
-      throw std::runtime_error("The length of the concatenated vector does not correspond to the total length of the variables.");
-    }
+void UpdatelessFunction::assign(const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const
+{
+  const auto & x = f_->variables().variables();
 
-    s = 0;
-    for (size_t i = 0; i < x.size(); ++i)
-    {
-      auto ni = x[i]->size();
-      x[i]->value(val.segment(s, ni));
-      s += ni;
-    }
+  auto sp = x[0]->size();
+  auto sd = dx_[0]->size();
+  for(size_t i = 1; i < x.size(); ++i)
+  {
+    sp += x[i]->size();
+    sd += dx_[i]->size();
+  }
+  if(val.size() != sp)
+  {
+    throw std::runtime_error(
+        "The length of the concatenated value vector does not correspond to the total length of the variables.");
+  }
+  if(vel.size() != sd)
+  {
+    throw std::runtime_error("The length of the concatenated vector velocity does not correspond to the total length "
+                             "of the variables derivatives.");
   }
 
-  void UpdatelessFunction::assign(const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const
+  sp = 0;
+  sd = 0;
+  for(size_t i = 0; i < x.size(); ++i)
   {
-    const auto& x = f_->variables().variables();
-
-    auto sp = x[0]->size();
-    auto sd = dx_[0]->size();
-    for (size_t i = 1; i < x.size(); ++i)
-    {
-      sp += x[i]->size();
-      sd += dx_[i]->size();
-    }
-    if (val.size() != sp)
-    {
-      throw std::runtime_error("The length of the concatenated value vector does not correspond to the total length of the variables.");
-    }
-    if (vel.size() != sd)
-    {
-      throw std::runtime_error("The length of the concatenated vector velocity does not correspond to the total length of the variables derivatives.");
-    }
-
-    sp = 0;
-    sd = 0;
-    for (size_t i = 0; i < x.size(); ++i)
-    {
-      auto spi = x[i]->size();
-      auto sdi = dx_[i]->size();
-      x[i]->value(val.segment(sp, spi));
-      dx_[i]->value(vel.segment(sd, sdi));
-      sp += spi;
-      sd += sdi;
-    }
+    auto spi = x[i]->size();
+    auto sdi = dx_[i]->size();
+    x[i]->value(val.segment(sp, spi));
+    dx_[i]->value(vel.segment(sd, sdi));
+    sp += spi;
+    sd += sdi;
   }
+}
 
-  void UpdatelessFunction::parseValues_(int i, const Eigen::VectorXd & v) const
+void UpdatelessFunction::parseValues_(int i, const Eigen::VectorXd & v) const
+{
+  const auto & x = f_->variables().variables();
+  if(i + 1 == static_cast<int>(x.size()))
   {
-    const auto& x = f_->variables().variables();
-    if (i + 1 == static_cast<int>(x.size()))
+    assign(i, v, true);
+  }
+  else
+  {
+    if(i < static_cast<int>(x.size()))
     {
-      assign(i, v, true);
-    }
-    else
-    {
-      if (i < static_cast<int>(x.size()))
+      if(i == 0) // case of concatenated values and velocities
       {
-        if (i == 0) //case of concatenated values and velocities
-        {
-          assign(v);
-        }
-        else
-        {
-          std::stringstream s;
-          s << "Too few values provided (got " << i << ", expected " << x.size() << ")." << std::endl;
-          throw std::runtime_error(s.str());
-        }
+        assign(v);
       }
       else
       {
         std::stringstream s;
-        s << "Too many values provided (got " << i << ", expected " << x.size() << ")." << std::endl;
+        s << "Too few values provided (got " << i << ", expected " << x.size() << ")." << std::endl;
         throw std::runtime_error(s.str());
       }
     }
-  }
-
-  void UpdatelessFunction::parseValues_(int i, std::initializer_list<double> v) const
-  {
-    parseValues_(i, toVec(v));
-  }
-
-  void UpdatelessFunction::parseValues_(Variable & x, const Eigen::VectorXd & v) const
-  {
-    assign(x, v, true);
-  }
-
-  void UpdatelessFunction::parseValues_(Variable & x, std::initializer_list<double> v) const
-  {
-    parseValues_(x, toVec(v));
-  }
-
-  void UpdatelessFunction::parseValuesAndVelocities_(int i, const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const
-  {
-    const auto& x = f_->variables().variables();
-    if (i + 1 == static_cast<int>(x.size()))
-    {
-      assign(i, val, true);
-      assign(i, vel, false);
-    }
     else
     {
-      if (i < static_cast<int>(x.size()))
+      std::stringstream s;
+      s << "Too many values provided (got " << i << ", expected " << x.size() << ")." << std::endl;
+      throw std::runtime_error(s.str());
+    }
+  }
+}
+
+void UpdatelessFunction::parseValues_(int i, std::initializer_list<double> v) const { parseValues_(i, toVec(v)); }
+
+void UpdatelessFunction::parseValues_(Variable & x, const Eigen::VectorXd & v) const { assign(x, v, true); }
+
+void UpdatelessFunction::parseValues_(Variable & x, std::initializer_list<double> v) const
+{
+  parseValues_(x, toVec(v));
+}
+
+void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                   const Eigen::VectorXd & val,
+                                                   const Eigen::VectorXd & vel) const
+{
+  const auto & x = f_->variables().variables();
+  if(i + 1 == static_cast<int>(x.size()))
+  {
+    assign(i, val, true);
+    assign(i, vel, false);
+  }
+  else
+  {
+    if(i < static_cast<int>(x.size()))
+    {
+      if(i == 0) // case of concatenated values and velocities
       {
-        if (i == 0) //case of concatenated values and velocities
-        {
-          assign(val, vel);
-        }
-        else
-        {
-          std::stringstream s;
-          s << "Too few values provided (got " << i << " pairs value/velocity, expected " << x.size() << ")." << std::endl;
-          throw std::runtime_error(s.str());
-        }
+        assign(val, vel);
       }
       else
       {
         std::stringstream s;
-        s << "Too many values provided (got " << i << " pairs value/velocity, expected " << x.size() << ")." << std::endl;
+        s << "Too few values provided (got " << i << " pairs value/velocity, expected " << x.size() << ")."
+          << std::endl;
         throw std::runtime_error(s.str());
       }
     }
+    else
+    {
+      std::stringstream s;
+      s << "Too many values provided (got " << i << " pairs value/velocity, expected " << x.size() << ")." << std::endl;
+      throw std::runtime_error(s.str());
+    }
   }
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(int i, const Eigen::VectorXd & val, std::initializer_list<double> vel) const
-  {
-    parseValuesAndVelocities_(i, val, toVec(vel));
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                   const Eigen::VectorXd & val,
+                                                   std::initializer_list<double> vel) const
+{
+  parseValuesAndVelocities_(i, val, toVec(vel));
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(int i, std::initializer_list<double> val, const Eigen::VectorXd & vel) const
-  {
-    parseValuesAndVelocities_(i, toVec(val), vel);
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                   std::initializer_list<double> val,
+                                                   const Eigen::VectorXd & vel) const
+{
+  parseValuesAndVelocities_(i, toVec(val), vel);
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(int i, std::initializer_list<double> val, std::initializer_list<double> vel) const
-  {
-    parseValuesAndVelocities_(i, toVec(val), toVec(vel));
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(int i,
+                                                   std::initializer_list<double> val,
+                                                   std::initializer_list<double> vel) const
+{
+  parseValuesAndVelocities_(i, toVec(val), toVec(vel));
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, const Eigen::VectorXd & val, const Eigen::VectorXd & vel) const
-  {
-    assign(x, val, true);
-    assign(x, vel, false);
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                   const Eigen::VectorXd & val,
+                                                   const Eigen::VectorXd & vel) const
+{
+  assign(x, val, true);
+  assign(x, vel, false);
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, const Eigen::VectorXd & val, std::initializer_list<double> vel) const
-  {
-    parseValuesAndVelocities_(x, val, toVec(vel));
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                   const Eigen::VectorXd & val,
+                                                   std::initializer_list<double> vel) const
+{
+  parseValuesAndVelocities_(x, val, toVec(vel));
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, std::initializer_list<double> val, const Eigen::VectorXd & vel) const
-  {
-    parseValuesAndVelocities_(x, toVec(val), vel);
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                   std::initializer_list<double> val,
+                                                   const Eigen::VectorXd & vel) const
+{
+  parseValuesAndVelocities_(x, toVec(val), vel);
+}
 
-  void UpdatelessFunction::parseValuesAndVelocities_(Variable & x, std::initializer_list<double> val, std::initializer_list<double> vel) const
-  {
-    parseValuesAndVelocities_(x, toVec(val), toVec(vel));
-  }
+void UpdatelessFunction::parseValuesAndVelocities_(Variable & x,
+                                                   std::initializer_list<double> val,
+                                                   std::initializer_list<double> vel) const
+{
+  parseValuesAndVelocities_(x, toVec(val), toVec(vel));
+}
 
-} //namespace utils
+} // namespace utils
 
 } // namespace tvm

--- a/src/utils/UpdatelessFunction.cpp
+++ b/src/utils/UpdatelessFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/utils/UpdatelessFunction.h>
 

--- a/src/utils/checkFunction.cpp
+++ b/src/utils/checkFunction.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/utils/checkFunction.h>
 
@@ -41,206 +41,204 @@ namespace tvm
 
 namespace utils
 {
-  bool TVM_DLLAPI checkJacobian(FunctionPtr f, CheckOptions opt)
+bool TVM_DLLAPI checkJacobian(FunctionPtr f, CheckOptions opt)
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(!(f->isOutputEnabled(Output::Value) && f->isOutputEnabled(Output::Jacobian)))
   {
-    using Output = tvm::function::abstract::Function::Output;
-    if (!(f->isOutputEnabled(Output::Value) && f->isOutputEnabled(Output::Jacobian)))
+    throw std::runtime_error("The function must provide its value and jacobian for this test.");
+  }
+
+  const double h = opt.step;
+
+  UpdatelessFunction uf(f);
+  const auto & x = f->variables().variables();
+
+  int n = 0;
+  for(const auto & xi : x)
+  {
+    if(!xi->isEuclidean())
     {
-      throw std::runtime_error("The function must provide its value and jacobian for this test.");
+      // For now, we only accept Euclidean variables. This could be extended to generic
+      // manifolds if we get the information on how to make finite differences on the
+      // non-Euclidean variables (i.e. if we get a retraction).
+      // Note to developpers: ffd with manifolds can be found in PostureGenerator and
+      // externally-provided retraction are used in GeometricFramework
+      throw std::runtime_error("This function is implemented for Euclidean variables only.");
     }
+    n += xi->size();
+  }
+  VectorXd v0 = VectorXd::Random(n);
+  VectorXd v = v0;
+  VectorXd f0 = uf.value(v0);
+  MatrixXd J(f0.size(), n);
+  MatrixXd J0(f0.size(), n);
 
-    const double h = opt.step;
+  int s = 0;
+  for(const auto & xi : x)
+  {
+    int ni = xi->size();
+    J0.middleCols(s, ni) = uf.jacobian(*xi, v0);
+    s += ni;
+  }
 
-    UpdatelessFunction uf(f);
-    const auto& x = f->variables().variables();
-
-    int n = 0;
-    for (const auto& xi : x)
+  bool b = true;
+  int i = 0;
+  for(const auto & xi : x)
+  {
+    for(int j = 0; j < xi->size(); ++j)
     {
-      if (!xi->isEuclidean())
+      v[i] += h;
+      const VectorXd & f = uf.value(v);
+      J.col(i) = (f - f0) / h;
+      if(!J.col(i).isApprox(J0.col(i), opt.prec))
       {
-        //For now, we only accept Euclidean variables. This could be extended to generic 
-        //manifolds if we get the information on how to make finite differences on the
-        //non-Euclidean variables (i.e. if we get a retraction).
-        //Note to developpers: ffd with manifolds can be found in PostureGenerator and
-        //externally-provided retraction are used in GeometricFramework
-        throw std::runtime_error("This function is implemented for Euclidean variables only.");
-      }
-      n += xi->size();
-    }
-    VectorXd v0 = VectorXd::Random(n);
-    VectorXd v = v0;
-    VectorXd f0 = uf.value(v0);
-    MatrixXd J(f0.size(), n);
-    MatrixXd J0(f0.size(), n);
-    
-    int s = 0;
-    for (const auto& xi : x)
-    {
-      int ni = xi->size();
-      J0.middleCols(s,ni) = uf.jacobian(*xi, v0);
-      s += ni;
-    }
-
-    bool b = true;
-    int i = 0;
-    for (const auto& xi : x) 
-    {
-      for (int j = 0; j < xi->size(); ++j)
-      {
-        v[i] += h;
-        const VectorXd& f = uf.value(v);
-        J.col(i) = (f - f0) / h;
-        if (!J.col(i).isApprox(J0.col(i), opt.prec))
+        b = false;
+        if(opt.verbose)
         {
-          b = false;
-          if (opt.verbose)
-          {
-            std::cout << "col(" << j << ") of the jacobian matrix associated to variable " << xi->name()
-                      << " (col(" << i << ") of the total jacobian) is not equivalent to the result of the ffd." << std::endl;
-          }
+          std::cout << "col(" << j << ") of the jacobian matrix associated to variable " << xi->name() << " (col(" << i
+                    << ") of the total jacobian) is not equivalent to the result of the ffd." << std::endl;
         }
-        v[i] -= h;
-        ++i;
       }
-    }
-
-    if (!b && opt.verbose)
-    {
-      std::cout << "got:\n" << J0 << std::endl;
-      std::cout << "ffd:\n" << J << std::endl;
-    }
-    return b;
-  }
-
-  bool TVM_DLLAPI checkVelocity(FunctionPtr f, CheckOptions opt)
-  {
-    using Output = tvm::function::abstract::Function::Output;
-    if (!(f->isOutputEnabled(Output::Velocity) && f->isOutputEnabled(Output::Jacobian)))
-    {
-      throw std::runtime_error("The function must provide its velocity and jacobian for this test.");
-    }
-
-    UpdatelessFunction uf(f);
-    const auto& x = f->variables().variables();
-
-    int n = 0;
-    int nd = 0;
-    for (const auto& xi : x)
-    {
-      //We can handle non-Euclidean variables here
-      n += xi->size();
-      nd += dot(xi)->size();
-    }
-    VectorXd val = VectorXd::Random(n);
-    VectorXd vel = VectorXd::Random(nd);
-
-    VectorXd v0 = uf.velocity(val, vel);
-    
-    VectorXd v = VectorXd::Zero(v0.size());
-    //Force computation of jacobian matrices
-    uf.jacobian(*x[0], val);
-
-    //sum df/dxi * dxi/dt
-    for (const auto& xi : x)
-    {
-      v += f->jacobian(*xi)*dot(xi)->value();
-    }
-
-    if (v.isApprox(v0, opt.prec))
-    {
-      return true;
-    }
-    else
-    {
-      if (opt.verbose)
-      {
-        std::cout << "Incorrect velocity (or jacobian if you did not check it):\n"
-                  << "got\t\t" << v0.transpose()
-                  << "\nexpected\t" << v.transpose() << std::endl;
-      }
-      return false;
+      v[i] -= h;
+      ++i;
     }
   }
 
-  bool TVM_DLLAPI checkNormalAcceleration(FunctionPtr f, CheckOptions opt)
+  if(!b && opt.verbose)
   {
-    using Output = tvm::function::abstract::Function::Output;
-    if (!(f->isOutputEnabled(Output::Velocity) && f->isOutputEnabled(Output::Jacobian)))
-    {
-      throw std::runtime_error("The function must provide its velocity and jacobian for this test.");
-    }
+    std::cout << "got:\n" << J0 << std::endl;
+    std::cout << "ffd:\n" << J << std::endl;
+  }
+  return b;
+}
 
-    UpdatelessFunction uf(f);
-    const auto& x = f->variables().variables();
-
-    int n = 0;
-    int nd = 0;
-    for (const auto& xi : x)
-    {
-      if (!xi->isEuclidean())
-      {
-        //For now, we only accept Euclidean variables. See note in checkJacobian's code.
-        throw std::runtime_error("This function is implemented for Euclidean variables only.");
-      }
-      n += xi->size();
-      nd += dot(xi)->size();
-    }
-
-    //value of x(t)
-    VectorXd val0 = VectorXd::Random(n);
-    //value of dx(t)
-    VectorXd vel0 = VectorXd::Random(nd);
-    //value of ddx(t)
-    VectorXd acc = VectorXd::Random(nd).normalized();
-
-    //we consider a constant-acceleration trajectory in variable space
-    double dt = opt.step;
-    VectorXd vel1 = vel0 + acc*dt;
-    VectorXd val1 = val0 + vel0*dt + 0.5*acc.cwiseProduct(acc)*dt*dt;
-
-    VectorXd v0 = uf.velocity(val0, vel0);
-    VectorXd v1 = uf.velocity(val1, vel1);
-    //Approximation of d2f/dt2
-    VectorXd a = (v1 - v0)/dt;
-
-    //Force computation of jacobian matrices
-    uf.jacobian(*x[0], val0);
-
-    //Compute (d2f/dt2-J*dx2/dt2)
-    int s = 0;
-    for (const auto& xi : x)
-    {
-      int ni = xi->size();
-      a -= f->jacobian(*xi)*acc.segment(s, ni);
-      s += ni;
-    }
-
-    const VectorXd& na = uf.normalAcceleration(val0, vel0);
-    if (na.isApprox(a, opt.prec))
-    {
-      return true;
-    }
-    else
-    {
-      if (opt.verbose)
-      {
-        std::cout << "Incorrect normal acceleration:\n"
-                  << "got\t\t" << na.transpose()
-                  << "\nexpected\t" << a.transpose() << std::endl;
-      }
-      return false;
-    }
+bool TVM_DLLAPI checkVelocity(FunctionPtr f, CheckOptions opt)
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(!(f->isOutputEnabled(Output::Velocity) && f->isOutputEnabled(Output::Jacobian)))
+  {
+    throw std::runtime_error("The function must provide its velocity and jacobian for this test.");
   }
 
-  bool TVM_DLLAPI checkFunction(FunctionPtr f, CheckOptions opt)
+  UpdatelessFunction uf(f);
+  const auto & x = f->variables().variables();
+
+  int n = 0;
+  int nd = 0;
+  for(const auto & xi : x)
   {
-    // Call the functions in order: checkVelocity will only be called if checkj\Jacobian
-    // passes, which is good as checkVelocity relies on having correct jacobian matrices.
-    // Likewise checkNormalAcceleration relies on having correct jacobian matrices and
-    // velocities.
-    return checkJacobian(f,opt) && checkVelocity(f,opt) && checkNormalAcceleration(f, opt);
+    // We can handle non-Euclidean variables here
+    n += xi->size();
+    nd += dot(xi)->size();
+  }
+  VectorXd val = VectorXd::Random(n);
+  VectorXd vel = VectorXd::Random(nd);
+
+  VectorXd v0 = uf.velocity(val, vel);
+
+  VectorXd v = VectorXd::Zero(v0.size());
+  // Force computation of jacobian matrices
+  uf.jacobian(*x[0], val);
+
+  // sum df/dxi * dxi/dt
+  for(const auto & xi : x)
+  {
+    v += f->jacobian(*xi) * dot(xi)->value();
+  }
+
+  if(v.isApprox(v0, opt.prec))
+  {
+    return true;
+  }
+  else
+  {
+    if(opt.verbose)
+    {
+      std::cout << "Incorrect velocity (or jacobian if you did not check it):\n"
+                << "got\t\t" << v0.transpose() << "\nexpected\t" << v.transpose() << std::endl;
+    }
+    return false;
   }
 }
 
+bool TVM_DLLAPI checkNormalAcceleration(FunctionPtr f, CheckOptions opt)
+{
+  using Output = tvm::function::abstract::Function::Output;
+  if(!(f->isOutputEnabled(Output::Velocity) && f->isOutputEnabled(Output::Jacobian)))
+  {
+    throw std::runtime_error("The function must provide its velocity and jacobian for this test.");
+  }
+
+  UpdatelessFunction uf(f);
+  const auto & x = f->variables().variables();
+
+  int n = 0;
+  int nd = 0;
+  for(const auto & xi : x)
+  {
+    if(!xi->isEuclidean())
+    {
+      // For now, we only accept Euclidean variables. See note in checkJacobian's code.
+      throw std::runtime_error("This function is implemented for Euclidean variables only.");
+    }
+    n += xi->size();
+    nd += dot(xi)->size();
+  }
+
+  // value of x(t)
+  VectorXd val0 = VectorXd::Random(n);
+  // value of dx(t)
+  VectorXd vel0 = VectorXd::Random(nd);
+  // value of ddx(t)
+  VectorXd acc = VectorXd::Random(nd).normalized();
+
+  // we consider a constant-acceleration trajectory in variable space
+  double dt = opt.step;
+  VectorXd vel1 = vel0 + acc * dt;
+  VectorXd val1 = val0 + vel0 * dt + 0.5 * acc.cwiseProduct(acc) * dt * dt;
+
+  VectorXd v0 = uf.velocity(val0, vel0);
+  VectorXd v1 = uf.velocity(val1, vel1);
+  // Approximation of d2f/dt2
+  VectorXd a = (v1 - v0) / dt;
+
+  // Force computation of jacobian matrices
+  uf.jacobian(*x[0], val0);
+
+  // Compute (d2f/dt2-J*dx2/dt2)
+  int s = 0;
+  for(const auto & xi : x)
+  {
+    int ni = xi->size();
+    a -= f->jacobian(*xi) * acc.segment(s, ni);
+    s += ni;
+  }
+
+  const VectorXd & na = uf.normalAcceleration(val0, vel0);
+  if(na.isApprox(a, opt.prec))
+  {
+    return true;
+  }
+  else
+  {
+    if(opt.verbose)
+    {
+      std::cout << "Incorrect normal acceleration:\n"
+                << "got\t\t" << na.transpose() << "\nexpected\t" << a.transpose() << std::endl;
+    }
+    return false;
+  }
 }
+
+bool TVM_DLLAPI checkFunction(FunctionPtr f, CheckOptions opt)
+{
+  // Call the functions in order: checkVelocity will only be called if checkj\Jacobian
+  // passes, which is good as checkVelocity relies on having correct jacobian matrices.
+  // Likewise checkNormalAcceleration relies on having correct jacobian matrices and
+  // velocities.
+  return checkJacobian(f, opt) && checkVelocity(f, opt) && checkNormalAcceleration(f, opt);
+}
+} // namespace utils
+
+} // namespace tvm

--- a/src/utils/checkFunction.cpp
+++ b/src/utils/checkFunction.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/utils/checkFunction.h>
 

--- a/src/utils/sch.cpp
+++ b/src/utils/sch.cpp
@@ -1,31 +1,31 @@
 /* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-*
-* 3. Neither the name of the copyright holder nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <tvm/utils/sch.h>
 
@@ -35,46 +35,45 @@ namespace tvm
 namespace utils
 {
 
-  void transform(sch::S_Object& obj, const sva::PTransformd& t)
-  {
-    sch::Matrix4x4 m;
-    const Eigen::Matrix3d& rot = t.rotation();
-    const Eigen::Vector3d& tran = t.translation();
+void transform(sch::S_Object & obj, const sva::PTransformd & t)
+{
+  sch::Matrix4x4 m;
+  const Eigen::Matrix3d & rot = t.rotation();
+  const Eigen::Vector3d & tran = t.translation();
 
-    for(unsigned int i = 0; i < 3; ++i)
+  for(unsigned int i = 0; i < 3; ++i)
+  {
+    for(unsigned int j = 0; j < 3; ++j)
     {
-      for(unsigned int j = 0; j < 3; ++j)
-      {
-        m(i,j) = rot(j,i);
-      }
+      m(i, j) = rot(j, i);
     }
-
-    m(0,3) = tran(0);
-    m(1,3) = tran(1);
-    m(2,3) = tran(2);
-
-    obj.setTransformation(m);
   }
 
-  std::unique_ptr<sch::S_Polyhedron> Polyhedron(const std::string& filename)
-  {
-    auto s = std::unique_ptr<sch::S_Polyhedron>(new sch::S_Polyhedron{});
-    s->constructFromFile(filename);
-    return s;
-  }
+  m(0, 3) = tran(0);
+  m(1, 3) = tran(1);
+  m(2, 3) = tran(2);
 
+  obj.setTransformation(m);
+}
 
-  double distance(sch::CD_Pair& pair, Eigen::Vector3d& p1, Eigen::Vector3d& p2)
-  {
-    sch::Point3 p1Tmp, p2Tmp;
-    double dist = pair.getClosestPoints(p1Tmp, p2Tmp);
+std::unique_ptr<sch::S_Polyhedron> Polyhedron(const std::string & filename)
+{
+  auto s = std::unique_ptr<sch::S_Polyhedron>(new sch::S_Polyhedron{});
+  s->constructFromFile(filename);
+  return s;
+}
 
-    p1 << p1Tmp[0], p1Tmp[1], p1Tmp[2];
-    p2 << p2Tmp[0], p2Tmp[1], p2Tmp[2];
+double distance(sch::CD_Pair & pair, Eigen::Vector3d & p1, Eigen::Vector3d & p2)
+{
+  sch::Point3 p1Tmp, p2Tmp;
+  double dist = pair.getClosestPoints(p1Tmp, p2Tmp);
 
-    return dist;
-  }
+  p1 << p1Tmp[0], p1Tmp[1], p1Tmp[2];
+  p2 << p2Tmp[0], p2Tmp[1], p2Tmp[2];
 
-} // utils
+  return dist;
+}
+
+} // namespace utils
 
 } // namespace tvm

--- a/src/utils/sch.cpp
+++ b/src/utils/sch.cpp
@@ -1,31 +1,4 @@
-/* Copyright 2017-2018 CNRS-AIST JRL and CNRS-UM LIRMM
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
+/** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/utils/sch.h>
 

--- a/tests/AffineExprTest.cpp
+++ b/tests/AffineExprTest.cpp
@@ -71,21 +71,21 @@ TEST_CASE("Test AffineExpr compilation and validity")
   VectorXd d = VectorXd::Random(6);
   VectorXd e = VectorXd::Random(6);
 
-  TEST_AFFINE_EXPR(A * x, x, vx) // LinearExpr, simple case
-  TEST_AFFINE_EXPR(M * A * x, x, vx) // LinearExpr, simple matrix expression
-  TEST_AFFINE_EXPR((d.asDiagonal() * A + M * B) * x, x, vx) // complex matrix expression
-  TEST_AFFINE_EXPR(A * x + d, x, vx) // AffineExpr = LinearExpr + vector
-  TEST_AFFINE_EXPR(d + A * x, x, vx) // AffineExpr = vector + LinearExpr
-  TEST_AFFINE_EXPR(A * x + (3 * d + M * e), x, vx) // AffineExpr = LinearExpr + vector(complex expr)
-  TEST_AFFINE_EXPR(A * x + B * y, x, vx, y, vy) // AffineExpr = LinearExpr + LinearExpr
-  TEST_AFFINE_EXPR(A * x + B * y + C * z, x, vx, y, vy, z, vz) // AffineExpr = AffineExpr + LinearExpr
+  TEST_AFFINE_EXPR(A * x, x, vx)                                 // LinearExpr, simple case
+  TEST_AFFINE_EXPR(M * A * x, x, vx)                             // LinearExpr, simple matrix expression
+  TEST_AFFINE_EXPR((d.asDiagonal() * A + M * B) * x, x, vx)      // complex matrix expression
+  TEST_AFFINE_EXPR(A * x + d, x, vx)                             // AffineExpr = LinearExpr + vector
+  TEST_AFFINE_EXPR(d + A * x, x, vx)                             // AffineExpr = vector + LinearExpr
+  TEST_AFFINE_EXPR(A * x + (3 * d + M * e), x, vx)               // AffineExpr = LinearExpr + vector(complex expr)
+  TEST_AFFINE_EXPR(A * x + B * y, x, vx, y, vy)                  // AffineExpr = LinearExpr + LinearExpr
+  TEST_AFFINE_EXPR(A * x + B * y + C * z, x, vx, y, vy, z, vz)   // AffineExpr = AffineExpr + LinearExpr
   TEST_AFFINE_EXPR(A * x + (B * y + C * z), x, vx, y, vy, z, vz) // AffineExpr = LinearExpr + AffineExpr
-  TEST_AFFINE_EXPR(A * x + B * y + d, x, vx, y, vy) // AffineExpr = AffineExpr(NoConstant) + vector
-  TEST_AFFINE_EXPR(d + (A * x + B * y), x, vx, y, vy) // AffineExpr = vector + AffineExpr(NoConstant)
-  TEST_AFFINE_EXPR(A * x + d + e, x, vx) // AffineExpr = AffineExpr(with constant) + vector
-  TEST_AFFINE_EXPR(A * x + d + B * y + e, x, vx, y, vy) // AffineExpr = AffineExpr(with constant) + vector
-  TEST_AFFINE_EXPR(e + (A * x + d), x, vx) // AffineExpr = vector + AffineExpr(with constant)
-  TEST_AFFINE_EXPR(e + (A * x + d + B * y), x, vx, y, vy) // AffineExpr = vector + AffineExpr(with constant)
+  TEST_AFFINE_EXPR(A * x + B * y + d, x, vx, y, vy)              // AffineExpr = AffineExpr(NoConstant) + vector
+  TEST_AFFINE_EXPR(d + (A * x + B * y), x, vx, y, vy)            // AffineExpr = vector + AffineExpr(NoConstant)
+  TEST_AFFINE_EXPR(A * x + d + e, x, vx)                         // AffineExpr = AffineExpr(with constant) + vector
+  TEST_AFFINE_EXPR(A * x + d + B * y + e, x, vx, y, vy)          // AffineExpr = AffineExpr(with constant) + vector
+  TEST_AFFINE_EXPR(e + (A * x + d), x, vx)                       // AffineExpr = vector + AffineExpr(with constant)
+  TEST_AFFINE_EXPR(e + (A * x + d + B * y), x, vx, y, vy)        // AffineExpr = vector + AffineExpr(with constant)
   TEST_AFFINE_EXPR((A * x + B * y) + (C * z + C * w), x, vx, y, vy, z, vz, w,
                    vw) // AffineExpr = AffineExpr(NoConstant) + AffineExpr(NoConstant)
   TEST_AFFINE_EXPR((A * x + B * y) + (C * z + C * w + e), x, vx, y, vy, z, vz, w,

--- a/tests/AffineExprTest.cpp
+++ b/tests/AffineExprTest.cpp
@@ -4,11 +4,11 @@
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"
 
-#include<tvm/Variable.h>
-#include<tvm/function/BasicLinearFunction.h>
-#include<tvm/utils/AffineExpr.h>
-#include<tvm/utils/ProtoTask.h>
-#include<tvm/internal/enums.h>
+#include <tvm/Variable.h>
+#include <tvm/function/BasicLinearFunction.h>
+#include <tvm/internal/enums.h>
+#include <tvm/utils/AffineExpr.h>
+#include <tvm/utils/ProtoTask.h>
 
 #include <iostream>
 
@@ -18,30 +18,31 @@ using namespace tvm::function;
 using namespace Eigen;
 
 #define CREATE_VEC(x, vx) VectorXd x = vx;
-#define CREATE_VAR(x, vx) \
+#define CREATE_VAR(x, vx)                  \
   Space R##x(static_cast<int>(vx.size())); \
   VariablePtr x = R##x.createVariable(#x); \
   x << vx;
 
 #define EVAL_EIG(res, expr) res = expr;
-#define EVAL_AFF(res, expr) \
+#define EVAL_AFF(res, expr)    \
   BasicLinearFunction f(expr); \
-  f.updateValue(); \
+  f.updateValue();             \
   res = f.value();
 
-#define GENERATE(create, eval, ...) \
-  PP_ID(PP_APPLY(CHOOSE_GEN_START, PP_NARG(__VA_ARGS__)) \
-          (create, eval, __VA_ARGS__))
+#define GENERATE(create, eval, ...) PP_ID(PP_APPLY(CHOOSE_GEN_START, PP_NARG(__VA_ARGS__))(create, eval, __VA_ARGS__))
 
 #define CHOOSE_GEN_START(count) GENERATE##count
 
 #define GENERATE2(create, eval, res, expr) eval(res, expr)
-#define GENERATE4(create, eval, res, expr, x, vx, ...) create(x,vx) PP_ID(GENERATE2(create, eval, res, expr))
-#define GENERATE6(create, eval, res, expr, x, vx, ...) create(x,vx) PP_ID(GENERATE4(create, eval, res, expr, __VA_ARGS__))
-#define GENERATE8(create, eval, res, expr, x, vx, ...) create(x,vx) PP_ID(GENERATE6(create, eval, res, expr, __VA_ARGS__))
-#define GENERATE10(create, eval, res, expr, x, vx, ...) create(x,vx) PP_ID(GENERATE8(create, eval, res, expr, __VA_ARGS__))
-#define GENERATE12(create, eval, res, expr, x, vx, ...) create(x,vx) PP_ID(GENERATE10(create, eval, res, expr, __VA_ARGS__))
-
+#define GENERATE4(create, eval, res, expr, x, vx, ...) create(x, vx) PP_ID(GENERATE2(create, eval, res, expr))
+#define GENERATE6(create, eval, res, expr, x, vx, ...) \
+  create(x, vx) PP_ID(GENERATE4(create, eval, res, expr, __VA_ARGS__))
+#define GENERATE8(create, eval, res, expr, x, vx, ...) \
+  create(x, vx) PP_ID(GENERATE6(create, eval, res, expr, __VA_ARGS__))
+#define GENERATE10(create, eval, res, expr, x, vx, ...) \
+  create(x, vx) PP_ID(GENERATE8(create, eval, res, expr, __VA_ARGS__))
+#define GENERATE12(create, eval, res, expr, x, vx, ...) \
+  create(x, vx) PP_ID(GENERATE10(create, eval, res, expr, __VA_ARGS__))
 
 // Called as TEST_AFFINE_EXPR(expr x1, v1, x2, v2, ...)
 // Test if the expression expr (e.g. A1*x1+A2*x2+b) evaluated at xi=vi gives the
@@ -49,18 +50,12 @@ using namespace Eigen;
 // by expr where the xi are VariablePtr with value vi.
 // This tests in passing that the corresponding AffineExpr creation compiles
 // correctly.
-#define TEST_AFFINE_EXPR(expr, ...) \
-{ \
-  VectorXd res1, res2; \
-  { \
-    PP_ID(GENERATE(CREATE_VEC, EVAL_EIG, res1, expr, __VA_ARGS__)) \
-  } \
-  { \
-    PP_ID(GENERATE(CREATE_VAR, EVAL_AFF, res2, expr, __VA_ARGS__)) \
-  } \
-  FAST_CHECK_UNARY((res1-res2).isZero()); \
-}
-
+#define TEST_AFFINE_EXPR(expr, ...)                                                                               \
+  {                                                                                                               \
+    VectorXd res1, res2;                                                                                          \
+    {PP_ID(GENERATE(CREATE_VEC, EVAL_EIG, res1, expr, __VA_ARGS__))} {                                            \
+        PP_ID(GENERATE(CREATE_VAR, EVAL_AFF, res2, expr, __VA_ARGS__))} FAST_CHECK_UNARY((res1 - res2).isZero()); \
+  }
 
 TEST_CASE("Test AffineExpr compilation and validity")
 {
@@ -75,66 +70,70 @@ TEST_CASE("Test AffineExpr compilation and validity")
   MatrixXd M = MatrixXd::Random(6, 6);
   VectorXd d = VectorXd::Random(6);
   VectorXd e = VectorXd::Random(6);
-  
-  
-  TEST_AFFINE_EXPR(A * x,                                     x, vx)                      //LinearExpr, simple case
-  TEST_AFFINE_EXPR(M * A * x,                                 x, vx)                      //LinearExpr, simple matrix expression
-  TEST_AFFINE_EXPR((d.asDiagonal() * A + M * B) * x,          x, vx)                      // complex matrix expression
-  TEST_AFFINE_EXPR(A * x + d,                                 x, vx)                      // AffineExpr = LinearExpr + vector
-  TEST_AFFINE_EXPR(d + A * x,                                 x, vx)                      // AffineExpr = vector + LinearExpr
-  TEST_AFFINE_EXPR(A * x + (3*d+M*e),                         x, vx)                      // AffineExpr = LinearExpr + vector(complex expr)
-  TEST_AFFINE_EXPR(A * x + B * y,                             x, vx, y, vy)               // AffineExpr = LinearExpr + LinearExpr
-  TEST_AFFINE_EXPR(A * x + B * y + C * z,                     x, vx, y, vy, z, vz)        // AffineExpr = AffineExpr + LinearExpr
-  TEST_AFFINE_EXPR(A * x + (B * y + C * z),                   x, vx, y, vy, z, vz)        // AffineExpr = LinearExpr + AffineExpr
-  TEST_AFFINE_EXPR(A * x + B * y + d,                         x, vx, y, vy)               // AffineExpr = AffineExpr(NoConstant) + vector
-  TEST_AFFINE_EXPR(d + (A * x + B * y),                       x, vx, y, vy)               // AffineExpr = vector + AffineExpr(NoConstant)
-  TEST_AFFINE_EXPR(A * x + d + e,                             x, vx)                      // AffineExpr = AffineExpr(with constant) + vector
-  TEST_AFFINE_EXPR(A * x + d + B * y + e,                     x, vx, y, vy)               // AffineExpr = AffineExpr(with constant) + vector
-  TEST_AFFINE_EXPR(e + (A * x + d),                           x, vx)                      // AffineExpr = vector + AffineExpr(with constant)
-  TEST_AFFINE_EXPR(e + (A * x + d + B * y),                   x, vx, y, vy)               // AffineExpr = vector + AffineExpr(with constant)
-  TEST_AFFINE_EXPR((A * x + B * y) + (C * z + C * w),         x, vx, y, vy, z, vz, w, vw) // AffineExpr = AffineExpr(NoConstant) + AffineExpr(NoConstant)
-  TEST_AFFINE_EXPR((A * x + B * y) + (C * z + C * w + e),     x, vx, y, vy, z, vz, w, vw) // AffineExpr = AffineExpr(NoConstant) + AffineExpr(with constant)
-  TEST_AFFINE_EXPR((A * x + B * y + d) + (C * z + C * w),     x, vx, y, vy, z, vz, w, vw) // AffineExpr = AffineExpr(with constant) + AffineExpr(with constant)
-  TEST_AFFINE_EXPR((A * x + B * y + d) + (C * z + C * w + e), x, vx, y, vy, z, vz, w, vw) // AffineExpr = AffineExpr(with complex constant) + AffineExpr(with complex constant)
-  TEST_AFFINE_EXPR(A * x + (C * z + B * x),                   x, vx, z, vz)               // AffineExpr = LinearExpr + AffineExpr (with duplicated variable)
 
-  TEST_AFFINE_EXPR(A * x + u,                                 x, vx, u, vu)
-  TEST_AFFINE_EXPR(u + A * x,                                 x, vx, u, vu)
-  TEST_AFFINE_EXPR(x + y,                                     x, vx, y, vy)
-  TEST_AFFINE_EXPR(-x,                                        x, vx)
-  TEST_AFFINE_EXPR(3 * x,                                     x, vx)
-  TEST_AFFINE_EXPR(u + d,                                     u, vu)
-  TEST_AFFINE_EXPR(d + u,                                     u, vu)
-  TEST_AFFINE_EXPR(A * x + d + u,                             x, vx, u, vu)
-  TEST_AFFINE_EXPR(u + (A * x + d),                           x, vx, u, vu)
-  TEST_AFFINE_EXPR(-(A*x),                                    x, vx)
-  TEST_AFFINE_EXPR(-((d.asDiagonal() * A + M * B) * x),       x, vx)
-  TEST_AFFINE_EXPR(3 * (A*x),                                 x, vx)
-  TEST_AFFINE_EXPR(3 * M * (A*x),                             x, vx)
-  TEST_AFFINE_EXPR(3 * (M *(A*x)),                            x, vx)
-  TEST_AFFINE_EXPR(M *((d.asDiagonal() * A + M * B) * x),     x, vx)
-  TEST_AFFINE_EXPR(-M *((d.asDiagonal() * A + M * B) * x),    x, vx)
-  TEST_AFFINE_EXPR(A * x - u,                                 x, vx, u, vu)
-  TEST_AFFINE_EXPR(u - A * x,                                 x, vx, u, vu)
-  TEST_AFFINE_EXPR(x - y,                                     x, vx, y, vy)
-  TEST_AFFINE_EXPR(u - d,                                     u, vu)
-  TEST_AFFINE_EXPR(d - u,                                     u, vu)
-  TEST_AFFINE_EXPR(A * x + d - u,                             x, vx, u, vu)
-  TEST_AFFINE_EXPR(u - (A * x + d),                           x, vx, u, vu)
-  TEST_AFFINE_EXPR(A * x - B * y,                             x, vx, y, vy)
-  TEST_AFFINE_EXPR((A * x + B * y) - (C * z + C * w),         x, vx, y, vy, z, vz, w, vw)
+  TEST_AFFINE_EXPR(A * x, x, vx) // LinearExpr, simple case
+  TEST_AFFINE_EXPR(M * A * x, x, vx) // LinearExpr, simple matrix expression
+  TEST_AFFINE_EXPR((d.asDiagonal() * A + M * B) * x, x, vx) // complex matrix expression
+  TEST_AFFINE_EXPR(A * x + d, x, vx) // AffineExpr = LinearExpr + vector
+  TEST_AFFINE_EXPR(d + A * x, x, vx) // AffineExpr = vector + LinearExpr
+  TEST_AFFINE_EXPR(A * x + (3 * d + M * e), x, vx) // AffineExpr = LinearExpr + vector(complex expr)
+  TEST_AFFINE_EXPR(A * x + B * y, x, vx, y, vy) // AffineExpr = LinearExpr + LinearExpr
+  TEST_AFFINE_EXPR(A * x + B * y + C * z, x, vx, y, vy, z, vz) // AffineExpr = AffineExpr + LinearExpr
+  TEST_AFFINE_EXPR(A * x + (B * y + C * z), x, vx, y, vy, z, vz) // AffineExpr = LinearExpr + AffineExpr
+  TEST_AFFINE_EXPR(A * x + B * y + d, x, vx, y, vy) // AffineExpr = AffineExpr(NoConstant) + vector
+  TEST_AFFINE_EXPR(d + (A * x + B * y), x, vx, y, vy) // AffineExpr = vector + AffineExpr(NoConstant)
+  TEST_AFFINE_EXPR(A * x + d + e, x, vx) // AffineExpr = AffineExpr(with constant) + vector
+  TEST_AFFINE_EXPR(A * x + d + B * y + e, x, vx, y, vy) // AffineExpr = AffineExpr(with constant) + vector
+  TEST_AFFINE_EXPR(e + (A * x + d), x, vx) // AffineExpr = vector + AffineExpr(with constant)
+  TEST_AFFINE_EXPR(e + (A * x + d + B * y), x, vx, y, vy) // AffineExpr = vector + AffineExpr(with constant)
+  TEST_AFFINE_EXPR((A * x + B * y) + (C * z + C * w), x, vx, y, vy, z, vz, w,
+                   vw) // AffineExpr = AffineExpr(NoConstant) + AffineExpr(NoConstant)
+  TEST_AFFINE_EXPR((A * x + B * y) + (C * z + C * w + e), x, vx, y, vy, z, vz, w,
+                   vw) // AffineExpr = AffineExpr(NoConstant) + AffineExpr(with constant)
+  TEST_AFFINE_EXPR((A * x + B * y + d) + (C * z + C * w), x, vx, y, vy, z, vz, w,
+                   vw) // AffineExpr = AffineExpr(with constant) + AffineExpr(with constant)
+  TEST_AFFINE_EXPR((A * x + B * y + d) + (C * z + C * w + e), x, vx, y, vy, z, vz, w,
+                   vw) // AffineExpr = AffineExpr(with complex constant) + AffineExpr(with complex constant)
+  TEST_AFFINE_EXPR(A * x + (C * z + B * x), x, vx, z,
+                   vz) // AffineExpr = LinearExpr + AffineExpr (with duplicated variable)
+
+  TEST_AFFINE_EXPR(A * x + u, x, vx, u, vu)
+  TEST_AFFINE_EXPR(u + A * x, x, vx, u, vu)
+  TEST_AFFINE_EXPR(x + y, x, vx, y, vy)
+  TEST_AFFINE_EXPR(-x, x, vx)
+  TEST_AFFINE_EXPR(3 * x, x, vx)
+  TEST_AFFINE_EXPR(u + d, u, vu)
+  TEST_AFFINE_EXPR(d + u, u, vu)
+  TEST_AFFINE_EXPR(A * x + d + u, x, vx, u, vu)
+  TEST_AFFINE_EXPR(u + (A * x + d), x, vx, u, vu)
+  TEST_AFFINE_EXPR(-(A * x), x, vx)
+  TEST_AFFINE_EXPR(-((d.asDiagonal() * A + M * B) * x), x, vx)
+  TEST_AFFINE_EXPR(3 * (A * x), x, vx)
+  TEST_AFFINE_EXPR(3 * M * (A * x), x, vx)
+  TEST_AFFINE_EXPR(3 * (M * (A * x)), x, vx)
+  TEST_AFFINE_EXPR(M * ((d.asDiagonal() * A + M * B) * x), x, vx)
+  TEST_AFFINE_EXPR(-M * ((d.asDiagonal() * A + M * B) * x), x, vx)
+  TEST_AFFINE_EXPR(A * x - u, x, vx, u, vu)
+  TEST_AFFINE_EXPR(u - A * x, x, vx, u, vu)
+  TEST_AFFINE_EXPR(x - y, x, vx, y, vy)
+  TEST_AFFINE_EXPR(u - d, u, vu)
+  TEST_AFFINE_EXPR(d - u, u, vu)
+  TEST_AFFINE_EXPR(A * x + d - u, x, vx, u, vu)
+  TEST_AFFINE_EXPR(u - (A * x + d), x, vx, u, vu)
+  TEST_AFFINE_EXPR(A * x - B * y, x, vx, y, vy)
+  TEST_AFFINE_EXPR((A * x + B * y) - (C * z + C * w), x, vx, y, vy, z, vz, w, vw)
   TEST_AFFINE_EXPR((A * x + B * y + d) - (C * z + C * w + e), x, vx, y, vy, z, vz, w, vw)
-  TEST_AFFINE_EXPR(2 * (A * x + u),                           x, vx, u, vu)
-  TEST_AFFINE_EXPR(M * (A * x + u),                           x, vx, u, vu)
-  TEST_AFFINE_EXPR(2 * (A * x + u + d),                       x, vx, u, vu)
-  TEST_AFFINE_EXPR(M * (A * x + u + d),                       x, vx, u, vu)
+  TEST_AFFINE_EXPR(2 * (A * x + u), x, vx, u, vu)
+  TEST_AFFINE_EXPR(M * (A * x + u), x, vx, u, vu)
+  TEST_AFFINE_EXPR(2 * (A * x + u + d), x, vx, u, vu)
+  TEST_AFFINE_EXPR(M * (A * x + u + d), x, vx, u, vu)
 }
 
 TEST_CASE("Test integration with ProtoTask")
 {
   MatrixXd A = MatrixXd::Random(6, 5);
   VectorXd b = VectorXd::Random(6);
-  
+
   VariablePtr x = Space(5).createVariable("x");
 
   auto p1 = (A * x == 0);

--- a/tests/CompareTasks.cpp
+++ b/tests/CompareTasks.cpp
@@ -20,18 +20,18 @@ static double dt = 0.005;
 /* Tasks */
 
 #include <Tasks/Bounds.h>
-#include <Tasks/QPSolver.h>
 #include <Tasks/QPConstr.h>
-#include <Tasks/QPContacts.h>
 #include <Tasks/QPContactConstr.h>
+#include <Tasks/QPContacts.h>
 #include <Tasks/QPMotionConstr.h>
+#include <Tasks/QPSolver.h>
 #include <Tasks/QPTasks.h>
 
 #include <RBDyn/CoM.h>
 #include <RBDyn/EulerIntegration.h>
+#include <RBDyn/FA.h>
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
-#include <RBDyn/FA.h>
 
 #ifndef M_PI
 #  define M_PI 3.141592653589793238462643383279502884e+00 // from boost/math/constant
@@ -42,11 +42,8 @@ static void BM_Tasks(benchmark::State & state)
   std::vector<rbd::MultiBody> mbs;
   std::vector<rbd::MultiBodyConfig> mbcs;
 
-  auto load_robot = [&mbs,&mbcs](const std::string & path, bool fixed,
-                       const std::vector<std::string> & filteredLinks,
-                       const std::vector<std::vector<double>> & ref_q)
-    -> rbd::parsers::Limits
-  {
+  auto load_robot = [&mbs, &mbcs](const std::string & path, bool fixed, const std::vector<std::string> & filteredLinks,
+                                  const std::vector<std::vector<double>> & ref_q) -> rbd::parsers::Limits {
     std::ifstream ifs(path);
     if(!ifs.good())
     {
@@ -83,10 +80,54 @@ static void BM_Tasks(benchmark::State & state)
     return data.limits;
   };
   rbd::parsers::Limits jvrc_limits;
-  std::vector<std::string> jvrc_filtered = {
-    "R_UTHUMB_S", "R_LTHUMB_S", "R_UINDEX_S", "R_LINDEX_S", "R_ULITTLE_S", "R_LLITTLE_S",
-    "L_UTHUMB_S", "L_LTHUMB_S", "L_UINDEX_S", "L_LINDEX_S", "L_ULITTLE_S", "L_LLITTLE_S"};
-  std::vector<std::vector<double>> ref_q = {{1.0,0.0,0.0,0.0,0.0,0.0,0.8275}, {-0.38}, {-0.01}, {0.0}, {0.72}, {-0.01}, {-0.33}, {-0.38}, {0.02}, {0.0}, {0.72}, {-0.02}, {-0.33}, {0.0}, {0.13}, {0.0}, {0.0}, {0.0}, {0.0}, {-0.052}, {-0.17}, {0.0}, {-0.52}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {-0.052}, {0.17}, {0.0}, {-0.52}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}, {0.0}};
+  std::vector<std::string> jvrc_filtered = {"R_UTHUMB_S",  "R_LTHUMB_S",  "R_UINDEX_S",  "R_LINDEX_S",
+                                            "R_ULITTLE_S", "R_LLITTLE_S", "L_UTHUMB_S",  "L_LTHUMB_S",
+                                            "L_UINDEX_S",  "L_LINDEX_S",  "L_ULITTLE_S", "L_LLITTLE_S"};
+  std::vector<std::vector<double>> ref_q = {{1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8275},
+                                            {-0.38},
+                                            {-0.01},
+                                            {0.0},
+                                            {0.72},
+                                            {-0.01},
+                                            {-0.33},
+                                            {-0.38},
+                                            {0.02},
+                                            {0.0},
+                                            {0.72},
+                                            {-0.02},
+                                            {-0.33},
+                                            {0.0},
+                                            {0.13},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {-0.052},
+                                            {-0.17},
+                                            {0.0},
+                                            {-0.52},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {-0.052},
+                                            {0.17},
+                                            {0.0},
+                                            {-0.52},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0},
+                                            {0.0}};
   jvrc_limits = load_robot(jvrc_urdf, false, jvrc_filtered, ref_q);
   load_robot(ground_urdf, true, {}, {});
 
@@ -95,11 +136,8 @@ static void BM_Tasks(benchmark::State & state)
   tasks::qp::PositiveLambda posLambda{};
   posLambda.addToSolver(mbs, solver);
 
-  auto bound2TasksBound = [](const rbd::MultiBody & mb,
-                             const std::map<std::string, std::vector<double>> & b,
-                             double mul,
-                             double ff_limit)
-  {
+  auto bound2TasksBound = [](const rbd::MultiBody & mb, const std::map<std::string, std::vector<double>> & b,
+                             double mul, double ff_limit) {
     std::vector<std::vector<double>> ret;
     for(const auto & j : mb.joints())
     {
@@ -130,56 +168,53 @@ static void BM_Tasks(benchmark::State & state)
     }
     return ret;
   };
-  tasks::TorqueBound tb {
-    bound2TasksBound(mbs[0], jvrc_limits.torque, -1, 0),
-    bound2TasksBound(mbs[0], jvrc_limits.torque, 1, 0)
-  };
+  tasks::TorqueBound tb{bound2TasksBound(mbs[0], jvrc_limits.torque, -1, 0),
+                        bound2TasksBound(mbs[0], jvrc_limits.torque, 1, 0)};
   tasks::qp::MotionConstr motionConstr{mbs, 0, tb};
   motionConstr.addToSolver(mbs, solver);
 
-  tasks::QBound qb {
-    bound2TasksBound(mbs[0], jvrc_limits.lower, 1, -std::numeric_limits<double>::infinity()),
-    bound2TasksBound(mbs[0], jvrc_limits.upper, 1, std::numeric_limits<double>::infinity())
-  };
-  tasks::AlphaBound ab {
-    bound2TasksBound(mbs[0], jvrc_limits.velocity, -0.5, -std::numeric_limits<double>::infinity()),
-    bound2TasksBound(mbs[0], jvrc_limits.velocity, 0.5, std::numeric_limits<double>::infinity())
-  };
-  tasks::qp::DamperJointLimitsConstr jl { mbs, 0, qb, ab, 0.1, 0.01, 0.5, dt};
+  tasks::QBound qb{bound2TasksBound(mbs[0], jvrc_limits.lower, 1, -std::numeric_limits<double>::infinity()),
+                   bound2TasksBound(mbs[0], jvrc_limits.upper, 1, std::numeric_limits<double>::infinity())};
+  tasks::AlphaBound ab{bound2TasksBound(mbs[0], jvrc_limits.velocity, -0.5, -std::numeric_limits<double>::infinity()),
+                       bound2TasksBound(mbs[0], jvrc_limits.velocity, 0.5, std::numeric_limits<double>::infinity())};
+  tasks::qp::DamperJointLimitsConstr jl{mbs, 0, qb, ab, 0.1, 0.01, 0.5, dt};
   jl.addToSolver(mbs, solver);
 
   tasks::qp::ContactPosConstr contactConstr{dt};
   contactConstr.addToSolver(mbs, solver);
 
   auto ll5_pos = mbcs[0].bodyPosW[mbs[0].bodyIndexByName("L_ANKLE_P_S")];
-  Eigen::Vector3d ll5_o {0.014592470601201057, 0.010025011375546455, -0.138};
+  Eigen::Vector3d ll5_o{0.014592470601201057, 0.010025011375546455, -0.138};
   auto rl5_pos = mbcs[0].bodyPosW[mbs[0].bodyIndexByName("R_ANKLE_P_S")];
-  Eigen::Vector3d rl5_o {0.014592470601201057, 0.010025011375546455, -0.138};
+  Eigen::Vector3d rl5_o{0.014592470601201057, 0.010025011375546455, -0.138};
   auto g_pos = mbcs[1].bodyPosW[mbs[1].bodyIndexByName("ground")];
-  std::vector<tasks::qp::UnilateralContact> uniC {
-    {0, 1, "L_ANKLE_P_S", "ground",
-      {
-        ll5_o + Eigen::Vector3d(0.1093074306845665, -0.06831501424312592, 0.),
+  std::vector<tasks::qp::UnilateralContact> uniC{
+      {0,
+       1,
+       "L_ANKLE_P_S",
+       "ground",
+       {ll5_o + Eigen::Vector3d(0.1093074306845665, -0.06831501424312592, 0.),
         ll5_o + Eigen::Vector3d(0.10640743374824524, 0.06836499273777008, 0.),
         ll5_o + Eigen::Vector3d(-0.10778241604566574, 0.06897497922182083, 0.),
-        ll5_o + Eigen::Vector3d(-0.1079324409365654, -0.069024957716465, 0.)
-      },
-      Eigen::Matrix3d::Identity(),
-      g_pos * ll5_pos.inv(),
-      4, 0.7, {ll5_o}
-    },
-    {0, 1, "R_ANKLE_P_S", "ground",
-      {
-        rl5_o + Eigen::Vector3d(-0.1079324409365654, 0.069024957716465, 0.),
+        ll5_o + Eigen::Vector3d(-0.1079324409365654, -0.069024957716465, 0.)},
+       Eigen::Matrix3d::Identity(),
+       g_pos * ll5_pos.inv(),
+       4,
+       0.7,
+       {ll5_o}},
+      {0,
+       1,
+       "R_ANKLE_P_S",
+       "ground",
+       {rl5_o + Eigen::Vector3d(-0.1079324409365654, 0.069024957716465, 0.),
         rl5_o + Eigen::Vector3d(-0.10778241604566574, -0.06897497922182083, 0.),
         rl5_o + Eigen::Vector3d(0.10640743374824524, -0.06836499273777008, 0.),
-        rl5_o + Eigen::Vector3d(0.1093074306845665, 0.06831501424312592, 0.)
-      },
-      Eigen::Matrix3d::Identity(),
-      g_pos * rl5_pos.inv(),
-      4, 0.7, {rl5_o}
-    }
-  };
+        rl5_o + Eigen::Vector3d(0.1093074306845665, 0.06831501424312592, 0.)},
+       Eigen::Matrix3d::Identity(),
+       g_pos * rl5_pos.inv(),
+       4,
+       0.7,
+       {rl5_o}}};
 
   auto q_target = mbcs[0].q;
   q_target[mbs[0].jointIndexByName("NECK_P")] = {0.75};
@@ -188,18 +223,18 @@ static void BM_Tasks(benchmark::State & state)
 
   auto com_target = rbd::computeCoM(mbs[0], mbcs[0]);
   com_target.z() -= 0.1;
-  tasks::qp::CoMTask com_t {mbs, 0, com_target};
-  tasks::qp::SetPointTask com_sp {mbs, 0, &com_t, 2., 100.};
+  tasks::qp::CoMTask com_t{mbs, 0, com_target};
+  tasks::qp::SetPointTask com_sp{mbs, 0, &com_t, 2., 100.};
   solver.addTask(mbs, &com_sp);
 
   auto lh_pos = mbcs[0].bodyPosW[mbs[0].bodyIndexByName("L_WRIST_Y_S")];
 
-  tasks::qp::OrientationTask ori_t {mbs, 0, "L_WRIST_Y_S", Eigen::Quaterniond(sva::RotY(-M_PI/2))};
-  tasks::qp::SetPointTask ori_sp {mbs, 0, &ori_t, 2., 10.};
+  tasks::qp::OrientationTask ori_t{mbs, 0, "L_WRIST_Y_S", Eigen::Quaterniond(sva::RotY(-M_PI / 2))};
+  tasks::qp::SetPointTask ori_sp{mbs, 0, &ori_t, 2., 10.};
   solver.addTask(mbs, &ori_sp);
 
-  tasks::qp::PositionTask pos_t {mbs, 0, "L_WRIST_Y_S", lh_pos.translation() + Eigen::Vector3d{0.3, -0.1, 0.2}};
-  tasks::qp::SetPointTask pos_sp {mbs, 0, &pos_t, 1., 10.};
+  tasks::qp::PositionTask pos_t{mbs, 0, "L_WRIST_Y_S", lh_pos.translation() + Eigen::Vector3d{0.3, -0.1, 0.2}};
+  tasks::qp::SetPointTask pos_sp{mbs, 0, &pos_t, 1., 10.};
   solver.addTask(mbs, &pos_sp);
 
   /** Make sure everything is up-to-date in QPSolver */
@@ -219,7 +254,7 @@ static void BM_Tasks(benchmark::State & state)
     }
   }
 }
-BENCHMARK(BM_Tasks)->Unit(benchmark::kMicrosecond);//->MinTime(10.0);
+BENCHMARK(BM_Tasks)->Unit(benchmark::kMicrosecond); //->MinTime(10.0);
 
 /* TVM */
 
@@ -232,12 +267,12 @@ BENCHMARK(BM_Tasks)->Unit(benchmark::kMicrosecond);//->MinTime(10.0);
 #include <tvm/task_dynamics/VelocityDamper.h>
 
 #include <tvm/Robot.h>
-#include <tvm/robot/internal/GeometricContactFunction.h>
-#include <tvm/robot/internal/DynamicFunction.h>
 #include <tvm/robot/CoMFunction.h>
 #include <tvm/robot/OrientationFunction.h>
 #include <tvm/robot/PositionFunction.h>
 #include <tvm/robot/PostureFunction.h>
+#include <tvm/robot/internal/DynamicFunction.h>
+#include <tvm/robot/internal/GeometricContactFunction.h>
 #include <tvm/robot/utils.h>
 
 static void BM_TVM(benchmark::State & state)
@@ -245,111 +280,100 @@ static void BM_TVM(benchmark::State & state)
   tvm::ControlProblem pb;
   tvm::Clock clock(dt);
 
-  std::vector<std::string> jvrc_filtered = {
-    "R_UTHUMB_S", "R_LTHUMB_S", "R_UINDEX_S", "R_LINDEX_S", "R_ULITTLE_S", "R_LLITTLE_S",
-    "L_UTHUMB_S", "L_LTHUMB_S", "L_UINDEX_S", "L_LINDEX_S", "L_ULITTLE_S", "L_LLITTLE_S"};
-  std::map<std::string, std::vector<double>> ref_q = {
-    {"Root", {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8275}},
-    {"R_HIP_P", {-0.38}},
-    {"R_HIP_R", {-0.01}},
-    {"R_HIP_Y", {0.0}},
-    {"R_KNEE", {0.72}},
-    {"R_ANKLE_R", {-0.01}},
-    {"R_ANKLE_P", {-0.33}},
-    {"L_HIP_P", {-0.38}},
-    {"L_HIP_R", {0.02}},
-    {"L_HIP_Y", {0.0}},
-    {"L_KNEE", {0.72}},
-    {"L_ANKLE_R", {-0.02}},
-    {"L_ANKLE_P", {-0.33}},
-    {"WAIST_Y", {0.0}},
-    {"WAIST_P", {0.13}},
-    {"WAIST_R", {0.00}},
-    {"NECK_Y", {0.0}},
-    {"NECK_R", {0.0}},
-    {"NECK_P", {0.0}},
-    {"R_SHOULDER_P", {-0.052}},
-    {"R_SHOULDER_R", {-0.17}},
-    {"R_SHOULDER_Y", {0.0}},
-    {"R_ELBOW_P", {-0.52}},
-    {"R_ELBOW_Y", {0.0}},
-    {"R_WRIST_R", {0.0}},
-    {"R_WRIST_Y", {0.0}},
-    {"R_UTHUMB", {0.0}},
-    {"R_LTHUMB", {0.0}},
-    {"R_UINDEX", {0.0}},
-    {"R_LINDEX", {0.0}},
-    {"R_ULITTLE", {0.0}},
-    {"R_LLITTLE", {0.0}},
-    {"L_SHOULDER_P", {-0.052000}},
-    {"L_SHOULDER_R", {0.17}},
-    {"L_SHOULDER_Y", {0.0}},
-    {"L_ELBOW_P", {-0.52}},
-    {"L_ELBOW_Y", {0.0}},
-    {"L_WRIST_R", {0.0}},
-    {"L_WRIST_Y", {0.0}},
-    {"L_UTHUMB", {0.0}},
-    {"L_LTHUMB", {0.0}},
-    {"L_UINDEX", {0.0}},
-    {"L_LINDEX", {0.0}},
-    {"L_ULITTLE", {0.0}},
-    {"L_LLITTLE", {0.0}}
-  };
+  std::vector<std::string> jvrc_filtered = {"R_UTHUMB_S",  "R_LTHUMB_S",  "R_UINDEX_S",  "R_LINDEX_S",
+                                            "R_ULITTLE_S", "R_LLITTLE_S", "L_UTHUMB_S",  "L_LTHUMB_S",
+                                            "L_UINDEX_S",  "L_LINDEX_S",  "L_ULITTLE_S", "L_LLITTLE_S"};
+  std::map<std::string, std::vector<double>> ref_q = {{"Root", {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8275}},
+                                                      {"R_HIP_P", {-0.38}},
+                                                      {"R_HIP_R", {-0.01}},
+                                                      {"R_HIP_Y", {0.0}},
+                                                      {"R_KNEE", {0.72}},
+                                                      {"R_ANKLE_R", {-0.01}},
+                                                      {"R_ANKLE_P", {-0.33}},
+                                                      {"L_HIP_P", {-0.38}},
+                                                      {"L_HIP_R", {0.02}},
+                                                      {"L_HIP_Y", {0.0}},
+                                                      {"L_KNEE", {0.72}},
+                                                      {"L_ANKLE_R", {-0.02}},
+                                                      {"L_ANKLE_P", {-0.33}},
+                                                      {"WAIST_Y", {0.0}},
+                                                      {"WAIST_P", {0.13}},
+                                                      {"WAIST_R", {0.00}},
+                                                      {"NECK_Y", {0.0}},
+                                                      {"NECK_R", {0.0}},
+                                                      {"NECK_P", {0.0}},
+                                                      {"R_SHOULDER_P", {-0.052}},
+                                                      {"R_SHOULDER_R", {-0.17}},
+                                                      {"R_SHOULDER_Y", {0.0}},
+                                                      {"R_ELBOW_P", {-0.52}},
+                                                      {"R_ELBOW_Y", {0.0}},
+                                                      {"R_WRIST_R", {0.0}},
+                                                      {"R_WRIST_Y", {0.0}},
+                                                      {"R_UTHUMB", {0.0}},
+                                                      {"R_LTHUMB", {0.0}},
+                                                      {"R_UINDEX", {0.0}},
+                                                      {"R_LINDEX", {0.0}},
+                                                      {"R_ULITTLE", {0.0}},
+                                                      {"R_LLITTLE", {0.0}},
+                                                      {"L_SHOULDER_P", {-0.052000}},
+                                                      {"L_SHOULDER_R", {0.17}},
+                                                      {"L_SHOULDER_Y", {0.0}},
+                                                      {"L_ELBOW_P", {-0.52}},
+                                                      {"L_ELBOW_Y", {0.0}},
+                                                      {"L_WRIST_R", {0.0}},
+                                                      {"L_WRIST_Y", {0.0}},
+                                                      {"L_UTHUMB", {0.0}},
+                                                      {"L_LTHUMB", {0.0}},
+                                                      {"L_UINDEX", {0.0}},
+                                                      {"L_LINDEX", {0.0}},
+                                                      {"L_ULITTLE", {0.0}},
+                                                      {"L_LLITTLE", {0.0}}};
   tvm::RobotPtr jvrc = tvm::robot::fromURDF(clock, "JVRC1", jvrc_urdf, false, jvrc_filtered, ref_q);
   tvm::RobotPtr ground = tvm::robot::fromURDF(clock, "ground", ground_urdf, true, {}, {});
 
-  auto jvrc_lf = std::make_shared<tvm::robot::Frame>("LFullSoleFrame",
-                                                     jvrc,
-                                                     "L_ANKLE_P_S",
-                                                     sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)}
-                                                     );
-  auto jvrc_rf = std::make_shared<tvm::robot::Frame>("RFullSoleFrame",
-                                                     jvrc,
-                                                     "R_ANKLE_P_S",
-                                                     sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)}
-                                                     );
-  auto ground_f = std::make_shared<tvm::robot::Frame>("GroundFrame",
-                                                      ground,
-                                                      "ground",
-                                                      sva::PTransformd::Identity());
+  auto jvrc_lf = std::make_shared<tvm::robot::Frame>(
+      "LFullSoleFrame", jvrc, "L_ANKLE_P_S",
+      sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)});
+  auto jvrc_rf = std::make_shared<tvm::robot::Frame>(
+      "RFullSoleFrame", jvrc, "R_ANKLE_P_S",
+      sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)});
+  auto ground_f = std::make_shared<tvm::robot::Frame>("GroundFrame", ground, "ground", sva::PTransformd::Identity());
 
-  auto jvrc_lh = std::make_shared<tvm::robot::Frame>("LeftHand",
-                                                     jvrc,
-                                                     "L_WRIST_Y_S",
-                                                     sva::PTransformd::Identity());
+  auto jvrc_lh = std::make_shared<tvm::robot::Frame>("LeftHand", jvrc, "L_WRIST_Y_S", sva::PTransformd::Identity());
 
-  auto contact_lf_ground = std::make_shared<tvm::robot::Contact>
-    (jvrc_lf, ground_f, std::vector<sva::PTransformd>{
-        {Eigen::Vector3d(0.1093074306845665, -0.06831501424312592, 0.)},
-        {Eigen::Vector3d(0.10640743374824524, 0.06836499273777008, 0.)},
-        {Eigen::Vector3d(-0.10778241604566574, 0.06897497922182083, 0.)},
-        {Eigen::Vector3d(-0.1079324409365654, -0.069024957716465, 0.)}
-     });
-  auto contact_rf_ground = std::make_shared<tvm::robot::Contact>
-    (jvrc_rf, ground_f, std::vector<sva::PTransformd>{
-        {Eigen::Vector3d(-0.1079324409365654, 0.069024957716465, 0.)},
-        {Eigen::Vector3d(-0.10778241604566574, -0.06897497922182083, 0.)},
-        {Eigen::Vector3d(0.10640743374824524, -0.06836499273777008, 0.)},
-        {Eigen::Vector3d(0.1093074306845665, 0.06831501424312592, 0.)}
-     });
+  auto contact_lf_ground = std::make_shared<tvm::robot::Contact>(
+      jvrc_lf, ground_f,
+      std::vector<sva::PTransformd>{{Eigen::Vector3d(0.1093074306845665, -0.06831501424312592, 0.)},
+                                    {Eigen::Vector3d(0.10640743374824524, 0.06836499273777008, 0.)},
+                                    {Eigen::Vector3d(-0.10778241604566574, 0.06897497922182083, 0.)},
+                                    {Eigen::Vector3d(-0.1079324409365654, -0.069024957716465, 0.)}});
+  auto contact_rf_ground = std::make_shared<tvm::robot::Contact>(
+      jvrc_rf, ground_f,
+      std::vector<sva::PTransformd>{{Eigen::Vector3d(-0.1079324409365654, 0.069024957716465, 0.)},
+                                    {Eigen::Vector3d(-0.10778241604566574, -0.06897497922182083, 0.)},
+                                    {Eigen::Vector3d(0.10640743374824524, -0.06836499273777008, 0.)},
+                                    {Eigen::Vector3d(0.1093074306845665, 0.06831501424312592, 0.)}});
 
   auto dyn_fn = std::make_shared<tvm::robot::internal::DynamicFunction>(jvrc);
 
-  auto lfg_fn = std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_lf_ground, Eigen::Matrix6d::Identity());
+  auto lfg_fn =
+      std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_lf_ground, Eigen::Matrix6d::Identity());
   dyn_fn->addContact(contact_lf_ground, true, 0.7, 4);
 
-  auto rfg_fn = std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_rf_ground, Eigen::Matrix6d::Identity());
+  auto rfg_fn =
+      std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_rf_ground, Eigen::Matrix6d::Identity());
   dyn_fn->addContact(contact_rf_ground, true, 0.7, 4);
 
   auto posture_fn = std::make_shared<tvm::robot::PostureFunction>(jvrc);
-  std::string joint = "NECK_P"; std::vector<double> joint_q = {1.5};
+  std::string joint = "NECK_P";
+  std::vector<double> joint_q = {1.5};
   posture_fn->posture(joint, joint_q);
 
   auto com_fn = std::make_shared<tvm::robot::CoMFunction>(jvrc);
   com_fn->com(com_fn->com() + Eigen::Vector3d(0, 0, -0.1));
 
   auto ori_fn = std::make_shared<tvm::robot::OrientationFunction>(jvrc_lh);
-  ori_fn->orientation(sva::RotY(-M_PI/2));
+  ori_fn->orientation(sva::RotY(-M_PI / 2));
 
   auto pos_fn = std::make_shared<tvm::robot::PositionFunction>(jvrc_lh);
   pos_fn->position(pos_fn->position() + Eigen::Vector3d{0.3, -0.1, 0.2});
@@ -359,14 +383,21 @@ static void BM_TVM(benchmark::State & state)
   auto dyn_task = pb.add(dyn_fn == 0., tvm::task_dynamics::None(), {tvm::requirements::PriorityLevel(0)});
   dyn_fn->addPositiveLambdaToProblem(pb);
 
-  pb.add(posture_fn == 0., tvm::task_dynamics::PD(1.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(1.)});
-  pb.add(com_fn == 0., tvm::task_dynamics::PD(2.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(100.)});
-  pb.add(ori_fn == 0., tvm::task_dynamics::PD(2.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
-  pb.add(pos_fn == 0., tvm::task_dynamics::PD(1.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
+  pb.add(posture_fn == 0., tvm::task_dynamics::PD(1.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(1.)});
+  pb.add(com_fn == 0., tvm::task_dynamics::PD(2.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(100.)});
+  pb.add(ori_fn == 0., tvm::task_dynamics::PD(2.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
+  pb.add(pos_fn == 0., tvm::task_dynamics::PD(1.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
 
   /* Bounds */
-  pb.add(jvrc->lQBound() <= jvrc->qJoints() <= jvrc->uQBound(), tvm::task_dynamics::VelocityDamper(dt, {0.01, 0.001, 0}, tvm::constant::big_number), { tvm::requirements::PriorityLevel(0) });
-  pb.add(jvrc->lTauBound() <= jvrc->tau() <= jvrc->uTauBound(), tvm::task_dynamics::None(), { tvm::requirements::PriorityLevel(0) });
+  pb.add(jvrc->lQBound() <= jvrc->qJoints() <= jvrc->uQBound(),
+         tvm::task_dynamics::VelocityDamper(dt, {0.01, 0.001, 0}, tvm::constant::big_number),
+         {tvm::requirements::PriorityLevel(0)});
+  pb.add(jvrc->lTauBound() <= jvrc->tau() <= jvrc->uTauBound(), tvm::task_dynamics::None(),
+         {tvm::requirements::PriorityLevel(0)});
 
   tvm::LinearizedControlProblem lpb(pb);
 
@@ -380,6 +411,6 @@ static void BM_TVM(benchmark::State & state)
     clock.advance();
   }
 }
-BENCHMARK(BM_TVM)->Unit(benchmark::kMicrosecond);//->MinTime(10.0);
+BENCHMARK(BM_TVM)->Unit(benchmark::kMicrosecond); //->MinTime(10.0);
 
 BENCHMARK_MAIN()

--- a/tests/ConstraintTest.cpp
+++ b/tests/ConstraintTest.cpp
@@ -8,7 +8,6 @@
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"
 
-
 TEST_CASE("Test constraint")
 {
   Eigen::MatrixXd A1 = Eigen::MatrixXd::Random(4, 5);
@@ -21,19 +20,19 @@ TEST_CASE("Test constraint")
   x1->value(Eigen::VectorXd::Random(5));
   x2->value(Eigen::VectorXd::Random(2));
 
-  //A1x >= 0
+  // A1x >= 0
   tvm::constraint::BasicLinearConstraint C1(A1, x1, tvm::constraint::Type::GREATER_THAN);
   C1.updateValue();
 
-  FAST_CHECK_UNARY(C1.value().isApprox(A1*x1->value()));
+  FAST_CHECK_UNARY(C1.value().isApprox(A1 * x1->value()));
 
   // [A1 A2] [x1' x2']' <= b
-  tvm::constraint::BasicLinearConstraint C2({ A1,A2 }, { x1,x2 }, b, tvm::constraint::Type::LOWER_THAN);
+  tvm::constraint::BasicLinearConstraint C2({A1, A2}, {x1, x2}, b, tvm::constraint::Type::LOWER_THAN);
   C2.updateValue();
-  tvm::constraint::BasicLinearConstraint C3({ A2,A1 }, { x2,x1 }, b, tvm::constraint::Type::LOWER_THAN);
+  tvm::constraint::BasicLinearConstraint C3({A2, A1}, {x2, x1}, b, tvm::constraint::Type::LOWER_THAN);
   C3.updateValue();
 
-  FAST_CHECK_UNARY(C2.value().isApprox(A1*x1->value() + A2*x2->value()));
+  FAST_CHECK_UNARY(C2.value().isApprox(A1 * x1->value() + A2 * x2->value()));
   FAST_CHECK_UNARY(C2.value().isApprox(C3.value()));
   FAST_CHECK_UNARY(C2.u().isApprox(b));
 }

--- a/tests/DependencyGraph.cpp
+++ b/tests/DependencyGraph.cpp
@@ -39,11 +39,11 @@ TEST_CASE("SCC test")
 {
   tvm::graph::internal::DependencyGraph g;
   g.addNode();
-  g.addNode(); //  0---+
-  g.addNode(); //  |   |
-  g.addNode(); //  |   v
-  g.addNode(); //  |   3
-  g.addNode(); //  |   |
+  g.addNode();     //  0---+
+  g.addNode();     //  |   |
+  g.addNode();     //  |   v
+  g.addNode();     //  |   3
+  g.addNode();     //  |   |
   g.addEdge(0, 3); //  1<--+
   g.addEdge(3, 1); //  |
   g.addEdge(1, 0); //  +-->4
@@ -74,14 +74,14 @@ TEST_CASE("Order test")
   tvm::graph::internal::DependencyGraph g;
   g.addNode();
   g.addNode();
-  g.addNode(); //  +-->1---+
-  g.addNode(); //  |       |
-  g.addNode(); //  0       |
-  g.addNode(); //  |       v
-  g.addNode(); //  +-->2-->4
-  g.addNode(); //          ^
-  g.addNode(); //          |
-  g.addNode(); //  8-->9---+
+  g.addNode();     //  +-->1---+
+  g.addNode();     //  |       |
+  g.addNode();     //  0       |
+  g.addNode();     //  |       v
+  g.addNode();     //  +-->2-->4
+  g.addNode();     //          ^
+  g.addNode();     //          |
+  g.addNode();     //  8-->9---+
   g.addEdge(0, 1); //
   g.addEdge(0, 2); //  +-->5
   g.addEdge(1, 2); //  |   |

--- a/tests/DependencyGraph.cpp
+++ b/tests/DependencyGraph.cpp
@@ -8,28 +8,28 @@
 
 struct compVec
 {
-  bool operator()(const std::vector<size_t>& u, const std::vector<size_t>& v) const
+  bool operator()(const std::vector<size_t> & u, const std::vector<size_t> & v) const
   {
-    if (u.size() < v.size())
+    if(u.size() < v.size())
       return true;
-    else if (v.size() < u.size())
+    else if(v.size() < u.size())
       return false;
     else
       return std::set<size_t>(u.begin(), u.end()) < std::set<size_t>(v.begin(), v.end());
   }
 };
 
-bool equal(const std::vector<std::vector<size_t>>& u, const std::vector<std::vector<size_t>>& v)
+bool equal(const std::vector<std::vector<size_t>> & u, const std::vector<std::vector<size_t>> & v)
 {
-  if (u.size() == v.size())
+  if(u.size() == v.size())
   {
     std::set<std::vector<size_t>, compVec> su(u.begin(), u.end());
     std::set<std::vector<size_t>, compVec> sv(v.begin(), v.end());
-    //using ==, <=, ... between two sets seems to always use ==, <=, ... on the
-    //elements of the set, irrespective of the comparator given to the set. We
-    //thus relies on std::lexicographical_compare with our custom comparator
+    // using ==, <=, ... between two sets seems to always use ==, <=, ... on the
+    // elements of the set, irrespective of the comparator given to the set. We
+    // thus relies on std::lexicographical_compare with our custom comparator
     return !std::lexicographical_compare(su.begin(), su.end(), sv.begin(), sv.end(), compVec())
-      && !std::lexicographical_compare(sv.begin(), sv.end(), su.begin(), su.end(), compVec());
+           && !std::lexicographical_compare(sv.begin(), sv.end(), su.begin(), su.end(), compVec());
   }
   else
     return false;
@@ -39,28 +39,29 @@ TEST_CASE("SCC test")
 {
   tvm::graph::internal::DependencyGraph g;
   g.addNode();
-  g.addNode();        //  0---+
-  g.addNode();        //  |   |
-  g.addNode();        //  |   v
-  g.addNode();        //  |   3 
-  g.addNode();        //  |   |
-  g.addEdge(0, 3);    //  1<--+
-  g.addEdge(3, 1);    //  |     
-  g.addEdge(1, 0);    //  +-->4
-  g.addEdge(1, 2);    //  |
-  g.addEdge(1, 4);    //  v
-  g.addEdge(2, 5);    //  2<->5
+  g.addNode(); //  0---+
+  g.addNode(); //  |   |
+  g.addNode(); //  |   v
+  g.addNode(); //  |   3
+  g.addNode(); //  |   |
+  g.addEdge(0, 3); //  1<--+
+  g.addEdge(3, 1); //  |
+  g.addEdge(1, 0); //  +-->4
+  g.addEdge(1, 2); //  |
+  g.addEdge(1, 4); //  v
+  g.addEdge(2, 5); //  2<->5
   g.addEdge(5, 2);
 
   auto r = g.reduce();
-  const auto& e = r.second.edges();
+  const auto & e = r.second.edges();
 
-  FAST_CHECK_UNARY(equal(r.first, { { 0,1,3 },{ 4 },{ 2,5 } }));
+  FAST_CHECK_UNARY(equal(r.first, {{0, 1, 3}, {4}, {2, 5}}));
   FAST_CHECK_EQ(e.size(), 2);
-  //we have two edges, one from the SCC with size 3 to the SCC with size 1,
-  //one from the SCC with size 3 to the SCC with size 2
+  // we have two edges, one from the SCC with size 3 to the SCC with size 1,
+  // one from the SCC with size 3 to the SCC with size 2
   auto it1 = e.begin();
-  auto it2 = e.begin(); ++it2;
+  auto it2 = e.begin();
+  ++it2;
   FAST_CHECK_EQ(r.first[it1->first].size(), 3);
   FAST_CHECK_EQ(r.first[it2->first].size(), 3);
   auto s1 = r.first[it1->second].size();
@@ -73,27 +74,27 @@ TEST_CASE("Order test")
   tvm::graph::internal::DependencyGraph g;
   g.addNode();
   g.addNode();
-  g.addNode();      //  +-->1---+
-  g.addNode();      //  |       |
-  g.addNode();      //  0       |
-  g.addNode();      //  |       v
-  g.addNode();      //  +-->2-->4 
-  g.addNode();      //          ^
-  g.addNode();      //          |
-  g.addNode();      //  8-->9---+
-  g.addEdge(0, 1);  //  
-  g.addEdge(0, 2);  //  +-->5
-  g.addEdge(1, 2);  //  |   |
-  g.addEdge(1, 4);  //  3   |
-  g.addEdge(2, 4);  //  |   v
-  g.addEdge(3, 5);  //  +-->6
-  g.addEdge(3, 6);  //  
-  g.addEdge(5, 6);  //  7
+  g.addNode(); //  +-->1---+
+  g.addNode(); //  |       |
+  g.addNode(); //  0       |
+  g.addNode(); //  |       v
+  g.addNode(); //  +-->2-->4
+  g.addNode(); //          ^
+  g.addNode(); //          |
+  g.addNode(); //  8-->9---+
+  g.addEdge(0, 1); //
+  g.addEdge(0, 2); //  +-->5
+  g.addEdge(1, 2); //  |   |
+  g.addEdge(1, 4); //  3   |
+  g.addEdge(2, 4); //  |   v
+  g.addEdge(3, 5); //  +-->6
+  g.addEdge(3, 6); //
+  g.addEdge(5, 6); //  7
   g.addEdge(8, 9);
   g.addEdge(9, 4);
 
   auto r = g.order();
-  auto find = [&r](int i) {return std::find(r.begin(), r.end(), i); };
+  auto find = [&r](int i) { return std::find(r.begin(), r.end(), i); };
   FAST_CHECK_LT(find(4), find(1));
   FAST_CHECK_LT(find(4), find(2));
   FAST_CHECK_LT(find(4), find(9));
@@ -105,6 +106,6 @@ TEST_CASE("Order test")
   FAST_CHECK_LT(find(5), find(3));
 
   auto rg = g.groupedOrder();
-  std::set<std::vector<size_t>> vg = { { 4,2,1,0,9,8 },{ 6,5,3 },{ 7 } };
+  std::set<std::vector<size_t>> vg = {{4, 2, 1, 0, 9, 8}, {6, 5, 3}, {7}};
   FAST_CHECK_EQ(std::set<std::vector<size_t>>(rg.begin(), rg.end()), vg);
 }

--- a/tests/EventsTest.cpp
+++ b/tests/EventsTest.cpp
@@ -7,13 +7,13 @@
 #include <tvm/scheme/WeightedLeastSquares.h>
 #include <tvm/solver/defaultLeastSquareSolver.h>
 #ifdef TVM_USE_LSSOL
-# include <tvm/solver/LSSOLLeastSquareSolver.h>
+#  include <tvm/solver/LSSOLLeastSquareSolver.h>
 #endif
 #ifdef TVM_USE_QLD
-# include <tvm/solver/QLDLeastSquareSolver.h>
+#  include <tvm/solver/QLDLeastSquareSolver.h>
 #endif
 #ifdef TVM_USE_QUADPROG
-# include <tvm/solver/QuadprogLeastSquareSolver.h>
+#  include <tvm/solver/QuadprogLeastSquareSolver.h>
 #endif
 
 #include <array>
@@ -27,19 +27,28 @@ using namespace Eigen;
 #include "doctest/doctest.h"
 
 #ifdef TVM_USE_LSSOL
-#define IF_USE_LSSOL(x) x
+#  define IF_USE_LSSOL(x) x
 #else
-#define IF_USE_LSSOL(x) do {} while(0)
+#  define IF_USE_LSSOL(x) \
+    do                    \
+    {                     \
+    } while(0)
 #endif
 #ifdef TVM_USE_QLD
-#define IF_USE_QLD(x) x
+#  define IF_USE_QLD(x) x
 #else
-#define IF_USE_QLD(x) do {} while(0)
+#  define IF_USE_QLD(x) \
+    do                  \
+    {                   \
+    } while(0)
 #endif
 #ifdef TVM_USE_QUADPROG
-#define IF_USE_QUADPROG(x) x
+#  define IF_USE_QUADPROG(x) x
 #else
-#define IF_USE_QUADPROG(x) do {} while(0)
+#  define IF_USE_QUADPROG(x) \
+    do                       \
+    {                        \
+    } while(0)
 #endif
 
 using namespace Eigen;
@@ -52,13 +61,13 @@ TEST_CASE("Weight change")
   VariablePtr x = R2.createVariable("x");
 
   LinearizedControlProblem pb;
-  auto t1 = pb.add(x == -1., { PriorityLevel(1) });
-  auto t2 = pb.add(x == Vector2d(1,3), {PriorityLevel(1), Weight(1)});
+  auto t1 = pb.add(x == -1., {PriorityLevel(1)});
+  auto t2 = pb.add(x == Vector2d(1, 3), {PriorityLevel(1), Weight(1)});
 
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions{});
 
   solver.solve(pb);
-  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0,1)));
+  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 1)));
 
   t2->requirements.weight() = 3;
   solver.solve(pb);
@@ -80,8 +89,8 @@ TEST_CASE("Simple add/Remove constraint")
   VariablePtr x = R2.createVariable("x");
 
   LinearizedControlProblem pb;
-  auto t1 = pb.add(x == -1., { PriorityLevel(1) });
-  auto t2 = pb.add(x == Vector2d(1, 3), { PriorityLevel(1), Weight(1) });
+  auto t1 = pb.add(x == -1., {PriorityLevel(1)});
+  auto t2 = pb.add(x == Vector2d(1, 3), {PriorityLevel(1), Weight(1)});
 
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions{});
 
@@ -96,18 +105,17 @@ TEST_CASE("Simple add/Remove constraint")
   solver.solve(pb);
   FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 1)));
 
-  pb.add(x == 0., { PriorityLevel(1) });
+  pb.add(x == 0., {PriorityLevel(1)});
   solver.solve(pb);
-  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 2./3)));
+  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 2. / 3)));
 
   pb.remove(t1.get());
   solver.solve(pb);
-  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(1./2, 3./2)));
+  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(1. / 2, 3. / 2)));
 
   pb.add(t1);
   solver.solve(pb);
   FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 2. / 3)));
-
 }
 
 TEST_CASE("Add/Remove variables from problem")
@@ -118,14 +126,14 @@ TEST_CASE("Add/Remove variables from problem")
   VariablePtr y = R3.createVariable("y");
 
   LinearizedControlProblem pb;
-  auto t1 = pb.add(x == 0., { PriorityLevel(1) });
+  auto t1 = pb.add(x == 0., {PriorityLevel(1)});
 
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions{});
 
   solver.solve(pb);
   FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 0)));
 
-  auto t2 = pb.add(y == 0., { PriorityLevel(1) });
+  auto t2 = pb.add(y == 0., {PriorityLevel(1)});
   solver.solve(pb);
   FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 0)));
   FAST_CHECK_UNARY(y->value().isApprox(Vector3d(0, 0, 0)));
@@ -136,7 +144,7 @@ TEST_CASE("Add/Remove variables from problem")
 }
 
 // Skip if more than one type of constraints/objective is added more than once
-bool skip(const std::bitset<12>& a)
+bool skip(const std::bitset<12> & a)
 {
   int eq = a[0] + a[1] + a[2];
   int ineq = a[3] + a[4] + a[5];
@@ -148,8 +156,8 @@ bool skip(const std::bitset<12>& a)
 }
 
 // Skip if more than one type of constraints/objective is added more than once
-// and more than three types is added. 
-bool skip2(const std::bitset<8>& a)
+// and more than three types is added.
+bool skip2(const std::bitset<8> & a)
 {
   int eq = a[0] + a[1];
   int ineq = a[2] + a[3];
@@ -162,52 +170,59 @@ bool skip2(const std::bitset<8>& a)
 }
 
 template<std::size_t N>
-void buildPb(LinearizedControlProblem& pb,
-             const std::array<TaskWithRequirementsPtr, N>& tasks,
-             const std::bitset<N>& selection)
+void buildPb(LinearizedControlProblem & pb,
+             const std::array<TaskWithRequirementsPtr, N> & tasks,
+             const std::bitset<N> & selection)
 {
-  for (int i = 0; i < N; ++i)
+  for(int i = 0; i < N; ++i)
   {
-    if (selection[i]) pb.add(tasks[i]);
+    if(selection[i])
+      pb.add(tasks[i]);
   }
 }
 
 template<std::size_t N>
-void checkSolution(const std::array<TaskWithRequirementsPtr, N>& tasks,
-                   const std::bitset<N>& added, 
-                   const LinearizedControlProblem& pb0,
-                   const VectorXd& s0, 
-                   const LinearizedControlProblem& pb,
+void checkSolution(const std::array<TaskWithRequirementsPtr, N> & tasks,
+                   const std::bitset<N> & added,
+                   const LinearizedControlProblem & pb0,
+                   const VectorXd & s0,
+                   const LinearizedControlProblem & pb,
                    const VectorXd s)
 {
   Vector2d eps = Vector2d::Constant(1e-6);
-  for (int j = 0; j < (3*N)/4; ++j) // all constraints
+  for(int j = 0; j < (3 * N) / 4; ++j) // all constraints
   {
-    if (added[j])
+    if(added[j])
     {
       auto t = tasks[j]->task;
       auto f = std::static_pointer_cast<tvm::function::abstract::LinearFunction>(t.function());
       pb.variables().value(s);
       f->updateValue();
       Vector2d v = f->value() - tasks[j]->task.template taskDynamics<task_dynamics::None>()->value();
-      switch (t.type())
+      switch(t.type())
       {
-      case constraint::Type::EQUAL: FAST_CHECK_UNARY(v.isZero(1e-6)); break;
-      case constraint::Type::GREATER_THAN: FAST_CHECK_UNARY((v.array() >= -eps.array()).all()); break;
-      case constraint::Type::LOWER_THAN: FAST_CHECK_UNARY((v.array() <= eps.array()).all()); break;
-      case constraint::Type::DOUBLE_SIDED:
-      {
-        Vector2d v2 = f->value() - tasks[j]->task.template secondBoundTaskDynamics<task_dynamics::None>()->value();
-        FAST_CHECK_UNARY((v.array() >= -eps.array()).all());
-        FAST_CHECK_UNARY((v2.array() <= eps.array()).all());
-      }
-      break;
+        case constraint::Type::EQUAL:
+          FAST_CHECK_UNARY(v.isZero(1e-6));
+          break;
+        case constraint::Type::GREATER_THAN:
+          FAST_CHECK_UNARY((v.array() >= -eps.array()).all());
+          break;
+        case constraint::Type::LOWER_THAN:
+          FAST_CHECK_UNARY((v.array() <= eps.array()).all());
+          break;
+        case constraint::Type::DOUBLE_SIDED:
+        {
+          Vector2d v2 = f->value() - tasks[j]->task.template secondBoundTaskDynamics<task_dynamics::None>()->value();
+          FAST_CHECK_UNARY((v.array() >= -eps.array()).all());
+          FAST_CHECK_UNARY((v2.array() <= eps.array()).all());
+        }
+        break;
       }
     }
   }
-  for (int j = (3 * N) / 4; j < N; ++j) //objectives
+  for(int j = (3 * N) / 4; j < N; ++j) // objectives
   {
-    if (added[j])
+    if(added[j])
     {
       auto t = tasks[j]->task;
       auto f = std::static_pointer_cast<tvm::function::abstract::LinearFunction>(t.function());
@@ -222,9 +237,9 @@ void checkSolution(const std::array<TaskWithRequirementsPtr, N>& tasks,
   }
 }
 
-void test1Change(const std::bitset<12>& selection, bool withSubstitution = false)
+void test1Change(const std::bitset<12> & selection, bool withSubstitution = false)
 {
-  if (skip(selection))
+  if(skip(selection))
     return;
 
   Space R2(2);
@@ -233,47 +248,49 @@ void test1Change(const std::bitset<12>& selection, bool withSubstitution = false
   VariablePtr z = R2.createVariable("z");
 
   using task_dynamics::None;
-  SolvingRequirements P0 = { PriorityLevel(0) };
-  SolvingRequirements P1 = { PriorityLevel(1) };
+  SolvingRequirements P0 = {PriorityLevel(0)};
+  SolvingRequirements P1 = {PriorityLevel(1)};
   // 3 of each: equality, inequality, bound and objective, in that order
   std::array<TaskWithRequirementsPtr, 12> tasks = {
-  std::make_shared<TaskWithRequirements>(Task{ x + 2 * y == 3., None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ 3 * x + z == 4., None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ y - z == 0.,     None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ x + y >= 0.,     None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ x + y + z >= 1., None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ x + z <= 3.,     None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ 0. <= x <= 4.,   None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ -2. <= x <= 2.,  None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ x <= 3.,         None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ y == 0.,         None() }, P1),
-  std::make_shared<TaskWithRequirements>(Task{ z == 0.,         None() }, P1),
-  std::make_shared<TaskWithRequirements>(Task{ x == 0.,         None() }, P1) };
+      std::make_shared<TaskWithRequirements>(Task{x + 2 * y == 3., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{3 * x + z == 4., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{y - z == 0., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{x + y >= 0., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{x + y + z >= 1., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{x + z <= 3., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{0. <= x <= 4., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{-2. <= x <= 2., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{x <= 3., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{y == 0., None()}, P1),
+      std::make_shared<TaskWithRequirements>(Task{z == 0., None()}, P1),
+      std::make_shared<TaskWithRequirements>(Task{x == 0., None()}, P1)};
 
   IF_USE_LSSOL(scheme::WeightedLeastSquares solverLssol(solver::LSSOLLSSolverOptions{}));
   IF_USE_QLD(scheme::WeightedLeastSquares solverQLD(solver::QLDLSSolverOptions().cholesky(true)));
   IF_USE_QUADPROG(scheme::WeightedLeastSquares solverQuadprog(solver::QuadprogLSSolverOptions().cholesky(true)));
-  
+
   int start = withSubstitution ? 1 : 0;
   int stop = withSubstitution ? 11 : 12;
-  for (int i = start; i < stop; ++i)
+  for(int i = start; i < stop; ++i)
   {
     std::bitset<12> added = selection;
-    if (withSubstitution)
+    if(withSubstitution)
     {
-      added[0] = true;      // We always want the first constraint, for substitution
-      added[11] = false;     // Since x is substituted, we make sure the objective is full rank (due to current limitations of QLD and quadprog)
+      added[0] = true; // We always want the first constraint, for substitution
+      added[11] = false; // Since x is substituted, we make sure the objective is full rank (due to current limitations
+                         // of QLD and quadprog)
     }
     LinearizedControlProblem pb;
     buildPb(pb, tasks, added);
-    if (withSubstitution) pb.add(hint::Substitution(pb.constraint(tasks[0].get()), x));
+    if(withSubstitution)
+      pb.add(hint::Substitution(pb.constraint(tasks[0].get()), x));
 
     // We solve pb for the current list of tasks
     IF_USE_LSSOL(solverLssol.solve(pb));
     IF_USE_QLD(solverQLD.solve(pb));
     IF_USE_QUADPROG(solverQuadprog.solve(pb));
-    
-    if (added[i])
+
+    if(added[i])
     {
       pb.remove(tasks[i].get());
       added[i] = false;
@@ -313,9 +330,9 @@ void test1Change(const std::bitset<12>& selection, bool withSubstitution = false
   }
 }
 
-void test3Change(const std::bitset<8>& selection)
+void test3Change(const std::bitset<8> & selection)
 {
-  if (skip2(selection))
+  if(skip2(selection))
     return;
 
   Space R2(2);
@@ -324,28 +341,28 @@ void test3Change(const std::bitset<8>& selection)
   VariablePtr z = R2.createVariable("z");
 
   using task_dynamics::None;
-  SolvingRequirements P0 = { PriorityLevel(0) };
-  SolvingRequirements P1 = { PriorityLevel(1) };
+  SolvingRequirements P0 = {PriorityLevel(0)};
+  SolvingRequirements P1 = {PriorityLevel(1)};
   // 2 of each: equality, inequality, bound and objective, in that order
   std::array<TaskWithRequirementsPtr, 8> tasks = {
-  std::make_shared<TaskWithRequirements>(Task{ x + 2 * y == 3., None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ 3 * x + z == 4., None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ x + y >= 0.,     None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ x + z <= 3.,     None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ 0. <= x <= 4.,   None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ -2. <= x <= 2.,  None() }, P0),
-  std::make_shared<TaskWithRequirements>(Task{ y == 0.,         None() }, P1),
-  std::make_shared<TaskWithRequirements>(Task{ z == 0.,         None() }, P1) };
+      std::make_shared<TaskWithRequirements>(Task{x + 2 * y == 3., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{3 * x + z == 4., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{x + y >= 0., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{x + z <= 3., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{0. <= x <= 4., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{-2. <= x <= 2., None()}, P0),
+      std::make_shared<TaskWithRequirements>(Task{y == 0., None()}, P1),
+      std::make_shared<TaskWithRequirements>(Task{z == 0., None()}, P1)};
 
   IF_USE_LSSOL(scheme::WeightedLeastSquares solverLssol(solver::LSSOLLSSolverOptions{}));
   IF_USE_QLD(scheme::WeightedLeastSquares solverQLD(solver::QLDLSSolverOptions().cholesky(true)));
   IF_USE_QUADPROG(scheme::WeightedLeastSquares solverQuadprog(solver::QuadprogLSSolverOptions().cholesky(true)));
 
-  for (int i = 0; i < 8; ++i)
+  for(int i = 0; i < 8; ++i)
   {
-    for (int j = 0; j < 8; ++j)
+    for(int j = 0; j < 8; ++j)
     {
-      for (int k = 0; k < 8; k+=2)
+      for(int k = 0; k < 8; k += 2)
       {
         std::bitset<8> added = selection;
         LinearizedControlProblem pb;
@@ -356,7 +373,7 @@ void test3Change(const std::bitset<8>& selection)
         IF_USE_QLD(solverQLD.solve(pb));
         IF_USE_QUADPROG(solverQuadprog.solve(pb));
 
-        if (added[i])
+        if(added[i])
         {
           pb.remove(tasks[i].get());
           added[i] = false;
@@ -367,7 +384,7 @@ void test3Change(const std::bitset<8>& selection)
           added[i] = true;
         }
 
-        if (added[j])
+        if(added[j])
         {
           pb.remove(tasks[j].get());
           added[j] = false;
@@ -378,7 +395,7 @@ void test3Change(const std::bitset<8>& selection)
           added[j] = true;
         }
 
-        if (added[k])
+        if(added[k])
         {
           pb.remove(tasks[k].get());
           added[k] = false;
@@ -420,7 +437,6 @@ void test3Change(const std::bitset<8>& selection)
   }
 }
 
-
 #ifdef TVM_THOROUGH_TESTING
 TEST_CASE("Systematic add/remove of one task")
 {
@@ -430,7 +446,7 @@ TEST_CASE("Systematic add/remove of one task")
 
   std::bitset<12> added(0);
   // all combinations of true/false for added
-  for (uint16_t i = 1; i < (1<<12); ++i)
+  for(uint16_t i = 1; i < (1 << 12); ++i)
   {
     added = i;
     test1Change(added);
@@ -443,23 +459,14 @@ TEST_CASE("Some add/remove of one task")
   // So we disable the logs here.
   tvm::graph::internal::Logger::logger().disable();
 
-  std::vector<std::bitset<12>> added = {std::bitset<12>("110000000000"),
-                                        std::bitset<12>("110100000000"),
-                                        std::bitset<12>("110000100000"),
-                                        std::bitset<12>("110000000100"),
-                                        std::bitset<12>("000110000000"),
-                                        std::bitset<12>("100110000000"),
-                                        std::bitset<12>("000110100000"),
-                                        std::bitset<12>("000110000100"),
-                                        std::bitset<12>("000000110000"),
-                                        std::bitset<12>("100000110000"),
-                                        std::bitset<12>("000100110000"),
-                                        std::bitset<12>("000000110100"),
-                                        std::bitset<12>("000000000110"),
-                                        std::bitset<12>("100000000110"),
-                                        std::bitset<12>("000100000110"),
-                                        std::bitset<12>("000000100110")};
-  for (size_t i = 0; i<added.size(); ++i)
+  std::vector<std::bitset<12>> added = {
+      std::bitset<12>("110000000000"), std::bitset<12>("110100000000"), std::bitset<12>("110000100000"),
+      std::bitset<12>("110000000100"), std::bitset<12>("000110000000"), std::bitset<12>("100110000000"),
+      std::bitset<12>("000110100000"), std::bitset<12>("000110000100"), std::bitset<12>("000000110000"),
+      std::bitset<12>("100000110000"), std::bitset<12>("000100110000"), std::bitset<12>("000000110100"),
+      std::bitset<12>("000000000110"), std::bitset<12>("100000000110"), std::bitset<12>("000100000110"),
+      std::bitset<12>("000000100110")};
+  for(size_t i = 0; i < added.size(); ++i)
   {
     test1Change(added[i]);
   }
@@ -475,7 +482,7 @@ TEST_CASE("Systematic add/remove of one task with substitution")
 
   std::bitset<12> added(1);
   // all combinations of true/false for added[1..10]
-  for (int i = 1; i < (1 << 10); ++i)
+  for(int i = 1; i < (1 << 10); ++i)
   {
     added = 1 + 2 * i + (1 << 11);
     test1Change(added, true);
@@ -488,20 +495,13 @@ TEST_CASE("Some add/remove of one task with substitution")
   // So we disable the logs here.
   tvm::graph::internal::Logger::logger().disable();
 
-  std::vector<std::bitset<12>> added = {std::bitset<12>("110000000000"),
-                                        std::bitset<12>("110000100000"),
-                                        std::bitset<12>("110000100000"),
-                                        std::bitset<12>("110000000100"),
-                                        std::bitset<12>("100110000000"),
-                                        std::bitset<12>("100110100000"),
-                                        std::bitset<12>("100110000100"),
-                                        std::bitset<12>("100000110000"),
-                                        std::bitset<12>("100100110000"),
-                                        std::bitset<12>("100000110100"),
-                                        std::bitset<12>("100000000110"),
-                                        std::bitset<12>("100100000110"),
-                                        std::bitset<12>("100000100110")};
-  for (size_t i = 0; i < added.size(); ++i)
+  std::vector<std::bitset<12>> added = {
+      std::bitset<12>("110000000000"), std::bitset<12>("110000100000"), std::bitset<12>("110000100000"),
+      std::bitset<12>("110000000100"), std::bitset<12>("100110000000"), std::bitset<12>("100110100000"),
+      std::bitset<12>("100110000100"), std::bitset<12>("100000110000"), std::bitset<12>("100100110000"),
+      std::bitset<12>("100000110100"), std::bitset<12>("100000000110"), std::bitset<12>("100100000110"),
+      std::bitset<12>("100000100110")};
+  for(size_t i = 0; i < added.size(); ++i)
   {
     test1Change(added[i], true);
   }
@@ -517,7 +517,7 @@ TEST_CASE("Systematic add/remove of three tasks")
 
   std::bitset<8> added(0);
   // all combinations of true/false for added
-  for (int i = 1; i < (1 << 8); ++i)
+  for(int i = 1; i < (1 << 8); ++i)
   {
     added = i;
     test3Change(added);
@@ -530,11 +530,9 @@ TEST_CASE("Some add/remove of three tasks")
   // So we disable the logs here.
   tvm::graph::internal::Logger::logger().disable();
 
-  std::vector<std::bitset<8>> added = { std::bitset<8>("11000000"),
-                                        std::bitset<8>("00110000"),
-                                        std::bitset<8>("00001100"),
-                                        std::bitset<8>("00000011")};
-  for (size_t i = 0; i < added.size(); ++i)
+  std::vector<std::bitset<8>> added = {std::bitset<8>("11000000"), std::bitset<8>("00110000"),
+                                       std::bitset<8>("00001100"), std::bitset<8>("00000011")};
+  for(size_t i = 0; i < added.size(); ++i)
   {
     test3Change(added[i]);
   }

--- a/tests/EventsTest.cpp
+++ b/tests/EventsTest.cpp
@@ -210,8 +210,7 @@ void checkSolution(const std::array<TaskWithRequirementsPtr, N> & tasks,
         case constraint::Type::LOWER_THAN:
           FAST_CHECK_UNARY((v.array() <= eps.array()).all());
           break;
-        case constraint::Type::DOUBLE_SIDED:
-        {
+        case constraint::Type::DOUBLE_SIDED: {
           Vector2d v2 = f->value() - tasks[j]->task.template secondBoundTaskDynamics<task_dynamics::None>()->value();
           FAST_CHECK_UNARY((v.array() >= -eps.array()).all());
           FAST_CHECK_UNARY((v2.array() <= eps.array()).all());

--- a/tests/EventsTest.cpp
+++ b/tests/EventsTest.cpp
@@ -276,7 +276,7 @@ void test1Change(const std::bitset<12> & selection, bool withSubstitution = fals
     std::bitset<12> added = selection;
     if(withSubstitution)
     {
-      added[0] = true; // We always want the first constraint, for substitution
+      added[0] = true;   // We always want the first constraint, for substitution
       added[11] = false; // Since x is substituted, we make sure the objective is full rank (due to current limitations
                          // of QLD and quadprog)
     }

--- a/tests/LeastSquareSolverTest.cpp
+++ b/tests/LeastSquareSolverTest.cpp
@@ -7,13 +7,13 @@
 #include <tvm/function/IdentityFunction.h>
 #include <tvm/scheme/WeightedLeastSquares.h>
 #ifdef TVM_USE_LSSOL
-# include <tvm/solver/LSSOLLeastSquareSolver.h>
+#  include <tvm/solver/LSSOLLeastSquareSolver.h>
 #endif
 #ifdef TVM_USE_QLD
-# include <tvm/solver/QLDLeastSquareSolver.h>
+#  include <tvm/solver/QLDLeastSquareSolver.h>
 #endif
 #ifdef TVM_USE_QUADPROG
-# include <tvm/solver/QuadprogLeastSquareSolver.h>
+#  include <tvm/solver/QuadprogLeastSquareSolver.h>
 #endif
 #include <tvm/task_dynamics/None.h>
 #include <tvm/task_dynamics/Proportional.h>
@@ -50,32 +50,34 @@ std::unique_ptr<LinearizedControlProblem> circleIK()
   Vector3d b = Vector3d::Constant(1.57);
 
   auto lpb = std::make_unique<LinearizedControlProblem>();
-  auto t1 = lpb->add(sf == 0., task_dynamics::P(2), { PriorityLevel(0) });
-  auto t2 = lpb->add(df == v, task_dynamics::P(2), { PriorityLevel(0) });
-  auto t3 = lpb->add(-b <= q <= b, task_dynamics::VelocityDamper({ 1, 0.01, 0, 0.1 }), { PriorityLevel(0) });
-  auto t4 = lpb->add(damp == 0., task_dynamics::None(), { PriorityLevel(1), AnisotropicWeight(Vector3d(10,2,1)) });
+  auto t1 = lpb->add(sf == 0., task_dynamics::P(2), {PriorityLevel(0)});
+  auto t2 = lpb->add(df == v, task_dynamics::P(2), {PriorityLevel(0)});
+  auto t3 = lpb->add(-b <= q <= b, task_dynamics::VelocityDamper({1, 0.01, 0, 0.1}), {PriorityLevel(0)});
+  auto t4 = lpb->add(damp == 0., task_dynamics::None(), {PriorityLevel(1), AnisotropicWeight(Vector3d(10, 2, 1))});
 
   return lpb;
 }
 
-void testSolvers(const std::unique_ptr<LinearizedControlProblem>& lpb, std::vector<std::shared_ptr<solver::abstract::LSSolverFactory> > configs, double eps)
+void testSolvers(const std::unique_ptr<LinearizedControlProblem> & lpb,
+                 std::vector<std::shared_ptr<solver::abstract::LSSolverFactory>> configs,
+                 double eps)
 {
   VariableVector variables = lpb->variables();
   std::vector<VectorXd> solutions;
 
-  for (const auto& c : configs)
+  for(const auto & c : configs)
   {
     scheme::WeightedLeastSquares s(*c);
     s.solve(*lpb);
     solutions.push_back(variables.value());
-    //Solve a second time
+    // Solve a second time
     s.solve(*lpb);
     FAST_CHECK_UNARY(solutions.back().isApprox(variables.value()));
   }
 
-  for (size_t i = 0; i < solutions.size(); ++i)
+  for(size_t i = 0; i < solutions.size(); ++i)
   {
-    for (size_t j = i + 1; j < solutions.size(); ++j)
+    for(size_t j = i + 1; j < solutions.size(); ++j)
     {
       FAST_CHECK_UNARY(solutions[i].isApprox(solutions[j], eps));
     }
@@ -85,7 +87,7 @@ void testSolvers(const std::unique_ptr<LinearizedControlProblem>& lpb, std::vect
 TEST_CASE("Simple IK")
 {
   auto lpb = circleIK();
-  std::vector<std::shared_ptr<LSSolverFactory> > configs;
+  std::vector<std::shared_ptr<LSSolverFactory>> configs;
 #ifdef TVM_USE_LSSOL
   configs.push_back(std::make_shared<LSSOLLSSolverFactory>());
 #endif

--- a/tests/LinearizedTaskConstraintTest.cpp
+++ b/tests/LinearizedTaskConstraintTest.cpp
@@ -10,9 +10,8 @@
 #include <tvm/constraint/internal/LinearizedTaskConstraint.h>
 #include <tvm/task_dynamics/Proportional.h>
 #include <tvm/task_dynamics/ProportionalDerivative.h>
-#include <tvm/utils/graph.h>
 #include <tvm/utils/ProtoTask.h>
-
+#include <tvm/utils/graph.h>
 
 using namespace Eigen;
 using namespace tvm;
@@ -70,11 +69,11 @@ TEST_CASE("Value test")
   auto J = LTC::Output::Jacobian;
   auto graph1 = utils::generateUpdateGraph(l1, E, J);
   graph1->execute();
-  CHECK_EQ(l1->e()[0], -2*9);
-  CHECK_UNARY(l1->jacobian(*dx).isApprox(Vector3d(0,4,6).transpose()));
+  CHECK_EQ(l1->e()[0], -2 * 9);
+  CHECK_UNARY(l1->jacobian(*dx).isApprox(Vector3d(0, 4, 6).transpose()));
 
   auto graph2 = utils::generateUpdateGraph(l2, U, J);
   graph2->execute();
-  CHECK_EQ(l2->u()[0], -2*9 - (-26) - 28); /*-kp*f - kv*df/dt - d2f/dxdt dx/dt*/
+  CHECK_EQ(l2->u()[0], -2 * 9 - (-26) - 28); /*-kp*f - kv*df/dt - d2f/dxdt dx/dt*/
   CHECK_UNARY(l2->jacobian(*ddx).isApprox(Vector3d(0, 4, 6).transpose()));
 }

--- a/tests/MatrixPropertiesTest.cpp
+++ b/tests/MatrixPropertiesTest.cpp
@@ -434,7 +434,6 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p16.isLowerTriangular());
   FAST_CHECK_UNARY(p16.isUpperTriangular());
 
-
   MatrixProperties p21(MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
   FAST_CHECK_EQ(p21.shape(), MatrixProperties::DIAGONAL);
   FAST_CHECK_EQ(p21.positiveness(), MatrixProperties::POSITIVE_SEMIDEFINITE);
@@ -561,7 +560,6 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p26.isLowerTriangular());
   FAST_CHECK_UNARY(p26.isUpperTriangular());
 
-
   MatrixProperties p31(MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
   FAST_CHECK_EQ(p31.shape(), MatrixProperties::DIAGONAL);
   FAST_CHECK_EQ(p31.positiveness(), MatrixProperties::POSITIVE_SEMIDEFINITE);
@@ -687,7 +685,6 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p36.isTriangular());
   FAST_CHECK_UNARY(p36.isLowerTriangular());
   FAST_CHECK_UNARY(p36.isUpperTriangular());
-
 
   MatrixProperties p41(MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
   FAST_CHECK_EQ(p41.shape(), MatrixProperties::MULTIPLE_OF_IDENTITY);
@@ -857,12 +854,10 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p52.isLowerTriangular());
   FAST_CHECK_UNARY(p52.isUpperTriangular());
 
-  CHECK_THROWS_AS(
-    MatrixProperties p53(MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE)
-    , std::runtime_error);
-  CHECK_THROWS_AS(
-    MatrixProperties p54(MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_DEFINITE)
-    , std::runtime_error);
+  CHECK_THROWS_AS(MatrixProperties p53(MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE),
+                  std::runtime_error);
+  CHECK_THROWS_AS(MatrixProperties p54(MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_DEFINITE),
+                  std::runtime_error);
 
   MatrixProperties p55(MatrixProperties::IDENTITY, MatrixProperties::INDEFINITE);
   FAST_CHECK_EQ(p55.shape(), MatrixProperties::IDENTITY);
@@ -906,13 +901,10 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p56.isLowerTriangular());
   FAST_CHECK_UNARY(p56.isUpperTriangular());
 
-  CHECK_THROWS_AS(
-    MatrixProperties p61(MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE)
-    , std::runtime_error);
-  CHECK_THROWS_AS(
-    MatrixProperties p62(MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_DEFINITE)
-    , std::runtime_error);
-
+  CHECK_THROWS_AS(MatrixProperties p61(MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE),
+                  std::runtime_error);
+  CHECK_THROWS_AS(MatrixProperties p62(MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_DEFINITE),
+                  std::runtime_error);
 
   MatrixProperties p63(MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
   FAST_CHECK_EQ(p63.shape(), MatrixProperties::MINUS_IDENTITY);
@@ -1019,10 +1011,8 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p71.isLowerTriangular());
   FAST_CHECK_UNARY(p71.isUpperTriangular());
 
-
-  CHECK_THROWS_AS(
-    MatrixProperties p72(MatrixProperties::ZERO, MatrixProperties::POSITIVE_DEFINITE)
-    , std::runtime_error);
+  CHECK_THROWS_AS(MatrixProperties p72(MatrixProperties::ZERO, MatrixProperties::POSITIVE_DEFINITE),
+                  std::runtime_error);
 
   MatrixProperties p73(MatrixProperties::ZERO, MatrixProperties::NEGATIVE_SEMIDEFINITE);
   FAST_CHECK_EQ(p73.shape(), MatrixProperties::ZERO);
@@ -1045,9 +1035,8 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p73.isLowerTriangular());
   FAST_CHECK_UNARY(p73.isUpperTriangular());
 
-  CHECK_THROWS_AS(
-    MatrixProperties p74(MatrixProperties::ZERO, MatrixProperties::NEGATIVE_DEFINITE)
-    , std::runtime_error);
+  CHECK_THROWS_AS(MatrixProperties p74(MatrixProperties::ZERO, MatrixProperties::NEGATIVE_DEFINITE),
+                  std::runtime_error);
 
   MatrixProperties p75(MatrixProperties::ZERO, MatrixProperties::INDEFINITE);
   FAST_CHECK_EQ(p75.shape(), MatrixProperties::ZERO);
@@ -1070,145 +1059,230 @@ TEST_CASE("Test properties deductions")
   FAST_CHECK_UNARY(p75.isLowerTriangular());
   FAST_CHECK_UNARY(p75.isUpperTriangular());
 
-  CHECK_THROWS_AS(
-    MatrixProperties p76(MatrixProperties::ZERO, MatrixProperties::NON_ZERO_INDEFINITE)
-    , std::runtime_error);
+  CHECK_THROWS_AS(MatrixProperties p76(MatrixProperties::ZERO, MatrixProperties::NON_ZERO_INDEFINITE),
+                  std::runtime_error);
 }
 
-
-#define buildAndCheck(shouldThrow, ... ) \
-  if (shouldThrow) {\
+#define buildAndCheck(shouldThrow, ...)                                 \
+  if(shouldThrow)                                                       \
+  {                                                                     \
     CHECK_THROWS_AS(MatrixProperties(__VA_ARGS__), std::runtime_error); \
-  } else {\
-    CHECK_NOTHROW(MatrixProperties(__VA_ARGS__)); }
+  }                                                                     \
+  else                                                                  \
+  {                                                                     \
+    CHECK_NOTHROW(MatrixProperties(__VA_ARGS__));                       \
+  }
 
 TEST_CASE("Test constness compatibility")
 {
   buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::GENERAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NA);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO, MatrixProperties::NON_ZERO_INDEFINITE);
-
+  buildAndCheck(true, MatrixProperties::Constness(false), MatrixProperties::ZERO,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::GENERAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::ZERO,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::ZERO,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::INDEFINITE);
   buildAndCheck(true, MatrixProperties::Constness(true), MatrixProperties::ZERO, MatrixProperties::NON_ZERO_INDEFINITE);
@@ -1217,133 +1291,225 @@ TEST_CASE("Test constness compatibility")
 TEST_CASE("Test invertibility compatibility")
 {
   buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::GENERAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NA);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NA);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::DIAGONAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NA);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::ZERO,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::ZERO,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::ZERO,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::ZERO,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::ZERO, MatrixProperties::NON_ZERO_INDEFINITE);
-
+  buildAndCheck(true, MatrixProperties::Invertibility(false), MatrixProperties::ZERO,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::GENERAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::LOWER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::UPPER_TRIANGULAR,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::DIAGONAL,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NA);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MULTIPLE_OF_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::NA);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NEGATIVE_DEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::INDEFINITE);
-  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::INDEFINITE);
+  buildAndCheck(false, MatrixProperties::Invertibility(true), MatrixProperties::MINUS_IDENTITY,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 
   buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::NA);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::POSITIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::POSITIVE_DEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_SEMIDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::NEGATIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO,
+                MatrixProperties::POSITIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO,
+                MatrixProperties::POSITIVE_DEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO,
+                MatrixProperties::NEGATIVE_SEMIDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO,
+                MatrixProperties::NEGATIVE_DEFINITE);
   buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::INDEFINITE);
-  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO, MatrixProperties::NON_ZERO_INDEFINITE);
+  buildAndCheck(true, MatrixProperties::Invertibility(true), MatrixProperties::ZERO,
+                MatrixProperties::NON_ZERO_INDEFINITE);
 }
 
 TEST_CASE("Test argument order and repetition")
@@ -1357,7 +1523,6 @@ TEST_CASE("Test argument order and repetition")
   buildAndCheck(false, s);
   buildAndCheck(false, c);
   buildAndCheck(false, i);
-
 
   buildAndCheck(false, s, p);
   buildAndCheck(false, s, c);
@@ -1374,7 +1539,6 @@ TEST_CASE("Test argument order and repetition")
   buildAndCheck(false, i, s);
   buildAndCheck(false, i, p);
   buildAndCheck(false, i, c);
-
 
   buildAndCheck(false, s, p, c);
   buildAndCheck(false, s, p, i);
@@ -1403,7 +1567,6 @@ TEST_CASE("Test argument order and repetition")
   buildAndCheck(false, i, p, c);
   buildAndCheck(false, i, c, s);
   buildAndCheck(false, i, c, p);
-
 
   buildAndCheck(false, s, p, c, i);
   buildAndCheck(false, s, p, i, c);

--- a/tests/MetaTest.cpp
+++ b/tests/MetaTest.cpp
@@ -28,22 +28,17 @@ static_assert(!derives_from<int, int>()); // derives_from only work with classes
 
 // Dummy classes for test purposes
 class A
-{
-};
+{};
 template<typename U, typename V>
 class TemplatedClass
-{
-};
+{};
 template<typename U>
 class TemplatedClassD1 : public TemplatedClass<U, int>
-{
-};
+{};
 class TemplatedClassD2 : public TemplatedClass<double, int>
-{
-};
+{};
 class TemplatedClassD3 : public TemplatedClassD1<int>
-{
-};
+{};
 
 // function accepting int and Eigen::MatrixXd
 template<typename T, enable_for_t<T, int, Eigen::MatrixXd> = 0>

--- a/tests/MetaTest.cpp
+++ b/tests/MetaTest.cpp
@@ -13,7 +13,6 @@
 using namespace tvm::internal;
 using namespace tvm::utils;
 
-
 //---------------------- derives_from ------------------------\\
 
 static_assert(derives_from<Eigen::MatrixXd, Eigen::MatrixBase>());
@@ -23,26 +22,44 @@ static_assert(!derives_from<Eigen::MatrixXd, LinearExpr>());
 static_assert(derives_from<AffineExpr<::internal::NoConstant, Eigen::MatrixXd>, AffineExpr>());
 static_assert(!derives_from<Eigen::MatrixXd, AffineExpr>());
 static_assert(derives_from<Eigen::MatrixXd, Eigen::MatrixXd>());
-static_assert(!derives_from<int, int>()); //derives_from only work with classes
+static_assert(!derives_from<int, int>()); // derives_from only work with classes
 
 //---------- enable_for_t and enable_for_templated_t ---------\\
 
 // Dummy classes for test purposes
-class A {};
-template<typename U, typename V> class TemplatedClass {};
-template<typename U> class TemplatedClassD1 : public TemplatedClass<U, int> {};
-class TemplatedClassD2 : public TemplatedClass<double, int> {};
-class TemplatedClassD3 : public TemplatedClassD1<int> {};
+class A
+{
+};
+template<typename U, typename V>
+class TemplatedClass
+{
+};
+template<typename U>
+class TemplatedClassD1 : public TemplatedClass<U, int>
+{
+};
+class TemplatedClassD2 : public TemplatedClass<double, int>
+{
+};
+class TemplatedClassD3 : public TemplatedClassD1<int>
+{
+};
 
-//function accepting int and Eigen::MatrixXd
+// function accepting int and Eigen::MatrixXd
 template<typename T, enable_for_t<T, int, Eigen::MatrixXd> = 0>
-constexpr std::true_type testSimple(const T&) { return {}; }
+constexpr std::true_type testSimple(const T &)
+{
+  return {};
+}
 // Fallback version
 constexpr std::false_type testSimple(...) { return {}; }
 
-//function accepting Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr
+// function accepting Eigen::MatrixBase, tvm::utils::LinearExpr, tvm::utils::AffineExpr
 template<typename T, enable_for_templated_t<T, Eigen::MatrixBase, TemplatedClass> = 0>
-constexpr std::true_type testTemplate(const T&) { return {}; }
+constexpr std::true_type testTemplate(const T &)
+{
+  return {};
+}
 // Fallback version
 constexpr std::false_type testTemplate(...) { return {}; }
 
@@ -60,7 +77,6 @@ static_assert(decltype(testTemplate(TemplatedClassD1<int>()))::value);
 static_assert(decltype(testTemplate(TemplatedClassD2()))::value);
 static_assert(decltype(testTemplate(TemplatedClassD3()))::value);
 
-
 //---------------- always_true, always_false -----------------\\
 
 static_assert(always_true<int>::value);
@@ -72,7 +88,10 @@ static_assert(!always_false<A>::value);
 
 TVM_CREATE_HAS_MEMBER_TYPE_TRAIT_FOR(Foo)
 
-class B { using Foo = int; };
+class B
+{
+  using Foo = int;
+};
 static_assert(!has_member_type_Foo<int>::value);
 static_assert(!has_member_type_Foo<A>::value);
 static_assert(has_member_type_Foo<B>::value);

--- a/tests/Mockup.cpp
+++ b/tests/Mockup.cpp
@@ -3,13 +3,14 @@
 #include "Mockup.h"
 #include <string>
 
-RobotMockup::RobotMockup()
-: k(0), v(0), d(0), a(0)
+RobotMockup::RobotMockup() : k(0), v(0), d(0), a(0)
 {
+  // clang-format off
   registerUpdates(Update::Kinematics, &RobotMockup::updateK,
                   Update::Velocity, &RobotMockup::updateV,
                   Update::Dynamics, &RobotMockup::updateD,
                   Update::Acceleration, &RobotMockup::updateA);
+  // clang-format on
 
   addOutputDependency({Output::K1, Output::K2, Output::K3}, Update::Kinematics);
   addOutputDependency({Output::V1, Output::V2}, Update::Velocity);
@@ -21,18 +22,19 @@ RobotMockup::RobotMockup()
   addInternalDependency(Update::Acceleration, Update::Velocity);
 }
 
-
 FunctionMockup::FunctionMockup()
 {
+  // clang-format off
   registerUpdates(Update::Value, &FunctionMockup::updateValue,
                   Update::Velocity, &FunctionMockup::updateVelocity,
                   Update::JDot, &FunctionMockup::updateJDot);
+  // clang-format on
 }
 
-RobotFunction::RobotFunction(std::shared_ptr<RobotMockup> robot)
-: robot_(robot)
+RobotFunction::RobotFunction(std::shared_ptr<RobotMockup> robot) : robot_(robot)
 {
-  addInput(robot, RobotMockup::Output::K1, RobotMockup::Output::K2, RobotMockup::Output::K3, RobotMockup::Output::V1, RobotMockup::Output::V2, RobotMockup::Output::D1, RobotMockup::Output::D2);
+  addInput(robot, RobotMockup::Output::K1, RobotMockup::Output::K2, RobotMockup::Output::K3, RobotMockup::Output::V1,
+           RobotMockup::Output::V2, RobotMockup::Output::D1, RobotMockup::Output::D2);
 
   addInternalDependency(Update::Velocity, Update::Value);
   addInternalDependency(Update::JDot, Update::Velocity);
@@ -42,8 +44,7 @@ RobotFunction::RobotFunction(std::shared_ptr<RobotMockup> robot)
   addInputDependency(Update::JDot, robot_, RobotMockup::Output::V1, RobotMockup::Output::V2);
 }
 
-SomeRobotFunction1::SomeRobotFunction1(std::shared_ptr<RobotMockup> robot)
-: RobotFunction(robot)
+SomeRobotFunction1::SomeRobotFunction1(std::shared_ptr<RobotMockup> robot) : RobotFunction(robot)
 {
   addOutputDependency(Output::Value, Update::Value);
   addOutputDependency(Output::Jacobian, Update::Velocity);
@@ -62,16 +63,15 @@ void SomeRobotFunction1::updateVelocity()
   std::cout << "update SomeRobotFunction1::Velocity" << std::endl;
   j = (int)robot_->getV1();
   vel = (int)robot_->getV2();
-  na = (int)robot_->getK3()*(int)robot_->getV1();
+  na = (int)robot_->getK3() * (int)robot_->getV1();
 }
 void SomeRobotFunction1::updateJDot()
 {
   std::cout << "update SomeRobotFunction1::JDot" << std::endl;
-  jdot = (int)robot_->getK3()*(int)robot_->getV1() + (int)robot_->getV2();
+  jdot = (int)robot_->getK3() * (int)robot_->getV1() + (int)robot_->getV2();
 }
 
-SomeRobotFunction2::SomeRobotFunction2(std::shared_ptr<RobotMockup> robot)
-: RobotFunction(robot)
+SomeRobotFunction2::SomeRobotFunction2(std::shared_ptr<RobotMockup> robot) : RobotFunction(robot)
 {
   addOutputDependency(Output::Value, Update::Value);
   addOutputDependency(Output::Jacobian, Update::Velocity);
@@ -88,16 +88,14 @@ void SomeRobotFunction2::updateVelocity()
   std::cout << "update SomeRobotFunction2::Velocity" << std::endl;
 }
 
-BadRobotFunction::BadRobotFunction(std::shared_ptr<RobotMockup> robot)
-: RobotFunction(robot)
+BadRobotFunction::BadRobotFunction(std::shared_ptr<RobotMockup> robot) : RobotFunction(robot)
 {
   addOutputDependency(Output::Value, Update::Value);
   addOutputDependency(Output::Jacobian, Update::Velocity);
-  addInternalDependency(Update::Velocity, Update::JDot); //BAAAAAD
+  addInternalDependency(Update::Velocity, Update::JDot); // BAAAAAD
 }
 
-LinearConstraint::LinearConstraint(const std::string& name)
-: name_(name)
+LinearConstraint::LinearConstraint(const std::string & name) : name_(name)
 {
   registerUpdates(Update::Matrices, &LinearConstraint::updateMatrices);
 
@@ -106,23 +104,17 @@ LinearConstraint::LinearConstraint(const std::string& name)
 
 Dummy<int(LinearConstraint::Output::Value)> LinearConstraint::value(int x) const
 {
-  //obviously, in real setting we would depend from a variable and take its value
-  return A_*x + b_;
+  // obviously, in real setting we would depend from a variable and take its value
+  return A_ * x + b_;
 }
 
-Dummy<int(LinearConstraint::Output::A)> LinearConstraint::A() const
-{
-  return A_;
-}
+Dummy<int(LinearConstraint::Output::A)> LinearConstraint::A() const { return A_; }
 
-Dummy<int(LinearConstraint::Output::b)> LinearConstraint::b() const
-{
-  return b_;
-}
+Dummy<int(LinearConstraint::Output::b)> LinearConstraint::b() const { return b_; }
 
-KinematicLinearizedConstraint::KinematicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function)
-  : LinearConstraint(name)
-  , function_(function)
+KinematicLinearizedConstraint::KinematicLinearizedConstraint(const std::string & name,
+                                                             std::shared_ptr<FunctionMockup> function)
+: LinearConstraint(name), function_(function)
 {
   addInput(function, FunctionMockup::Output::Value, FunctionMockup::Output::Jacobian);
   addInputDependency(Update::Matrices, function_, FunctionMockup::Output::Value, FunctionMockup::Output::Jacobian);
@@ -135,19 +127,15 @@ void KinematicLinearizedConstraint::updateMatrices()
   std::cout << "update KinematicLinearizedConstraint::updateMatrices" << std::endl;
 }
 
-DynamicLinearizedConstraint::DynamicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function)
-  : LinearConstraint(name)
-  , function_(function)
+DynamicLinearizedConstraint::DynamicLinearizedConstraint(const std::string & name,
+                                                         std::shared_ptr<FunctionMockup> function)
+: LinearConstraint(name), function_(function)
 {
-  addInput(function, FunctionMockup::Output::Value,
-                     FunctionMockup::Output::Jacobian,
-                     FunctionMockup::Output::Velocity,
-                     FunctionMockup::Output::NormalAcceleration);
+  addInput(function, FunctionMockup::Output::Value, FunctionMockup::Output::Jacobian, FunctionMockup::Output::Velocity,
+           FunctionMockup::Output::NormalAcceleration);
 
-  addInputDependency(Update::Matrices, function_, FunctionMockup::Output::Value,
-                                                  FunctionMockup::Output::Jacobian,
-                                                  FunctionMockup::Output::Velocity,
-                                                  FunctionMockup::Output::NormalAcceleration);
+  addInputDependency(Update::Matrices, function_, FunctionMockup::Output::Value, FunctionMockup::Output::Jacobian,
+                     FunctionMockup::Output::Velocity, FunctionMockup::Output::NormalAcceleration);
 }
 
 void DynamicLinearizedConstraint::updateMatrices()
@@ -157,9 +145,8 @@ void DynamicLinearizedConstraint::updateMatrices()
   std::cout << "update DynamicLinearizedConstraint::updateMatrices" << std::endl;
 }
 
-DynamicEquation::DynamicEquation(const std::string& name, std::shared_ptr<RobotMockup> robot)
-  : LinearConstraint(name)
-  , robot_(robot)
+DynamicEquation::DynamicEquation(const std::string & name, std::shared_ptr<RobotMockup> robot)
+: LinearConstraint(name), robot_(robot)
 {
   addInput(robot, RobotMockup::Output::D1, RobotMockup::Output::D2);
 
@@ -173,30 +160,21 @@ void DynamicEquation::updateMatrices()
   std::cout << "update DynamicEquation::updateMatrices" << std::endl;
 }
 
-BetterLinearConstraint::BetterLinearConstraint(const std::string& name)
-  : name_(name)
-{
-}
+BetterLinearConstraint::BetterLinearConstraint(const std::string & name) : name_(name) {}
 
 Dummy<int(BetterLinearConstraint::Output::Value)> BetterLinearConstraint::value(int x) const
 {
-  //obviously, in real setting we would depend from a variable and take its value
-  return A_*x + b_;
+  // obviously, in real setting we would depend from a variable and take its value
+  return A_ * x + b_;
 }
 
-Dummy<int(BetterLinearConstraint::Output::A)> BetterLinearConstraint::A() const
-{
-  return A_;
-}
+Dummy<int(BetterLinearConstraint::Output::A)> BetterLinearConstraint::A() const { return A_; }
 
-Dummy<int(BetterLinearConstraint::Output::b)> BetterLinearConstraint::b() const
-{
-  return b_;
-}
+Dummy<int(BetterLinearConstraint::Output::b)> BetterLinearConstraint::b() const { return b_; }
 
-BetterKinematicLinearizedConstraint::BetterKinematicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function)
-  : BetterLinearConstraint(name)
-  , function_(function)
+BetterKinematicLinearizedConstraint::BetterKinematicLinearizedConstraint(const std::string & name,
+                                                                         std::shared_ptr<FunctionMockup> function)
+: BetterLinearConstraint(name), function_(function)
 {
   addInput(function, FunctionMockup::Output::Value, FunctionMockup::Output::Jacobian);
   addDirectDependency(Output::A, function, FunctionMockup::Output::Jacobian);
@@ -213,20 +191,16 @@ Dummy<int(BetterLinearConstraint::Output::A)> BetterKinematicLinearizedConstrain
   return static_cast<int>(function_->jacobian());
 }
 
-BetterDynamicLinearizedConstraint::BetterDynamicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function)
-  : BetterLinearConstraint(name)
-  , function_(function)
+BetterDynamicLinearizedConstraint::BetterDynamicLinearizedConstraint(const std::string & name,
+                                                                     std::shared_ptr<FunctionMockup> function)
+: BetterLinearConstraint(name), function_(function)
 {
   registerUpdates(Update::Updateb, &BetterDynamicLinearizedConstraint::updateb);
 
-
-  addInput(function, FunctionMockup::Output::Value,
-           FunctionMockup::Output::Jacobian,
-           FunctionMockup::Output::Velocity,
+  addInput(function, FunctionMockup::Output::Value, FunctionMockup::Output::Jacobian, FunctionMockup::Output::Velocity,
            FunctionMockup::Output::NormalAcceleration);
 
-  addInputDependency<BetterDynamicLinearizedConstraint>(Update::Updateb, function_,
-                                                        FunctionMockup::Output::Value,
+  addInputDependency<BetterDynamicLinearizedConstraint>(Update::Updateb, function_, FunctionMockup::Output::Value,
                                                         FunctionMockup::Output::Velocity,
                                                         FunctionMockup::Output::NormalAcceleration);
 
@@ -244,4 +218,3 @@ void BetterDynamicLinearizedConstraint::updateb()
   b_ = function_->value() + function_->velocity() + function_->normalAcc();
   std::cout << "update BetterDynamicLinearizedConstraint::updateb" << std::endl;
 }
-

--- a/tests/Mockup.h
+++ b/tests/Mockup.h
@@ -5,12 +5,13 @@
 
 #include <iostream>
 
-template <int ReturnType>
+template<int ReturnType>
 class Dummy
 {
 public:
-  Dummy(int i) :i_(i) {}
+  Dummy(int i) : i_(i) {}
   operator int() { return i_; }
+
 private:
   int i_;
 };
@@ -18,11 +19,14 @@ private:
 class VariableMockup
 {
 public:
-  enum Output {Value};
+  enum Output
+  {
+    Value
+  };
 
   VariableMockup() {}
   void setValue(double) {}
-  double value() const  { return 0; }
+  double value() const { return 0; }
 };
 
 class RobotMockup : public tvm::graph::abstract::Node<RobotMockup>
@@ -43,10 +47,26 @@ public:
   Dummy<static_cast<int>(Output::A1)> getA1() const { return a; }
 
 protected:
-  void updateK() { std::cout << "update robot kinematics" << std::endl; ++k; }
-  void updateV() { std::cout << "update robot velocity" << std::endl; ++v; }
-  void updateD() { std::cout << "update robot dynamics" << std::endl; ++d; }
-  void updateA() { std::cout << "update robot acceleration" << std::endl; ++a; }
+  void updateK()
+  {
+    std::cout << "update robot kinematics" << std::endl;
+    ++k;
+  }
+  void updateV()
+  {
+    std::cout << "update robot velocity" << std::endl;
+    ++v;
+  }
+  void updateD()
+  {
+    std::cout << "update robot dynamics" << std::endl;
+    ++d;
+  }
+  void updateA()
+  {
+    std::cout << "update robot acceleration" << std::endl;
+    ++a;
+  }
 
   VariableMockup q;
   int k, v, d, a;
@@ -64,6 +84,7 @@ public:
   Dummy<int(Output::Value)> velocity() const { return vel; }
   Dummy<int(Output::Value)> normalAcc() const { return na; }
   Dummy<int(Output::Value)> Jdot() const { return jdot; }
+
 protected:
   FunctionMockup();
 
@@ -72,7 +93,6 @@ protected:
   virtual void updateJDot() {}
 
   int val, j, vel, na, jdot;
-
 };
 
 /** Base class for a function relying on a robot to compute its own outputs*/
@@ -89,6 +109,7 @@ class SomeRobotFunction1 : public RobotFunction
 {
 public:
   SomeRobotFunction1(std::shared_ptr<RobotMockup> robot);
+
 protected:
   void updateValue() override;
   void updateVelocity() override;
@@ -99,6 +120,7 @@ class SomeRobotFunction2 : public RobotFunction
 {
 public:
   SomeRobotFunction2(std::shared_ptr<RobotMockup> robot);
+
 protected:
   void updateValue() override;
   void updateVelocity() override;
@@ -108,20 +130,21 @@ class BadRobotFunction : public RobotFunction
 {
 public:
   BadRobotFunction(std::shared_ptr<RobotMockup> robot);
+
 protected:
   void update();
 };
 
 /** Base class for a linear expression Ax+b*/
-class LinearConstraint: public tvm::graph::abstract::Node<LinearConstraint>
+class LinearConstraint : public tvm::graph::abstract::Node<LinearConstraint>
 {
 public:
   SET_OUTPUTS(LinearConstraint, Value, A, b)
   SET_UPDATES(LinearConstraint, Matrices)
 
-  LinearConstraint(const std::string& name);
+  LinearConstraint(const std::string & name);
 
-  //example of method with argument
+  // example of method with argument
   Dummy<int(Output::Value)> value(int x) const;
   Dummy<int(Output::A)> A() const;
   Dummy<int(Output::b)> b() const;
@@ -139,7 +162,7 @@ private:
 class KinematicLinearizedConstraint : public LinearConstraint
 {
 public:
-  KinematicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function);
+  KinematicLinearizedConstraint(const std::string & name, std::shared_ptr<FunctionMockup> function);
 
 protected:
   void updateMatrices() override;
@@ -152,7 +175,7 @@ private:
 class DynamicLinearizedConstraint : public LinearConstraint
 {
 public:
-  DynamicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function);
+  DynamicLinearizedConstraint(const std::string & name, std::shared_ptr<FunctionMockup> function);
 
 protected:
   void updateMatrices() override;
@@ -165,7 +188,7 @@ private:
 class DynamicEquation : public LinearConstraint
 {
 public:
-  DynamicEquation(const std::string& name, std::shared_ptr<RobotMockup> robot);
+  DynamicEquation(const std::string & name, std::shared_ptr<RobotMockup> robot);
 
 protected:
   void updateMatrices() override;
@@ -174,16 +197,15 @@ private:
   std::shared_ptr<RobotMockup> robot_;
 };
 
-
 /** Base class for a linear expression Ax+b*/
 class BetterLinearConstraint : public tvm::graph::abstract::Node<BetterLinearConstraint>
 {
 public:
   SET_OUTPUTS(BetterLinearConstraint, Value, A, b)
 
-  BetterLinearConstraint(const std::string& name);
+  BetterLinearConstraint(const std::string & name);
 
-  //example of method with argument
+  // example of method with argument
   Dummy<int(Output::Value)> value(int x) const;
   virtual Dummy<int(Output::A)> A() const;
   virtual Dummy<int(Output::b)> b() const;
@@ -199,7 +221,7 @@ private:
 class BetterKinematicLinearizedConstraint : public BetterLinearConstraint
 {
 public:
-  BetterKinematicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function);
+  BetterKinematicLinearizedConstraint(const std::string & name, std::shared_ptr<FunctionMockup> function);
 
   virtual Dummy<int(Output::A)> A() const override;
   virtual Dummy<int(Output::b)> b() const override;
@@ -214,13 +236,12 @@ class BetterDynamicLinearizedConstraint : public BetterLinearConstraint
 public:
   SET_UPDATES(BetterDynamicLinearizedConstraint, Updateb)
 
-  BetterDynamicLinearizedConstraint(const std::string& name, std::shared_ptr<FunctionMockup> function);
+  BetterDynamicLinearizedConstraint(const std::string & name, std::shared_ptr<FunctionMockup> function);
   void updateb();
 
   virtual Dummy<int(Output::A)> A() const override;
 
 protected:
-
 private:
   std::shared_ptr<FunctionMockup> function_;
 };

--- a/tests/OutputSelectorTest.cpp
+++ b/tests/OutputSelectorTest.cpp
@@ -16,9 +16,7 @@ class Provider1 : public Node<Provider1>
 public:
   SET_OUTPUTS(Provider1, O0, O1, O2)
 
-  Provider1()
-  {
-  }
+  Provider1() {}
 };
 
 class Provider2 : public Provider1
@@ -27,18 +25,13 @@ public:
   SET_OUTPUTS(Provider2, O3, O4)
   DISABLE_OUTPUTS(Provider1::Output::O1)
 
-  Provider2()
-  {
-  }
+  Provider2() {}
 };
 
 class Provider3 : public OutputSelector<Provider2>
 {
 public:
-  Provider3()
-  {
-    disableOutput(Provider1::Output::O1, Provider2::Output::O3);
-  }
+  Provider3() { disableOutput(Provider1::Output::O1, Provider2::Output::O3); }
 };
 
 class Provider4 : public Provider3
@@ -46,24 +39,25 @@ class Provider4 : public Provider3
 public:
   SET_OUTPUTS(Provider4, O5, O6, O7)
 
-  Provider4()
-  {
-  }
+  Provider4() {}
 };
 
 class Provider5 : public OutputSelector<Provider4>
 {
 public:
-  Provider5()
+  Provider5() { disableOutput(Provider1::Output::O0, Provider4::Output::O6); }
+
+  template<typename EnumT>
+  void manualEnable(EnumT e)
   {
-    disableOutput(Provider1::Output::O0, Provider4::Output::O6);
+    enableOutput(e);
   }
 
   template<typename EnumT>
-  void manualEnable(EnumT e) { enableOutput(e); }
-
-  template<typename EnumT>
-  void manualDisable(EnumT e) { disableOutput(e); }
+  void manualDisable(EnumT e)
+  {
+    disableOutput(e);
+  }
 };
 
 class Provider6 : public OutputSelector<Provider6, Provider4>
@@ -77,7 +71,6 @@ public:
   }
 };
 
-
 TEST_CASE("Test outputs selector")
 {
   Provider3 p3;
@@ -88,7 +81,7 @@ TEST_CASE("Test outputs selector")
   FAST_CHECK_UNARY(p3.isOutputEnabled(Provider2::Output::O4));
 
   Provider5 p5;
-  for (int i = 0; i < 8; ++i)
+  for(int i = 0; i < 8; ++i)
   {
     if(i != 0 && i != 1 && i != 3 && i != 6)
     {

--- a/tests/PairElementTokenTest.cpp
+++ b/tests/PairElementTokenTest.cpp
@@ -10,7 +10,6 @@
 
 using namespace tvm::internal;
 
-
 TEST_CASE("Lifetime 1")
 {
   std::unique_ptr<PairElementToken>(t3);
@@ -44,13 +43,12 @@ TEST_CASE("Lifetime 1")
   // End of t3's life
 }
 
-
 std::pair<PairElementToken, PairElementToken> createPair1()
 {
   PairElementToken t1;
   PairElementToken t2;
   t1.pairWith(t2);
-  return { std::move(t1), std::move(t2) };
+  return {std::move(t1), std::move(t2)};
 }
 
 TEST_CASE("Lifetime 2")
@@ -63,7 +61,6 @@ TEST_CASE("Lifetime 2")
   FAST_CHECK_EQ(&t1.otherPairElement(), &t2);
   FAST_CHECK_EQ(&t2.otherPairElement(), &t1);
 }
-
 
 std::pair<PairElementToken, PairElementToken> createPair2()
 {
@@ -88,8 +85,7 @@ TEST_CASE("Lifetime 3")
   FAST_CHECK_UNARY(!t1.isPaired());
 }
 
-
-PairElementTokenHandle addToken(std::vector<PairElementToken>& tokens)
+PairElementTokenHandle addToken(std::vector<PairElementToken> & tokens)
 {
   tokens.emplace_back();
   return PairElementTokenHandle(tokens.back());
@@ -101,7 +97,7 @@ TEST_CASE("Use with vector and handle")
   {
     std::vector<PairElementToken> tokens2;
 
-    //adding paired tokens in tokens1 and tokens2 with various methods
+    // adding paired tokens in tokens1 and tokens2 with various methods
     tokens2.emplace_back(addToken(tokens1));
     tokens2.push_back(addToken(tokens1));
     auto h = addToken(tokens1);
@@ -113,7 +109,7 @@ TEST_CASE("Use with vector and handle")
     FAST_CHECK_UNARY(tokens1[2].isPairedWith(tokens2[2]));
     FAST_CHECK_UNARY(tokens2[2].isPairedWith(tokens1[2]));
 
-    //removing an element
+    // removing an element
     tokens1.erase(tokens1.begin());
     FAST_CHECK_UNARY(!tokens2[0].isPaired());
     FAST_CHECK_UNARY(tokens1[0].isPairedWith(tokens2[1]));
@@ -121,7 +117,7 @@ TEST_CASE("Use with vector and handle")
     FAST_CHECK_UNARY(tokens1[1].isPairedWith(tokens2[2]));
     FAST_CHECK_UNARY(tokens2[2].isPairedWith(tokens1[1]));
   }
-  
+
   // tokens2 does not exist anymore
   FAST_CHECK_UNARY(!tokens1[0].isPaired());
   FAST_CHECK_UNARY(!tokens1[1].isPaired());

--- a/tests/RobotProblem.cpp
+++ b/tests/RobotProblem.cpp
@@ -1,18 +1,18 @@
 /** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
 #include <tvm/Robot.h>
-#include <tvm/robot/internal/GeometricContactFunction.h>
-#include <tvm/robot/internal/DynamicFunction.h>
-#include <tvm/robot/CollisionFunction.h>
+#include <tvm/Task.h>
 #include <tvm/robot/CoMFunction.h>
 #include <tvm/robot/CoMInConvexFunction.h>
+#include <tvm/robot/CollisionFunction.h>
 #include <tvm/robot/ConvexHull.h>
 #include <tvm/robot/JointsSelector.h>
 #include <tvm/robot/OrientationFunction.h>
 #include <tvm/robot/PositionFunction.h>
 #include <tvm/robot/PostureFunction.h>
+#include <tvm/robot/internal/DynamicFunction.h>
+#include <tvm/robot/internal/GeometricContactFunction.h>
 #include <tvm/robot/utils.h>
-#include <tvm/Task.h>
 
 #include <tvm/Clock.h>
 #include <tvm/ControlProblem.h>
@@ -20,8 +20,8 @@
 #include <tvm/function/IdentityFunction.h>
 #include <tvm/hint/Substitution.h>
 #include <tvm/scheme/WeightedLeastSquares.h>
-#include <tvm/solver/defaultLeastSquareSolver.h>
 #include <tvm/solver/QuadprogLeastSquareSolver.h>
+#include <tvm/solver/defaultLeastSquareSolver.h>
 #include <tvm/task_dynamics/None.h>
 #include <tvm/task_dynamics/ProportionalDerivative.h>
 #include <tvm/task_dynamics/VelocityDamper.h>
@@ -40,7 +40,6 @@
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"
 
-
 static std::string jvrc_path = JVRC_DESCRIPTION_PATH;
 static std::string env_path = MC_ENV_DESCRIPTION_PATH;
 static std::string jvrc_urdf = jvrc_path + "/urdf/jvrc1.urdf";
@@ -49,159 +48,135 @@ static std::string jvrc_convex_path = jvrc_path + "/convex/jvrc1/";
 
 tvm::robot::ConvexHullPtr loadConvex(tvm::robot::FramePtr f)
 {
-  return std::make_shared<tvm::robot::ConvexHull>
-  (
-    jvrc_convex_path + f->body() + "-ch.txt",
-    f, sva::PTransformd::Identity()
-  );
+  return std::make_shared<tvm::robot::ConvexHull>(jvrc_convex_path + f->body() + "-ch.txt", f,
+                                                  sva::PTransformd::Identity());
 }
 
 /** Build a cube as a set of planes from a given origin and size */
 std::vector<tvm::geometry::PlanePtr> makeCube(const Eigen::Vector3d & origin, double size)
 {
-  return {
-    std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{1, 0, 0}, origin + Eigen::Vector3d{-size, 0, 0}),
-    std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{-1, 0, 0}, origin + Eigen::Vector3d{size, 0, 0}),
-    std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, 1, 0}, origin + Eigen::Vector3d{0, -size, 0}),
-    std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, -1, 0}, origin + Eigen::Vector3d{0, size, 0}),
-    std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, 0, 1}, origin + Eigen::Vector3d{0, 0, -size}),
-    std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, 0, -1}, origin + Eigen::Vector3d{0, 0, size})
-  };
+  return {std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{1, 0, 0}, origin + Eigen::Vector3d{-size, 0, 0}),
+          std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{-1, 0, 0}, origin + Eigen::Vector3d{size, 0, 0}),
+          std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, 1, 0}, origin + Eigen::Vector3d{0, -size, 0}),
+          std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, -1, 0}, origin + Eigen::Vector3d{0, size, 0}),
+          std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, 0, 1}, origin + Eigen::Vector3d{0, 0, -size}),
+          std::make_shared<tvm::geometry::Plane>(Eigen::Vector3d{0, 0, -1}, origin + Eigen::Vector3d{0, 0, size})};
 }
 
-#if defined(TVM_USE_LSSOL) || defined(TVM_USE_QLD) //Quadprog is having trouble, seemingly with the bounds on f
+#if defined(TVM_USE_LSSOL) || defined(TVM_USE_QLD) // Quadprog is having trouble, seemingly with the bounds on f
 TEST_CASE("Test a problem with a robot")
 {
-#if NDEBUG
+#  if NDEBUG
   size_t iter = 2000;
-#else
+#  else
   size_t iter = 100;
-#endif
+#  endif
   double dt = 0.005;
 
   tvm::ControlProblem pb;
   tvm::Clock clock(dt);
 
-  std::map<std::string, std::vector<double>> ref_q = {
-    {"Root", {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8275}},
-    {"R_HIP_P", {-0.38}},
-    {"R_HIP_R", {-0.01}},
-    {"R_HIP_Y", {0.0}},
-    {"R_KNEE", {0.72}},
-    {"R_ANKLE_R", {-0.01}},
-    {"R_ANKLE_P", {-0.33}},
-    {"L_HIP_P", {-0.38}},
-    {"L_HIP_R", {0.02}},
-    {"L_HIP_Y", {0.0}},
-    {"L_KNEE", {0.72}},
-    {"L_ANKLE_R", {-0.02}},
-    {"L_ANKLE_P", {-0.33}},
-    {"WAIST_Y", {0.0}},
-    {"WAIST_P", {0.13}},
-    {"WAIST_R", {0.00}},
-    {"NECK_Y", {0.0}},
-    {"NECK_R", {0.0}},
-    {"NECK_P", {0.0}},
-    {"R_SHOULDER_P", {-0.052}},
-    {"R_SHOULDER_R", {-0.17}},
-    {"R_SHOULDER_Y", {0.0}},
-    {"R_ELBOW_P", {-0.52}},
-    {"R_ELBOW_Y", {0.0}},
-    {"R_WRIST_R", {0.0}},
-    {"R_WRIST_Y", {0.0}},
-    {"R_UTHUMB", {0.0}},
-    {"R_LTHUMB", {0.0}},
-    {"R_UINDEX", {0.0}},
-    {"R_LINDEX", {0.0}},
-    {"R_ULITTLE", {0.0}},
-    {"R_LLITTLE", {0.0}},
-    {"L_SHOULDER_P", {-0.052000}},
-    {"L_SHOULDER_R", {0.17}},
-    {"L_SHOULDER_Y", {0.0}},
-    {"L_ELBOW_P", {-0.52}},
-    {"L_ELBOW_Y", {0.0}},
-    {"L_WRIST_R", {0.0}},
-    {"L_WRIST_Y", {0.0}},
-    {"L_UTHUMB", {0.0}},
-    {"L_LTHUMB", {0.0}},
-    {"L_UINDEX", {0.0}},
-    {"L_LINDEX", {0.0}},
-    {"L_ULITTLE", {0.0}},
-    {"L_LLITTLE", {0.0}}
-  };
-  std::vector<std::string> jvrc_filtered = {
-    "R_UTHUMB_S", "R_LTHUMB_S", "R_UINDEX_S", "R_LINDEX_S", "R_ULITTLE_S", "R_LLITTLE_S",
-    "L_UTHUMB_S", "L_LTHUMB_S", "L_UINDEX_S", "L_LINDEX_S", "L_ULITTLE_S", "L_LLITTLE_S"};
+  std::map<std::string, std::vector<double>> ref_q = {{"Root", {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8275}},
+                                                      {"R_HIP_P", {-0.38}},
+                                                      {"R_HIP_R", {-0.01}},
+                                                      {"R_HIP_Y", {0.0}},
+                                                      {"R_KNEE", {0.72}},
+                                                      {"R_ANKLE_R", {-0.01}},
+                                                      {"R_ANKLE_P", {-0.33}},
+                                                      {"L_HIP_P", {-0.38}},
+                                                      {"L_HIP_R", {0.02}},
+                                                      {"L_HIP_Y", {0.0}},
+                                                      {"L_KNEE", {0.72}},
+                                                      {"L_ANKLE_R", {-0.02}},
+                                                      {"L_ANKLE_P", {-0.33}},
+                                                      {"WAIST_Y", {0.0}},
+                                                      {"WAIST_P", {0.13}},
+                                                      {"WAIST_R", {0.00}},
+                                                      {"NECK_Y", {0.0}},
+                                                      {"NECK_R", {0.0}},
+                                                      {"NECK_P", {0.0}},
+                                                      {"R_SHOULDER_P", {-0.052}},
+                                                      {"R_SHOULDER_R", {-0.17}},
+                                                      {"R_SHOULDER_Y", {0.0}},
+                                                      {"R_ELBOW_P", {-0.52}},
+                                                      {"R_ELBOW_Y", {0.0}},
+                                                      {"R_WRIST_R", {0.0}},
+                                                      {"R_WRIST_Y", {0.0}},
+                                                      {"R_UTHUMB", {0.0}},
+                                                      {"R_LTHUMB", {0.0}},
+                                                      {"R_UINDEX", {0.0}},
+                                                      {"R_LINDEX", {0.0}},
+                                                      {"R_ULITTLE", {0.0}},
+                                                      {"R_LLITTLE", {0.0}},
+                                                      {"L_SHOULDER_P", {-0.052000}},
+                                                      {"L_SHOULDER_R", {0.17}},
+                                                      {"L_SHOULDER_Y", {0.0}},
+                                                      {"L_ELBOW_P", {-0.52}},
+                                                      {"L_ELBOW_Y", {0.0}},
+                                                      {"L_WRIST_R", {0.0}},
+                                                      {"L_WRIST_Y", {0.0}},
+                                                      {"L_UTHUMB", {0.0}},
+                                                      {"L_LTHUMB", {0.0}},
+                                                      {"L_UINDEX", {0.0}},
+                                                      {"L_LINDEX", {0.0}},
+                                                      {"L_ULITTLE", {0.0}},
+                                                      {"L_LLITTLE", {0.0}}};
+  std::vector<std::string> jvrc_filtered = {"R_UTHUMB_S",  "R_LTHUMB_S",  "R_UINDEX_S",  "R_LINDEX_S",
+                                            "R_ULITTLE_S", "R_LLITTLE_S", "L_UTHUMB_S",  "L_LTHUMB_S",
+                                            "L_UINDEX_S",  "L_LINDEX_S",  "L_ULITTLE_S", "L_LLITTLE_S"};
   tvm::RobotPtr jvrc = tvm::robot::fromURDF(clock, "JVRC1", jvrc_urdf, false, jvrc_filtered, ref_q);
   tvm::RobotPtr ground = tvm::robot::fromURDF(clock, "ground", ground_urdf, true, {}, {});
 
-  auto jvrc_lf = std::make_shared<tvm::robot::Frame>("LFullSoleFrame",
-                                                     jvrc,
-                                                     "L_ANKLE_P_S",
-                                                     sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)}
-                                                     );
-  auto jvrc_rf = std::make_shared<tvm::robot::Frame>("RFullSoleFrame",
-                                                     jvrc,
-                                                     "R_ANKLE_P_S",
-                                                     sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)}
-                                                     );
-  auto ground_f = std::make_shared<tvm::robot::Frame>("GroundFrame",
-                                                      ground,
-                                                      "ground",
-                                                      sva::PTransformd::Identity());
+  auto jvrc_lf = std::make_shared<tvm::robot::Frame>(
+      "LFullSoleFrame", jvrc, "L_ANKLE_P_S",
+      sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)});
+  auto jvrc_rf = std::make_shared<tvm::robot::Frame>(
+      "RFullSoleFrame", jvrc, "R_ANKLE_P_S",
+      sva::PTransformd{Eigen::Vector3d(0.014592470601201057, 0.010025011375546455, -0.138)});
+  auto ground_f = std::make_shared<tvm::robot::Frame>("GroundFrame", ground, "ground", sva::PTransformd::Identity());
 
-  auto jvrc_lh = std::make_shared<tvm::robot::Frame>("LeftHand",
-                                                     jvrc,
-                                                     "L_WRIST_Y_S",
-                                                     sva::PTransformd::Identity());
+  auto jvrc_lh = std::make_shared<tvm::robot::Frame>("LeftHand", jvrc, "L_WRIST_Y_S", sva::PTransformd::Identity());
 
-  auto jvrc_rh = std::make_shared<tvm::robot::Frame>("RightHand",
-                                                     jvrc,
-                                                     "R_WRIST_Y_S",
-                                                     sva::PTransformd::Identity());
+  auto jvrc_rh = std::make_shared<tvm::robot::Frame>("RightHand", jvrc, "R_WRIST_Y_S", sva::PTransformd::Identity());
 
-  auto jvrc_chest = std::make_shared<tvm::robot::Frame>("Chest",
-                                                        jvrc,
-                                                        "WAIST_R_S",
-                                                        sva::PTransformd::Identity());
+  auto jvrc_chest = std::make_shared<tvm::robot::Frame>("Chest", jvrc, "WAIST_R_S", sva::PTransformd::Identity());
 
-  auto jvrc_relbow = std::make_shared<tvm::robot::Frame>("RightElbow",
-                                                         jvrc,
-                                                         "R_ELBOW_P_S",
-                                                         sva::PTransformd::Identity());
+  auto jvrc_relbow =
+      std::make_shared<tvm::robot::Frame>("RightElbow", jvrc, "R_ELBOW_P_S", sva::PTransformd::Identity());
 
-  auto jvrc_body = std::make_shared<tvm::robot::Frame>("Body",
-                                                       jvrc,
-                                                       "PELVIS_S",
-                                                       sva::PTransformd::Identity());
+  auto jvrc_body = std::make_shared<tvm::robot::Frame>("Body", jvrc, "PELVIS_S", sva::PTransformd::Identity());
 
-  auto contact_lf_ground = std::make_shared<tvm::robot::Contact>
-    (jvrc_lf, ground_f, std::vector<sva::PTransformd>{
-        {Eigen::Vector3d(0.1093074306845665, -0.06831501424312592, 0.)},
-        {Eigen::Vector3d(0.10640743374824524, 0.06836499273777008, 0.)},
-        {Eigen::Vector3d(-0.10778241604566574, 0.06897497922182083, 0.)},
-        {Eigen::Vector3d(-0.1079324409365654, -0.069024957716465, 0.)}
-     });
-  auto contact_rf_ground = std::make_shared<tvm::robot::Contact>
-    (jvrc_rf, ground_f, std::vector<sva::PTransformd>{
-        {Eigen::Vector3d(-0.1079324409365654, 0.069024957716465, 0.)},
-        {Eigen::Vector3d(-0.10778241604566574, -0.06897497922182083, 0.)},
-        {Eigen::Vector3d(0.10640743374824524, -0.06836499273777008, 0.)},
-        {Eigen::Vector3d(0.1093074306845665, 0.06831501424312592, 0.)}
-     });
+  auto contact_lf_ground = std::make_shared<tvm::robot::Contact>(
+      jvrc_lf, ground_f,
+      std::vector<sva::PTransformd>{{Eigen::Vector3d(0.1093074306845665, -0.06831501424312592, 0.)},
+                                    {Eigen::Vector3d(0.10640743374824524, 0.06836499273777008, 0.)},
+                                    {Eigen::Vector3d(-0.10778241604566574, 0.06897497922182083, 0.)},
+                                    {Eigen::Vector3d(-0.1079324409365654, -0.069024957716465, 0.)}});
+  auto contact_rf_ground = std::make_shared<tvm::robot::Contact>(
+      jvrc_rf, ground_f,
+      std::vector<sva::PTransformd>{{Eigen::Vector3d(-0.1079324409365654, 0.069024957716465, 0.)},
+                                    {Eigen::Vector3d(-0.10778241604566574, -0.06897497922182083, 0.)},
+                                    {Eigen::Vector3d(0.10640743374824524, -0.06836499273777008, 0.)},
+                                    {Eigen::Vector3d(0.1093074306845665, 0.06831501424312592, 0.)}});
 
   auto dyn_fn = std::make_shared<tvm::robot::internal::DynamicFunction>(jvrc);
-  auto lfg_fn = std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_lf_ground, Eigen::Matrix6d::Identity());
+  auto lfg_fn =
+      std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_lf_ground, Eigen::Matrix6d::Identity());
   dyn_fn->addContact(contact_lf_ground, true, 0.7, 4);
-  auto rfg_fn = std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_rf_ground, Eigen::Matrix6d::Identity());
+  auto rfg_fn =
+      std::make_shared<tvm::robot::internal::GeometricContactFunction>(contact_rf_ground, Eigen::Matrix6d::Identity());
   dyn_fn->addContact(contact_rf_ground, true, 0.7, 4);
 
   auto com_in_fn = std::make_shared<tvm::robot::CoMInConvexFunction>(jvrc);
   auto cube = makeCube(jvrc->com(), 0.05);
-  for(auto p : cube) { com_in_fn->addPlane(p); }
+  for(auto p : cube)
+  {
+    com_in_fn->addPlane(p);
+  }
 
   auto posture_fn = std::make_shared<tvm::robot::PostureFunction>(jvrc);
-  std::string joint = "NECK_P"; std::vector<double> joint_q = {1.5};
+  std::string joint = "NECK_P";
+  std::vector<double> joint_q = {1.5};
   posture_fn->posture(joint, joint_q);
   /* This target configuration induces a collision between R_WRIST_Y_S and WAIST_R_S */
   posture_fn->posture("R_SHOULDER_P", {0.});
@@ -211,12 +186,14 @@ TEST_CASE("Test a problem with a robot")
   auto com_fn = std::make_shared<tvm::robot::CoMFunction>(jvrc);
   com_fn->com(com_fn->com() + Eigen::Vector3d(0, 0, -0.1));
   auto ori_fn = std::make_shared<tvm::robot::OrientationFunction>(jvrc_lh);
-  ori_fn->orientation(sva::RotY(-tvm::constant::pi/2));
+  ori_fn->orientation(sva::RotY(-tvm::constant::pi / 2));
   auto pos_fn = std::make_shared<tvm::robot::PositionFunction>(jvrc_lh);
   pos_fn->position(pos_fn->position() + Eigen::Vector3d{0.3, -0.1, 0.2});
 
-  std::shared_ptr<tvm::robot::JointsSelector> ori_js = tvm::robot::JointsSelector::InactiveJoints(ori_fn, jvrc, {"R_ELBOW_P"});
-  std::shared_ptr<tvm::robot::JointsSelector> pos_js = tvm::robot::JointsSelector::InactiveJoints(pos_fn, jvrc, {"R_ELBOW_P"});
+  std::shared_ptr<tvm::robot::JointsSelector> ori_js =
+      tvm::robot::JointsSelector::InactiveJoints(ori_fn, jvrc, {"R_ELBOW_P"});
+  std::shared_ptr<tvm::robot::JointsSelector> pos_js =
+      tvm::robot::JointsSelector::InactiveJoints(pos_fn, jvrc, {"R_ELBOW_P"});
 
   auto collision_fn = std::make_shared<tvm::robot::CollisionFunction>(clock);
   auto rhConvex = loadConvex(jvrc_rh);
@@ -231,17 +208,26 @@ TEST_CASE("Test a problem with a robot")
   auto tdyn = pb.add(dyn_fn == 0., tvm::task_dynamics::None(), {tvm::requirements::PriorityLevel(0)});
   dyn_fn->addPositiveLambdaToProblem(pb);
 
-  pb.add(posture_fn == 0., tvm::task_dynamics::PD(1.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(1.)});
-  pb.add(com_fn == 0., tvm::task_dynamics::PD(2.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(100.)});
-  pb.add(ori_js == 0., tvm::task_dynamics::PD(2.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
-  pb.add(pos_js == 0., tvm::task_dynamics::PD(1.), {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
+  pb.add(posture_fn == 0., tvm::task_dynamics::PD(1.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(1.)});
+  pb.add(com_fn == 0., tvm::task_dynamics::PD(2.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(100.)});
+  pb.add(ori_js == 0., tvm::task_dynamics::PD(2.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
+  pb.add(pos_js == 0., tvm::task_dynamics::PD(1.),
+         {tvm::requirements::PriorityLevel(1), tvm::requirements::Weight(10.)});
 
-  pb.add(collision_fn >= 0., tvm::task_dynamics::VelocityDamper(dt, {0.1, 0.055, 0}, tvm::constant::big_number), {tvm::requirements::PriorityLevel(0)});
-  pb.add(com_in_fn >= 0., tvm::task_dynamics::VelocityDamper(dt, {0.005, 0.001, 0}, tvm::constant::big_number), {tvm::requirements::PriorityLevel(0)});
+  pb.add(collision_fn >= 0., tvm::task_dynamics::VelocityDamper(dt, {0.1, 0.055, 0}, tvm::constant::big_number),
+         {tvm::requirements::PriorityLevel(0)});
+  pb.add(com_in_fn >= 0., tvm::task_dynamics::VelocityDamper(dt, {0.005, 0.001, 0}, tvm::constant::big_number),
+         {tvm::requirements::PriorityLevel(0)});
 
   /* Bounds */
-  pb.add(jvrc->lQBound() <= jvrc->qJoints() <= jvrc->uQBound(), tvm::task_dynamics::VelocityDamper(dt, {0.01, 0.001, 0}, tvm::constant::big_number), { tvm::requirements::PriorityLevel(0) });
-  pb.add(jvrc->lTauBound() <= jvrc->tau() <= jvrc->uTauBound(), tvm::task_dynamics::None(), { tvm::requirements::PriorityLevel(0) });
+  pb.add(jvrc->lQBound() <= jvrc->qJoints() <= jvrc->uQBound(),
+         tvm::task_dynamics::VelocityDamper(dt, {0.01, 0.001, 0}, tvm::constant::big_number),
+         {tvm::requirements::PriorityLevel(0)});
+  pb.add(jvrc->lTauBound() <= jvrc->tau() <= jvrc->uTauBound(), tvm::task_dynamics::None(),
+         {tvm::requirements::PriorityLevel(0)});
 
   tvm::LinearizedControlProblem lpb(pb);
 
@@ -261,7 +247,10 @@ TEST_CASE("Test a problem with a robot")
   {
     bool b = solver.solve(lpb);
     clock.advance();
-    if(!b) { break; }
+    if(!b)
+    {
+      break;
+    }
     rpub.publish(*jvrc);
     epub.publish(*ground);
     auto X_0_lf = jvrc->mbc().bodyPosW[jvrc->mb().bodyIndexByName("L_ANKLE_P_S")];

--- a/tests/RobotPublisher.h
+++ b/tests/RobotPublisher.h
@@ -14,6 +14,7 @@ public:
   ~RobotPublisher();
 
   void publish(const tvm::Robot & robot);
+
 private:
   std::unique_ptr<RobotPublisherImpl> impl_;
 };

--- a/tests/RobotPublisher_noros.cpp
+++ b/tests/RobotPublisher_noros.cpp
@@ -2,11 +2,11 @@
 
 #include "RobotPublisher.h"
 
-struct RobotPublisherImpl {};
+struct RobotPublisherImpl
+{
+};
 
-RobotPublisher::RobotPublisher(const std::string &):
-  impl_()
-{}
+RobotPublisher::RobotPublisher(const std::string &) : impl_() {}
 
 RobotPublisher::~RobotPublisher() {}
 

--- a/tests/RobotPublisher_noros.cpp
+++ b/tests/RobotPublisher_noros.cpp
@@ -3,8 +3,7 @@
 #include "RobotPublisher.h"
 
 struct RobotPublisherImpl
-{
-};
+{};
 
 RobotPublisher::RobotPublisher(const std::string &) : impl_() {}
 

--- a/tests/RobotPublisher_ros.cpp
+++ b/tests/RobotPublisher_ros.cpp
@@ -6,7 +6,6 @@
 #include <sensor_msgs/JointState.h>
 #include <tf2_ros/transform_broadcaster.h>
 
-
 namespace
 {
 
@@ -23,7 +22,11 @@ bool ros_init()
   return true;
 }
 
-geometry_msgs::TransformStamped PT2TF(const sva::PTransformd & X, const ros::Time & tm, const std::string & from, const std::string & to, unsigned int seq)
+geometry_msgs::TransformStamped PT2TF(const sva::PTransformd & X,
+                                      const ros::Time & tm,
+                                      const std::string & from,
+                                      const std::string & to,
+                                      unsigned int seq)
 {
   geometry_msgs::TransformStamped msg;
   msg.header.seq = seq;
@@ -46,13 +49,11 @@ geometry_msgs::TransformStamped PT2TF(const sva::PTransformd & X, const ros::Tim
   return msg;
 }
 
-}
+} // namespace
 
 struct RobotPublisherImpl
 {
-  RobotPublisherImpl(const std::string & prefix)
-  : nh(ros_init() ? new ros::NodeHandle() : 0),
-    prefix_(prefix)
+  RobotPublisherImpl(const std::string & prefix) : nh(ros_init() ? new ros::NodeHandle() : 0), prefix_(prefix)
   {
     if(nh)
     {
@@ -63,7 +64,10 @@ struct RobotPublisherImpl
 
   void publish(const tvm::Robot & robot)
   {
-    if(!nh) { return; }
+    if(!nh)
+    {
+      return;
+    }
     auto tm = ros::Time::now();
     sensor_msgs::JointState msg;
     msg.header.seq = seq_;
@@ -89,7 +93,8 @@ struct RobotPublisherImpl
     }
 
     std::vector<geometry_msgs::TransformStamped> tfs;
-    tfs.push_back(PT2TF(robot.bodyTransform(robot.mb().body(0).name())*robot.mbc().parentToSon[0], tm, std::string("robot_map"), prefix_+robot.mb().body(0).name(), seq_));
+    tfs.push_back(PT2TF(robot.bodyTransform(robot.mb().body(0).name()) * robot.mbc().parentToSon[0], tm,
+                        std::string("robot_map"), prefix_ + robot.mb().body(0).name(), seq_));
     for(int j = 1; j < robot.mb().nrJoints(); ++j)
     {
       const auto & predIndex = robot.mb().predecessor(j);
@@ -98,7 +103,8 @@ struct RobotPublisherImpl
       const auto & succName = robot.mb().body(succIndex).name();
       const auto & X_predp_pred = robot.bodyTransform(predName);
       const auto & X_succp_succ = robot.bodyTransform(succName);
-      tfs.push_back(PT2TF(X_succp_succ*robot.mbc().parentToSon[static_cast<unsigned int>(j)]*X_predp_pred.inv(), tm, prefix_ + predName, prefix_ + succName, seq_));
+      tfs.push_back(PT2TF(X_succp_succ * robot.mbc().parentToSon[static_cast<unsigned int>(j)] * X_predp_pred.inv(), tm,
+                          prefix_ + predName, prefix_ + succName, seq_));
     }
     seq_++;
     j_state_pub.publish(msg);
@@ -112,16 +118,8 @@ struct RobotPublisherImpl
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_caster;
 };
 
-RobotPublisher::RobotPublisher(const std::string & prefix)
-: impl_(new RobotPublisherImpl(prefix))
-{
-}
+RobotPublisher::RobotPublisher(const std::string & prefix) : impl_(new RobotPublisherImpl(prefix)) {}
 
-RobotPublisher::~RobotPublisher()
-{
-}
+RobotPublisher::~RobotPublisher() {}
 
-void RobotPublisher::publish(const tvm::Robot & robot)
-{
-  impl_->publish(robot);
-}
+void RobotPublisher::publish(const tvm::Robot & robot) { impl_->publish(robot); }

--- a/tests/SolverBasicTest.cpp
+++ b/tests/SolverBasicTest.cpp
@@ -8,19 +8,19 @@
 #include <tvm/LinearizedControlProblem.h>
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/Constraint.h>
-#include <tvm/function/abstract/LinearFunction.h>
 #include <tvm/function/IdentityFunction.h>
+#include <tvm/function/abstract/LinearFunction.h>
 #include <tvm/graph/CallGraph.h>
 #include <tvm/scheme/WeightedLeastSquares.h>
 #include <tvm/solver/defaultLeastSquareSolver.h>
 #ifdef TVM_USE_LSSOL
-# include <tvm/solver/LSSOLLeastSquareSolver.h>
+#  include <tvm/solver/LSSOLLeastSquareSolver.h>
 #endif
 #ifdef TVM_USE_QLD
-# include <tvm/solver/QLDLeastSquareSolver.h>
+#  include <tvm/solver/QLDLeastSquareSolver.h>
 #endif
 #ifdef TVM_USE_QUADPROG
-# include <tvm/solver/QuadprogLeastSquareSolver.h>
+#  include <tvm/solver/QuadprogLeastSquareSolver.h>
 #endif
 #include <tvm/task_dynamics/None.h>
 #include <tvm/task_dynamics/Proportional.h>
@@ -35,7 +35,7 @@ void solverTest01()
   Space s1(2);
   VariablePtr x = s1.createVariable("x");
   VariablePtr dx = dot(x);
-  x->value(Vector2d(0.5,0.5));
+  x->value(Vector2d(0.5, 0.5));
   dx->value(Vector2d::Zero());
 
   int dim = 3;
@@ -50,14 +50,16 @@ void solverTest01()
   auto idx = std::make_shared<function::IdentityFunction>(x);
   auto df = std::make_shared<Difference>(rf, idx);
 
-  VectorXd v(2); v << 0, 0;
+  VectorXd v(2);
+  v << 0, 0;
   Vector3d b = Vector3d::Constant(1.5);
 
   double dt = 1e-1;
   LinearizedControlProblem lpb;
-  auto t1 = lpb.add(sf == 0., task_dynamics::PD(2), { requirements::PriorityLevel(0) });
-  auto t2 = lpb.add(df == v, task_dynamics::PD(2), { requirements::PriorityLevel(0) });
-  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, { 1., 0.01, 0, 1 }), { requirements::PriorityLevel(0) });
+  auto t1 = lpb.add(sf == 0., task_dynamics::PD(2), {requirements::PriorityLevel(0)});
+  auto t2 = lpb.add(df == v, task_dynamics::PD(2), {requirements::PriorityLevel(0)});
+  auto t3 =
+      lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, {1., 0.01, 0, 1}), {requirements::PriorityLevel(0)});
   std::cout << t1->task.taskDynamics<task_dynamics::PD>()->kp<double>() << std::endl;
 
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverFactory{});
@@ -65,7 +67,6 @@ void solverTest01()
   std::cout << "ddx = " << dot(x, 2)->value().transpose() << std::endl;
   std::cout << "ddq = " << dot(q, 2)->value().transpose() << std::endl;
 }
-
 
 void solverTest02()
 {
@@ -79,8 +80,8 @@ void solverTest02()
   auto idq = std::make_shared<function::IdentityFunction>(q);
 
   ControlProblem pb;
-  pb.add(idx >= 0., { requirements::PriorityLevel(0) });
-  pb.add(idq >= 0., { requirements::PriorityLevel(0) });
+  pb.add(idx >= 0., {requirements::PriorityLevel(0)});
+  pb.add(idq >= 0., {requirements::PriorityLevel(0)});
 
   LinearizedControlProblem lpb(pb);
 
@@ -110,10 +111,10 @@ void minimalKin()
   Vector3d b = Vector3d::Constant(1.57);
 
   LinearizedControlProblem lpb;
-  auto t1 = lpb.add(sf == 0., task_dynamics::P(2), { PriorityLevel(0) });
-  auto t2 = lpb.add(df == v, task_dynamics::P(2), { PriorityLevel(0) });
-  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper({ 1, 0.01, 0, 0.1 }), { PriorityLevel(0) });
-  auto t4 = lpb.add(dot(q) == 0., task_dynamics::None(), { PriorityLevel(1), AnisotropicWeight(Vector3d(10,2,1)) });
+  auto t1 = lpb.add(sf == 0., task_dynamics::P(2), {PriorityLevel(0)});
+  auto t2 = lpb.add(df == v, task_dynamics::P(2), {PriorityLevel(0)});
+  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper({1, 0.01, 0, 0.1}), {PriorityLevel(0)});
+  auto t4 = lpb.add(dot(q) == 0., task_dynamics::None(), {PriorityLevel(1), AnisotropicWeight(Vector3d(10, 2, 1))});
 
 #ifdef TVM_USELSSOL
   scheme::WeightedLeastSquares solver(solver::LSSOLLSSolverOptions().verbose(true));
@@ -126,7 +127,7 @@ void minimalKin()
   scheme::WeightedLeastSquares solver4(solver::QuadprogLSSolverOptions().verbose(true));
   scheme::WeightedLeastSquares solver5(solver::QuadprogLSSolverOptions().verbose(true).cholesky(true));
 #endif
-  for (int i = 0; i < 1; ++i)
+  for(int i = 0; i < 1; ++i)
   {
 #ifdef TVM_USELSSOL
     solver.solve(lpb);
@@ -141,9 +142,9 @@ void minimalKin()
 #endif
 
     double dt = 0.01;
-    x->value(x->value() + dot(x, 1)->value()*dt);
-    q->value(q->value() + dot(q, 1)->value()*dt);
-    if (i % 10 == 0)
+    x->value(x->value() + dot(x, 1)->value() * dt);
+    q->value(q->value() + dot(q, 1)->value() * dt);
+    if(i % 10 == 0)
     {
       std::cout << "it = " << i << std::endl;
       std::cout << "x = " << x->value().transpose() << std::endl;
@@ -172,22 +173,22 @@ void minimalKinSub()
   Vector3d b = Vector3d::Constant(1.57);
 
   LinearizedControlProblem lpb;
-  auto t1 = lpb.add(sf == 0., task_dynamics::P(2), { PriorityLevel(0) });
-  auto t2 = lpb.add(df == v, task_dynamics::P(2), { PriorityLevel(0) });
-  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper({ 1, 0.01, 0, 0.1 }), { PriorityLevel(0) });
-  auto t4 = lpb.add(dot(q) == 0., { PriorityLevel(1), AnisotropicWeight(Vector3d(10,2,1)) });
+  auto t1 = lpb.add(sf == 0., task_dynamics::P(2), {PriorityLevel(0)});
+  auto t2 = lpb.add(df == v, task_dynamics::P(2), {PriorityLevel(0)});
+  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper({1, 0.01, 0, 0.1}), {PriorityLevel(0)});
+  auto t4 = lpb.add(dot(q) == 0., {PriorityLevel(1), AnisotropicWeight(Vector3d(10, 2, 1))});
 
   lpb.add(hint::Substitution(lpb.constraint(t2.get()), dot(x)));
 
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions().verbose(true));
-  for (int i = 0; i < 1; ++i)
+  for(int i = 0; i < 1; ++i)
   {
     solver.solve(lpb);
 
     double dt = 0.01;
-    x->value(x->value() + dot(x, 1)->value()*dt);
-    q->value(q->value() + dot(q, 1)->value()*dt);
-    if (i % 10 == 0)
+    x->value(x->value() + dot(x, 1)->value() * dt);
+    q->value(q->value() + dot(q, 1)->value() * dt);
+    if(i % 10 == 0)
     {
       std::cout << "it = " << i << std::endl;
       std::cout << "x = " << x->value().transpose() << std::endl;
@@ -216,25 +217,26 @@ void minimalDyn()
   auto idx = make_shared<function::IdentityFunction>(x);
   auto df = make_shared<Difference>(rf, idx);
 
-  VectorXd v(2); v << 0, 0;
+  VectorXd v(2);
+  v << 0, 0;
   Vector3d b = Vector3d::Constant(1.5);
 
   double dt = 1e-2;
   LinearizedControlProblem lpb;
-  auto t1 = lpb.add(sf == 0., task_dynamics::PD(50), { PriorityLevel(0) });
-  auto t2 = lpb.add(df == v, task_dynamics::PD(50), { PriorityLevel(0) });
-  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, { 1., 0.01, 0, 0.1 }), { PriorityLevel(0) });
-  auto t4 = lpb.add(dot(q, 2) == 0., { PriorityLevel(1), AnisotropicWeight(Vector3d(10,2,1)) });
+  auto t1 = lpb.add(sf == 0., task_dynamics::PD(50), {PriorityLevel(0)});
+  auto t2 = lpb.add(df == v, task_dynamics::PD(50), {PriorityLevel(0)});
+  auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, {1., 0.01, 0, 0.1}), {PriorityLevel(0)});
+  auto t4 = lpb.add(dot(q, 2) == 0., {PriorityLevel(1), AnisotropicWeight(Vector3d(10, 2, 1))});
 
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverFactory{});
-  for (int i = 0; i < 5000; ++i)
+  for(int i = 0; i < 5000; ++i)
   {
     solver.solve(lpb);
 
     double dt = 0.01;
-    x->value(x->value() + dx->value()*dt + 0.5 * dot(x, 2)->value()*dt*dt);
-    q->value(q->value() + dq->value()*dt + 0.5 * dot(q, 2)->value()*dt*dt);
-    if (i % 10 == 0)
+    x->value(x->value() + dx->value() * dt + 0.5 * dot(x, 2)->value() * dt * dt);
+    q->value(q->value() + dq->value() * dt + 0.5 * dot(q, 2)->value() * dt * dt);
+    if(i % 10 == 0)
     {
       std::cout << "it = " << i << std::endl;
       std::cout << "x = " << x->value().transpose() << std::endl;

--- a/tests/SolverTest.cpp
+++ b/tests/SolverTest.cpp
@@ -6,10 +6,10 @@
 #include <tvm/LinearizedControlProblem.h>
 #include <tvm/Variable.h>
 #include <tvm/constraint/abstract/Constraint.h>
-#include <tvm/hint/Substitution.h>
-#include <tvm/function/abstract/LinearFunction.h>
 #include <tvm/function/IdentityFunction.h>
+#include <tvm/function/abstract/LinearFunction.h>
 #include <tvm/graph/CallGraph.h>
+#include <tvm/hint/Substitution.h>
 #include <tvm/scheme/WeightedLeastSquares.h>
 #include <tvm/solver/defaultLeastSquareSolver.h>
 #include <tvm/task_dynamics/None.h>
@@ -23,10 +23,7 @@ using namespace Eigen;
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #include "doctest/doctest.h"
 
-TEST_CASE("Basic problem")
-{
-
-}
+TEST_CASE("Basic problem") {}
 
 TEST_CASE("Substitution")
 {
@@ -51,17 +48,19 @@ TEST_CASE("Substitution")
     auto rf = std::make_shared<Simple2dRobotEE>(q, Vector2d(2, 0), Vector3d(1, 1, 1));
     auto idx = std::make_shared<function::IdentityFunction>(x);
     auto df = std::make_shared<Difference>(rf, idx);
-    auto idq = std::make_shared<function::IdentityFunction>(dot(q,2));
+    auto idq = std::make_shared<function::IdentityFunction>(dot(q, 2));
 
-    VectorXd v(2); v << 0, 0;
+    VectorXd v(2);
+    v << 0, 0;
     Vector3d b = Vector3d::Constant(1.5);
 
     double dt = 1e-1;
     LinearizedControlProblem lpb;
-    auto t1 = lpb.add(sf == 0., task_dynamics::PD(2), { requirements::PriorityLevel(0) });
-    auto t2 = lpb.add(df == v, task_dynamics::PD(2), { requirements::PriorityLevel(0) });
-    auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, { 1., 0.01, 0, 1 }), { requirements::PriorityLevel(0) });
-    auto t4 = lpb.add(idq == 0., task_dynamics::None(), { requirements::PriorityLevel(1) });
+    auto t1 = lpb.add(sf == 0., task_dynamics::PD(2), {requirements::PriorityLevel(0)});
+    auto t2 = lpb.add(df == v, task_dynamics::PD(2), {requirements::PriorityLevel(0)});
+    auto t3 =
+        lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, {1., 0.01, 0, 1}), {requirements::PriorityLevel(0)});
+    auto t4 = lpb.add(idq == 0., task_dynamics::None(), {requirements::PriorityLevel(1)});
 
     scheme::WeightedLeastSquares solver(solver::DefaultLSSolverFactory{});
     solver.solve(lpb);
@@ -88,15 +87,17 @@ TEST_CASE("Substitution")
     auto df = std::make_shared<Difference>(rf, idx);
     auto idq = std::make_shared<function::IdentityFunction>(dot(q, 2));
 
-    VectorXd v(2); v << 0, 0;
+    VectorXd v(2);
+    v << 0, 0;
     Vector3d b = Vector3d::Constant(1.5);
 
     double dt = 1e-1;
     LinearizedControlProblem lpb;
-    auto t1 = lpb.add(sf == 0., task_dynamics::PD(2), { requirements::PriorityLevel(0) });
-    auto t2 = lpb.add(df == v, task_dynamics::PD(2), { requirements::PriorityLevel(0) });
-    auto t3 = lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, { 1., 0.01, 0, 1 }), { requirements::PriorityLevel(0) });
-    auto t4 = lpb.add(idq == 0., task_dynamics::None(), { requirements::PriorityLevel(1) });
+    auto t1 = lpb.add(sf == 0., task_dynamics::PD(2), {requirements::PriorityLevel(0)});
+    auto t2 = lpb.add(df == v, task_dynamics::PD(2), {requirements::PriorityLevel(0)});
+    auto t3 =
+        lpb.add(-b <= q <= b, task_dynamics::VelocityDamper(dt, {1., 0.01, 0, 1}), {requirements::PriorityLevel(0)});
+    auto t4 = lpb.add(idq == 0., task_dynamics::None(), {requirements::PriorityLevel(1)});
 
     lpb.add(hint::Substitution(lpb.constraint(t2.get()), dot(x, 2)));
 

--- a/tests/SolverTestFunctions.h
+++ b/tests/SolverTestFunctions.h
@@ -10,7 +10,7 @@ public:
   DISABLE_OUTPUTS(Output::JDot)
   SET_UPDATES(SphereFunction, Value, Jacobian, VelocityAndAcc)
 
-  SphereFunction(tvm::VariablePtr x, const Eigen::VectorXd& x0, double radius);
+  SphereFunction(tvm::VariablePtr x, const Eigen::VectorXd & x0, double radius);
 
   void updateValue();
   void updateJacobian();
@@ -22,15 +22,13 @@ private:
   Eigen::VectorXd x0_;
 };
 
-
-
 class Simple2dRobotEE : public tvm::graph::abstract::OutputSelector<tvm::function::abstract::Function>
 {
 public:
   DISABLE_OUTPUTS(Output::JDot)
   SET_UPDATES(Simple2dRobotEE, Value, Jacobian, VelocityAndAcc)
 
-  Simple2dRobotEE(tvm::VariablePtr x, const Eigen::Vector2d& base, const Eigen::VectorXd& lengths);
+  Simple2dRobotEE(tvm::VariablePtr x, const Eigen::Vector2d & base, const Eigen::VectorXd & lengths);
 
   void updateValue();
   void updateJacobian();
@@ -42,8 +40,7 @@ private:
   Eigen::VectorXd lengths_;
 };
 
-
-//f - g
+// f - g
 class Difference : public tvm::graph::abstract::OutputSelector<tvm::function::abstract::Function>
 {
 public:
@@ -65,17 +62,16 @@ private:
   tvm::FunctionPtr g_;
 };
 
-
 /** A brken f(x) = (x-x0)^2 - r^2
-  *
-  */
+ *
+ */
 class BrokenSphereFunction : public tvm::graph::abstract::OutputSelector<tvm::function::abstract::Function>
 {
 public:
   DISABLE_OUTPUTS(Output::JDot)
   SET_UPDATES(BrokenSphereFunction, Value, Jacobian, VelocityAndAcc)
 
-  BrokenSphereFunction(tvm::VariablePtr x, const Eigen::VectorXd& x0, double radius);
+  BrokenSphereFunction(tvm::VariablePtr x, const Eigen::VectorXd & x0, double radius);
 
   void breakJacobian(bool b);
   void breakVelocity(bool b);
@@ -92,5 +88,4 @@ private:
   bool breakJacobian_;
   bool breakVelocity_;
   bool breakNormalAcceleration_;
-
 };

--- a/tests/SolvingRequirementsTest.cpp
+++ b/tests/SolvingRequirementsTest.cpp
@@ -11,11 +11,15 @@
 using namespace tvm::requirements;
 using namespace Eigen;
 
-bool checkRequirements(const SolvingRequirements& sr,
-                       bool defaultPriority, int priority,
-                       bool defaultWeight, double weight,
-                       bool defaultAWeight, const VectorXd& aweight,
-                       bool defaultEval, ViolationEvaluationType type)
+bool checkRequirements(const SolvingRequirements & sr,
+                       bool defaultPriority,
+                       int priority,
+                       bool defaultWeight,
+                       double weight,
+                       bool defaultAWeight,
+                       const VectorXd & aweight,
+                       bool defaultEval,
+                       ViolationEvaluationType type)
 {
   bool b = (sr.priorityLevel().isDefault() == defaultPriority);
   b = b && (sr.priorityLevel().value() == priority);
@@ -42,12 +46,14 @@ TEST_CASE("Test SolvingRequirements")
   SolvingRequirements s3(Weight(3), PriorityLevel(2));
   FAST_CHECK_UNARY(checkRequirements(s3, false, 2, false, 3, true, VectorXd(), true, ViolationEvaluationType::L2));
 
-  SolvingRequirements s4(AnisotropicWeight((VectorXd(3) << 3,4,5).finished()), Weight(3), ViolationEvaluation(ViolationEvaluationType::L1), PriorityLevel(2));
-  FAST_CHECK_UNARY(checkRequirements(s4, false, 2, false, 3, false, (VectorXd(3) << 3, 4, 5).finished(), false, ViolationEvaluationType::L1));
+  SolvingRequirements s4(AnisotropicWeight((VectorXd(3) << 3, 4, 5).finished()), Weight(3),
+                         ViolationEvaluation(ViolationEvaluationType::L1), PriorityLevel(2));
+  FAST_CHECK_UNARY(checkRequirements(s4, false, 2, false, 3, false, (VectorXd(3) << 3, 4, 5).finished(), false,
+                                     ViolationEvaluationType::L1));
 
   CHECK_THROWS_AS(SolvingRequirements s(PriorityLevel(-1)), std::runtime_error);
 
   CHECK_THROWS_AS(SolvingRequirements s(Weight(-1)), std::runtime_error);
 
-  CHECK_THROWS_AS(SolvingRequirements s(AnisotropicWeight(Vector3d(-1,2,3))), std::runtime_error);
+  CHECK_THROWS_AS(SolvingRequirements s(AnisotropicWeight(Vector3d(-1, 2, 3))), std::runtime_error);
 }

--- a/tests/SubstitutionTest.cpp
+++ b/tests/SubstitutionTest.cpp
@@ -312,8 +312,8 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
 
   // Solve A [x;y] = b
   auto svdA = A.jacobiSvd(ComputeFullU | ComputeFullV);
-  auto sol0 = svdA.solve(b); // least square solution
-  auto r0 = (A * sol0 - b).norm(); // residual
+  auto sol0 = svdA.solve(b);                                      // least square solution
+  auto r0 = (A * sol0 - b).norm();                                // residual
   MatrixXd Na = svdA.matrixV().rightCols(A.cols() - svdA.rank()); // nullspace of A0
   FAST_CHECK_LE(r0, 1e-9);
 
@@ -323,7 +323,7 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   if(C.size() > 0)
   {
     auto svdC = C.jacobiSvd(ComputeFullU | ComputeFullV);
-    sol1 = svdC.solve(d); // least square solution
+    sol1 = svdC.solve(d);                                  // least square solution
     Nc = svdC.matrixV().rightCols(C.cols() - svdC.rank()); // nullspace of C
   }
   else
@@ -712,8 +712,8 @@ void randomSubstitutions()
   double nonFullRankP = 0.33;
   int nx = randI(nxmin, nxmax); // number of x variables
   int ny = randI(nymin, nymax); // number of y variables
-  double px = 0.4; // probability to have a non-zero off-diagonal block in the 'x part' of A
-  double py = 0.3; // probability to have a non-zero block in the 'y part' of B
+  double px = 0.4;              // probability to have a non-zero off-diagonal block in the 'x part' of A
+  double py = 0.3;              // probability to have a non-zero block in the 'y part' of B
 
   std::vector<VariablePtr> x;
   std::vector<VariablePtr> y;

--- a/tests/SubstitutionTest.cpp
+++ b/tests/SubstitutionTest.cpp
@@ -24,7 +24,6 @@ using namespace tvm::hint;
 using namespace tvm::hint::internal;
 using namespace Eigen;
 
-
 TEST_CASE("GenericCalculator")
 {
   VariablePtr x = Space(5).createVariable("x");
@@ -33,9 +32,10 @@ TEST_CASE("GenericCalculator")
   MatrixXd B = MatrixXd::Random(5, 3);
   VectorXd b = VectorXd::Random(5);
 
-  std::shared_ptr<constraint::BasicLinearConstraint> c(new constraint::BasicLinearConstraint({ A,B }, { x,y }, b, constraint::Type::EQUAL));
+  std::shared_ptr<constraint::BasicLinearConstraint> c(
+      new constraint::BasicLinearConstraint({A, B}, {x, y}, b, constraint::Type::EQUAL));
 
-  auto calc = GenericCalculator().impl({ std::static_pointer_cast<constraint::abstract::LinearConstraint>(c) }, { x }, 5);
+  auto calc = GenericCalculator().impl({std::static_pointer_cast<constraint::abstract::LinearConstraint>(c)}, {x}, 5);
   calc->update();
 
   MatrixXd AsA(5, 5);
@@ -50,15 +50,14 @@ TEST_CASE("GenericCalculator")
   FAST_CHECK_UNARY(AsB.isApprox(-MatrixXd(qrA.solve(B))));
 
   MatrixXd C(3, 5);
-  C << 1, 0, 0, 0, 0,
-       0, 1, 0, 0, 0,
-       0, 0, 0, 0, 0;
+  C << 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0;
   MatrixXd D = MatrixXd::Random(3, 3);
   VectorXd d = VectorXd::Random(3);
 
-  std::shared_ptr<constraint::BasicLinearConstraint> c2(new constraint::BasicLinearConstraint({ C,D }, { x,y }, d, constraint::Type::EQUAL));
+  std::shared_ptr<constraint::BasicLinearConstraint> c2(
+      new constraint::BasicLinearConstraint({C, D}, {x, y}, d, constraint::Type::EQUAL));
 
-  auto calc2 = GenericCalculator().impl({ std::static_pointer_cast<constraint::abstract::LinearConstraint>(c2) }, { x }, 2);
+  auto calc2 = GenericCalculator().impl({std::static_pointer_cast<constraint::abstract::LinearConstraint>(c2)}, {x}, 2);
   calc2->update();
   MatrixXd CsD(5, 3);
   MatrixXd StD(1, 3);
@@ -66,8 +65,8 @@ TEST_CASE("GenericCalculator")
   FAST_CHECK_UNARY(CsD.topRows(2).isApprox(-D.topRows(2)));
   FAST_CHECK_UNARY(CsD.bottomRows(3).isZero());
   FAST_CHECK_UNARY(StD.isApprox(D.row(2)));
-  FAST_CHECK_UNARY(MatrixXd(C*calc2->N()).isZero());
-  FAST_CHECK_EQ(calc2->N().colPivHouseholderQr().rank(),3);
+  FAST_CHECK_UNARY(MatrixXd(C * calc2->N()).isZero());
+  FAST_CHECK_EQ(calc2->N().colPivHouseholderQr().rank(), 3);
 }
 
 TEST_CASE("Diagonal Calculator")
@@ -80,9 +79,11 @@ TEST_CASE("Diagonal Calculator")
     MatrixXd B = MatrixXd::Random(7, 3);
     VectorXd b = VectorXd::Random(7);
 
-    std::shared_ptr<constraint::BasicLinearConstraint> c(new constraint::BasicLinearConstraint({ A,B }, { x,y }, b, constraint::Type::EQUAL));
+    std::shared_ptr<constraint::BasicLinearConstraint> c(
+        new constraint::BasicLinearConstraint({A, B}, {x, y}, b, constraint::Type::EQUAL));
 
-    auto calc = DiagonalCalculator().impl({ std::static_pointer_cast<constraint::abstract::LinearConstraint>(c) }, { x }, 7);
+    auto calc =
+        DiagonalCalculator().impl({std::static_pointer_cast<constraint::abstract::LinearConstraint>(c)}, {x}, 7);
     calc->update();
 
     MatrixXd AsA(7, 7);
@@ -101,100 +102,86 @@ TEST_CASE("Diagonal Calculator")
 
   {
     MatrixXd A(3, 7);
-    A << 0, 1, 0, 0, 0, 0, 0,
-         0, 0, 0, 1, 0, 0, 0,
-         0, 0, 0, 0, 1, 0, 0;
+    A << 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0;
     MatrixXd B = MatrixXd::Random(3, 3);
     VectorXd b = VectorXd::Random(3);
 
-    std::shared_ptr<constraint::BasicLinearConstraint> c(new constraint::BasicLinearConstraint({ A,B }, { x,y }, b, constraint::Type::EQUAL));
+    std::shared_ptr<constraint::BasicLinearConstraint> c(
+        new constraint::BasicLinearConstraint({A, B}, {x, y}, b, constraint::Type::EQUAL));
 
-    auto calc = DiagonalCalculator({1,3,4}).impl({ std::static_pointer_cast<constraint::abstract::LinearConstraint>(c) }, { x }, 3);
+    auto calc = DiagonalCalculator({1, 3, 4}).impl(
+        {std::static_pointer_cast<constraint::abstract::LinearConstraint>(c)}, {x}, 3);
     calc->update();
 
     MatrixXd AsA(7, 7);
     MatrixXd StA(0, 7);
     calc->premultiplyByASharpAndSTranspose(AsA, StA, A, false);
-    FAST_CHECK_UNARY(AsA.isApprox(A.transpose()* A));
+    FAST_CHECK_UNARY(AsA.isApprox(A.transpose() * A));
 
     MatrixXd AsB(7, 3);
     MatrixXd StB(0, 3);
     calc->premultiplyByASharpAndSTranspose(AsB, StB, B, false);
-    FAST_CHECK_UNARY(AsB.isApprox(A.transpose()*B));
+    FAST_CHECK_UNARY(AsB.isApprox(A.transpose() * B));
 
     MatrixXd N(7, 4);
-    N << 1, 0, 0, 0,
-         0, 0, 0, 0,
-         0, 1, 0, 0,
-         0, 0, 0, 0,
-         0, 0, 0, 0,
-         0, 0, 1, 0,
-         0, 0, 0 ,1;
+    N << 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1;
     FAST_CHECK_UNARY(N.isApprox(calc->N()));
   }
 
   {
     MatrixXd A(5, 7);
-    A << 0, 0, 0, 0, 0, 0, 0,
-         0, 1, 0, 0, 0, 0, 0,
-         0, 0, 0, 0, 0, 0, 0,
-         0, 0, 0, 1, 0, 0, 0,
-         0, 0, 0, 0, 1, 0, 0;
+    A << 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0;
     MatrixXd B = MatrixXd::Random(5, 3);
     VectorXd b = VectorXd::Random(5);
 
-    std::shared_ptr<constraint::BasicLinearConstraint> c(new constraint::BasicLinearConstraint({ A,B }, { x,y }, b, constraint::Type::EQUAL));
+    std::shared_ptr<constraint::BasicLinearConstraint> c(
+        new constraint::BasicLinearConstraint({A, B}, {x, y}, b, constraint::Type::EQUAL));
 
-    auto calc = DiagonalCalculator({ 1,3,4 }, { 0,2 }).impl({ std::static_pointer_cast<constraint::abstract::LinearConstraint>(c) }, { x }, 3);
+    auto calc = DiagonalCalculator({1, 3, 4}, {0, 2})
+                    .impl({std::static_pointer_cast<constraint::abstract::LinearConstraint>(c)}, {x}, 3);
     calc->update();
 
     MatrixXd AsA(7, 7);
     MatrixXd StA(2, 7);
     calc->premultiplyByASharpAndSTranspose(AsA, StA, A, false);
-    FAST_CHECK_UNARY(AsA.isApprox(A.transpose()* A));
+    FAST_CHECK_UNARY(AsA.isApprox(A.transpose() * A));
     FAST_CHECK_UNARY(StA.isZero());
 
     MatrixXd AsB(7, 3);
     MatrixXd StB(2, 3);
     calc->premultiplyByASharpAndSTranspose(AsB, StB, B, false);
-    FAST_CHECK_UNARY(AsB.isApprox(A.transpose()*B));
+    FAST_CHECK_UNARY(AsB.isApprox(A.transpose() * B));
     FAST_CHECK_UNARY(StB.row(0).isApprox(B.row(0)));
     FAST_CHECK_UNARY(StB.row(1).isApprox(B.row(2)));
 
     MatrixXd N(7, 4);
-    N << 1, 0, 0, 0,
-         0, 0, 0, 0,
-         0, 1, 0, 0,
-         0, 0, 0, 0,
-         0, 0, 0, 0,
-         0, 0, 1, 0,
-         0, 0, 0 ,1;
+    N << 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1;
     FAST_CHECK_UNARY(N.isApprox(calc->N()));
   }
-  
 }
 
-MatrixXd randM(int m, int n, int r=0)
+MatrixXd randM(int m, int n, int r = 0)
 {
-  if (r <= 0 || r==std::min(m,n))
+  if(r <= 0 || r == std::min(m, n))
     return MatrixXd::Random(m, n);
   else
-    return MatrixXd::Random(m, r)*MatrixXd::Random(r, n);
+    return MatrixXd::Random(m, r) * MatrixXd::Random(r, n);
 }
 
 /** check wether the systems given by cstr and by subs are equivalent.
-  * The system are supposed to be feasible.
-  * From cstr, we deduce a system A [x;y] = b (1)
-  * From subs, we deduce C [y;z] = d and x = E y + F z + g (2)
-  * We check that any solution of (1) is a solution of (2) by writting a
-  * solution of (1) [x;y] = pinv(A)*b + Na u with Na a base of the nullspace of
-  * A and u a vector. For size(u) different value of u, we the rewrite (2) as a
-  * system of z only, and verfy we can find a solution.
-  * To check that any solution of (2) yield a solution of (1), we first solve
-  * C [y;z] = d to get [y;z] = pinv(C)*d + Nc v. Then for size(v) value of v, we
-  * compute x from x = E y + F z + g, and check that [x;y] is a solution of (1).
-  */
-void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>>& cstr, Substitutions& subs)
+ * The system are supposed to be feasible.
+ * From cstr, we deduce a system A [x;y] = b (1)
+ * From subs, we deduce C [y;z] = d and x = E y + F z + g (2)
+ * We check that any solution of (1) is a solution of (2) by writting a
+ * solution of (1) [x;y] = pinv(A)*b + Na u with Na a base of the nullspace of
+ * A and u a vector. For size(u) different value of u, we the rewrite (2) as a
+ * system of z only, and verfy we can find a solution.
+ * To check that any solution of (2) yield a solution of (1), we first solve
+ * C [y;z] = d to get [y;z] = pinv(C)*d + Nc v. Then for size(v) value of v, we
+ * compute x from x = E y + F z + g, and check that [x;y] is a solution of (1).
+ */
+void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearConstraint>> & cstr,
+                      Substitutions & subs)
 {
   subs.updateSubstitutions();
 
@@ -202,12 +189,12 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   VariableVector y;
   VariableVector z(subs.additionalVariables());
   int m0 = 0;
-  for (auto& c : cstr)
+  for(auto & c : cstr)
   {
     m0 += c->size();
-    for (auto& vi : c->variables())
+    for(auto & vi : c->variables())
     {
-      if (!x.contains(*vi))
+      if(!x.contains(*vi))
       {
         y.add(vi);
       }
@@ -215,7 +202,7 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   }
 
   int m1 = 0;
-  for (auto& c : subs.additionalConstraints())
+  for(auto & c : subs.additionalConstraints())
   {
     m1 += c->size();
   }
@@ -224,30 +211,36 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   MatrixXd A = MatrixXd::Zero(m0, x.totalSize() + y.totalSize());
   VectorXd b(m0);
   m0 = 0;
-  for (const auto& c : cstr)
+  for(const auto & c : cstr)
   {
     auto mi = c->size();
-    for (const auto& xi : x.variables())
+    for(const auto & xi : x.variables())
     {
-      if (c->variables().contains(*xi))
+      if(c->variables().contains(*xi))
       {
         auto rx = xi->getMappingIn(x);
         A.block(m0, rx.start, mi, rx.dim) = c->jacobian(*xi);
       }
     }
-    for (const auto& yi : y.variables())
+    for(const auto & yi : y.variables())
     {
-      if (c->variables().contains(*yi))
+      if(c->variables().contains(*yi))
       {
         auto ry = yi->getMappingIn(y);
         A.block(m0, ry.start + x.totalSize(), mi, ry.dim) = c->jacobian(*yi);
       }
     }
-    switch (c->rhs())
+    switch(c->rhs())
     {
-    case constraint::RHS::ZERO: b.segment(m0, mi).setZero(); break;
-    case constraint::RHS::AS_GIVEN: b.segment(m0, mi) = c->e(); break;
-    case constraint::RHS::OPPOSITE: b.segment(m0, mi) = -c->e(); break;
+      case constraint::RHS::ZERO:
+        b.segment(m0, mi).setZero();
+        break;
+      case constraint::RHS::AS_GIVEN:
+        b.segment(m0, mi) = c->e();
+        break;
+      case constraint::RHS::OPPOSITE:
+        b.segment(m0, mi) = -c->e();
+        break;
     }
     m0 += mi;
   }
@@ -256,30 +249,36 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   MatrixXd C = MatrixXd::Zero(m1, y.totalSize() + z.totalSize());
   VectorXd d(m1);
   m1 = 0;
-  for (const auto& c : subs.additionalConstraints())
+  for(const auto & c : subs.additionalConstraints())
   {
     auto mi = c->size();
-    for (const auto& yi : y.variables())
+    for(const auto & yi : y.variables())
     {
-      if (c->variables().contains(*yi))
+      if(c->variables().contains(*yi))
       {
         auto ry = yi->getMappingIn(y);
         C.block(m1, ry.start, mi, ry.dim) = c->jacobian(*yi);
       }
     }
-    for (const auto& zi : z.variables())
+    for(const auto & zi : z.variables())
     {
-      if (c->variables().contains(*zi))
+      if(c->variables().contains(*zi))
       {
         auto rz = zi->getMappingIn(z);
         C.block(m1, rz.start + y.totalSize(), mi, rz.dim) = c->jacobian(*zi);
       }
     }
-    switch (c->rhs())
+    switch(c->rhs())
     {
-    case constraint::RHS::ZERO: d.segment(m1, mi).setZero(); break;
-    case constraint::RHS::AS_GIVEN: d.segment(m1, mi) = c->e(); break;
-    case constraint::RHS::OPPOSITE: d.segment(m1, mi) = -c->e(); break;
+      case constraint::RHS::ZERO:
+        d.segment(m1, mi).setZero();
+        break;
+      case constraint::RHS::AS_GIVEN:
+        d.segment(m1, mi) = c->e();
+        break;
+      case constraint::RHS::OPPOSITE:
+        d.segment(m1, mi) = -c->e();
+        break;
     }
     m1 += mi;
   }
@@ -288,21 +287,21 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   MatrixXd E = MatrixXd::Zero(x.totalSize(), y.totalSize());
   MatrixXd F = MatrixXd::Zero(x.totalSize(), z.totalSize());
   VectorXd g(x.totalSize());
-  for (size_t i = 0; i < x.variables().size(); ++i)
+  for(size_t i = 0; i < x.variables().size(); ++i)
   {
-    const auto& f = subs.variableSubstitutions()[i];
+    const auto & f = subs.variableSubstitutions()[i];
     auto rx = x[static_cast<int>(i)]->getMappingIn(x);
-    for (const auto& yi : y.variables())
+    for(const auto & yi : y.variables())
     {
-      if (f->variables().contains(*yi))
+      if(f->variables().contains(*yi))
       {
         auto ry = yi->getMappingIn(y);
         E.block(rx.start, ry.start, rx.dim, ry.dim) = f->jacobian(*yi);
       }
     }
-    for (const auto& zi : z.variables())
+    for(const auto & zi : z.variables())
     {
-      if (f->variables().contains(*zi))
+      if(f->variables().contains(*zi))
       {
         auto rz = zi->getMappingIn(z);
         F.block(rx.start, rz.start, rx.dim, rz.dim) = f->jacobian(*zi);
@@ -313,19 +312,19 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
 
   // Solve A [x;y] = b
   auto svdA = A.jacobiSvd(ComputeFullU | ComputeFullV);
-  auto sol0 = svdA.solve(b);         //least square solution
-  auto r0 = (A*sol0 - b).norm();     //residual
-  MatrixXd Na = svdA.matrixV().rightCols(A.cols() - svdA.rank()); //nullspace of A0
+  auto sol0 = svdA.solve(b); // least square solution
+  auto r0 = (A * sol0 - b).norm(); // residual
+  MatrixXd Na = svdA.matrixV().rightCols(A.cols() - svdA.rank()); // nullspace of A0
   FAST_CHECK_LE(r0, 1e-9);
 
-   // Solve C [y;z] = d
+  // Solve C [y;z] = d
   VectorXd sol1;
   MatrixXd Nc;
-  if (C.size()>0)
+  if(C.size() > 0)
   {
     auto svdC = C.jacobiSvd(ComputeFullU | ComputeFullV);
-    sol1 = svdC.solve(d);         //least square solution
-    Nc = svdC.matrixV().rightCols(C.cols() - svdC.rank()); //nullspace of C
+    sol1 = svdC.solve(d); // least square solution
+    Nc = svdC.matrixV().rightCols(C.cols() - svdC.rank()); // nullspace of C
   }
   else
   {
@@ -333,22 +332,22 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
     Nc = MatrixXd::Identity(C.cols(), C.cols());
   }
 
-  //now check the equivalence:
+  // now check the equivalence:
   // 1 - The solutions of Solve C [y;z] = d give solutions of A [x;y] = b
-  for (auto i = 0; i < Nc.cols(); ++i)
+  for(auto i = 0; i < Nc.cols(); ++i)
   {
-    //one solution to the additional constraints
-    VectorXd yz = sol1 + Nc*VectorXd::Random(Nc.cols());
-    //split it over y and z
+    // one solution to the additional constraints
+    VectorXd yz = sol1 + Nc * VectorXd::Random(Nc.cols());
+    // split it over y and z
     y.value(yz.head(y.totalSize()));
     z.value(yz.tail(z.totalSize()));
-    //compute the corresponding x
+    // compute the corresponding x
     subs.updateVariableValues();
-    //compute the residual for the current x and y
+    // compute the residual for the current x and y
     VectorXd xy(x.totalSize() + y.totalSize());
     xy.head(x.totalSize()) = x.value();
     xy.tail(y.totalSize()) = y.value();
-    double res = (A*xy - b).norm();
+    double res = (A * xy - b).norm();
     FAST_CHECK_LE(res, 1e-9);
   }
 
@@ -358,23 +357,23 @@ void checkEquivalence(const std::vector<std::shared_ptr<constraint::BasicLinearC
   M.topRows(C.rows()) = C.rightCols(z.totalSize());
   M.bottomRows(F.rows()) = F;
   JacobiSVD<MatrixXd> svdM;
-  if (z.totalSize() > 0)
+  if(z.totalSize() > 0)
   {
     svdM.compute(M, ComputeThinU | ComputeThinV);
   }
-  for (auto i = 0; i < Na.cols(); ++i)
+  for(auto i = 0; i < Na.cols(); ++i)
   {
-    //one solution to the original system
+    // one solution to the original system
     VectorXd xy = sol0 + Na * VectorXd::Random(Na.cols());
-    //solve C2 z = d - C1 y and F z = x - E y - g
+    // solve C2 z = d - C1 y and F z = x - E y - g
     VectorXd u(C.rows() + F.rows());
     u.head(C.rows()) = d - C.leftCols(y.totalSize()) * xy.tail(y.totalSize());
     u.tail(F.rows()) = xy.head(x.totalSize()) - E * xy.tail(y.totalSize()) - g;
     double res;
-    if (z.totalSize() > 0)
+    if(z.totalSize() > 0)
     {
       VectorXd s = svdM.solve(u);
-      res = (M*s - u).norm();
+      res = (M * s - u).norm();
     }
     else
     {
@@ -405,7 +404,7 @@ TEST_CASE("Substitution construction")
     VectorXd b = VectorXd::Random(5);
 
     auto c = std::shared_ptr<BLC>(new BLC(5, x, eq));
-    c->A(A, { tvm::internal::MatrixProperties::IDENTITY });
+    c->A(A, {tvm::internal::MatrixProperties::IDENTITY});
     Substitution s(c, x);
     FAST_CHECK_EQ(s.rank(), 5);
     FAST_CHECK_EQ(typeid(*s.calculator()).hash_code(), typeid(DiagonalCalculator::Impl).hash_code());
@@ -422,11 +421,10 @@ TEST_CASE("Substitution construction")
     CHECK_THROWS(Substitution s(c, y));
 
     auto c2 = std::shared_ptr<BLC>(new BLC(3, y, eq));
-    CHECK_THROWS(Substitution s({ c, c2 }, x));
+    CHECK_THROWS(Substitution s({c, c2}, x));
 
     auto c3 = std::shared_ptr<BLC>(new BLC(5, y, eq));
     CHECK_THROWS(Substitution s(c3, y));
-
   }
 }
 
@@ -464,12 +462,24 @@ TEST_CASE("Substitution0")
 
 TEST_CASE("Substitution1")
 {
-  int m1 = 3; int n1 = 4; int r1 = 2;
-  int m2 = 3; int n2 = 3; int r2 = 3;
-  int m3 = 3; int n3 = 6; int r3 = 3;
-  int m4 = 4; int n4 = 4; int r4 = 4;
-  int m5 = 7; int n5 = 8; int r5 = 4;
-  int m6 = 3; int n6 = 3; int r6 = 3;
+  int m1 = 3;
+  int n1 = 4;
+  int r1 = 2;
+  int m2 = 3;
+  int n2 = 3;
+  int r2 = 3;
+  int m3 = 3;
+  int n3 = 6;
+  int r3 = 3;
+  int m4 = 4;
+  int n4 = 4;
+  int r4 = 4;
+  int m5 = 7;
+  int n5 = 8;
+  int r5 = 4;
+  int m6 = 3;
+  int n6 = 3;
+  int r6 = 3;
   int l1 = 3;
   int l2 = 7;
   int l3 = 4;
@@ -526,12 +536,12 @@ TEST_CASE("Substitution1")
 
   using BLC = constraint::BasicLinearConstraint;
   auto eq = constraint::Type::EQUAL;
-  auto c1 = std::shared_ptr<BLC>(new BLC({ A11, A12, A13, A16, B11 }, { x1, x2, x3, x6, y1 }, b1, eq));
-  auto c2 = std::shared_ptr<BLC>(new BLC({ A22, A24 }, { x2, x4 }, b2, eq));
-  auto c3 = std::shared_ptr<BLC>(new BLC({ A33, A35, A36, B31 }, { x3, x5, x6, y1 }, b3, eq));
-  auto c4 = std::shared_ptr<BLC>(new BLC({ A44, A45 }, { x4, x5 }, b4, eq));
-  auto c5 = std::shared_ptr<BLC>(new BLC({ A55, B52, B54 }, { x5, y2, y4 }, b5, eq));
-  auto c6 = std::shared_ptr<BLC>(new BLC({ A66, B62, B63 }, { x6, y2, y3}, b6, eq));
+  auto c1 = std::shared_ptr<BLC>(new BLC({A11, A12, A13, A16, B11}, {x1, x2, x3, x6, y1}, b1, eq));
+  auto c2 = std::shared_ptr<BLC>(new BLC({A22, A24}, {x2, x4}, b2, eq));
+  auto c3 = std::shared_ptr<BLC>(new BLC({A33, A35, A36, B31}, {x3, x5, x6, y1}, b3, eq));
+  auto c4 = std::shared_ptr<BLC>(new BLC({A44, A45}, {x4, x5}, b4, eq));
+  auto c5 = std::shared_ptr<BLC>(new BLC({A55, B52, B54}, {x5, y2, y4}, b5, eq));
+  auto c6 = std::shared_ptr<BLC>(new BLC({A66, B62, B63}, {x6, y2, y3}, b6, eq));
 
   Substitution s1(c1, x1, r1);
   Substitution s2(c2, x2, r2);
@@ -550,20 +560,29 @@ TEST_CASE("Substitution1")
 
   subs.finalize();
 
-  checkEquivalence({ c1,c2,c3,c4,c5,c6 }, subs);
+  checkEquivalence({c1, c2, c3, c4, c5, c6}, subs);
 }
 
 TEST_CASE("Substitution2")
 {
-  int m1 = 3; int n1 = 4;
-  int m2 = 3; int n2 = 3;
-  int m3 = 3; int n3 = 6;
-  int m4 = 5; int n4 = 4;
-  int m5 = 7; int n5 = 5;
-  int m6 = 3; int n6 = 2;
-  int m7 = 6; int n7 = 7;
-  int m8 = 4; int n8 = 4;
-  int m9 = 4; int n9 = 3;
+  int m1 = 3;
+  int n1 = 4;
+  int m2 = 3;
+  int n2 = 3;
+  int m3 = 3;
+  int n3 = 6;
+  int m4 = 5;
+  int n4 = 4;
+  int m5 = 7;
+  int n5 = 5;
+  int m6 = 3;
+  int n6 = 2;
+  int m7 = 6;
+  int n7 = 7;
+  int m8 = 4;
+  int n8 = 4;
+  int m9 = 4;
+  int n9 = 3;
   int l1 = 3;
   int l2 = 7;
 
@@ -630,22 +649,22 @@ TEST_CASE("Substitution2")
 
   using BLC = constraint::BasicLinearConstraint;
   auto eq = constraint::Type::EQUAL;
-  auto c1 = std::shared_ptr<BLC>(new BLC({ A14, A17, A19, B11 }, { x4, x7, x9, y1 }, b1, eq));
-  auto c2 = std::shared_ptr<BLC>(new BLC({ A22, B21, B22 }, { x2, y1, y2 }, b2, eq));
-  auto c3 = std::shared_ptr<BLC>(new BLC({ A36, A38, B31 }, { x6, x8, y1 }, b3, eq));
-  auto c4 = std::shared_ptr<BLC>(new BLC({ A45, B41 }, { x5, y1 }, b4, eq));
-  auto c5 = std::shared_ptr<BLC>(new BLC({ A54, A57, A59 }, { x4, x7, x9 }, b5, eq));
-  auto c6 = std::shared_ptr<BLC>(new BLC({ A66, A68, B62, B61 }, { x6, x8, y2, y1 }, b6, eq));
-  auto c7 = std::shared_ptr<BLC>(new BLC({ A73, A75, B72 }, { x3, x5, y2 }, b7, eq));
-  auto c8 = std::shared_ptr<BLC>(new BLC({ A81, A87, B81 }, { x1, x7, y1 }, b8, eq));
-  auto c9 = std::shared_ptr<BLC>(new BLC({ A94, B92 }, { x4, y2 }, b9, eq));
+  auto c1 = std::shared_ptr<BLC>(new BLC({A14, A17, A19, B11}, {x4, x7, x9, y1}, b1, eq));
+  auto c2 = std::shared_ptr<BLC>(new BLC({A22, B21, B22}, {x2, y1, y2}, b2, eq));
+  auto c3 = std::shared_ptr<BLC>(new BLC({A36, A38, B31}, {x6, x8, y1}, b3, eq));
+  auto c4 = std::shared_ptr<BLC>(new BLC({A45, B41}, {x5, y1}, b4, eq));
+  auto c5 = std::shared_ptr<BLC>(new BLC({A54, A57, A59}, {x4, x7, x9}, b5, eq));
+  auto c6 = std::shared_ptr<BLC>(new BLC({A66, A68, B62, B61}, {x6, x8, y2, y1}, b6, eq));
+  auto c7 = std::shared_ptr<BLC>(new BLC({A73, A75, B72}, {x3, x5, y2}, b7, eq));
+  auto c8 = std::shared_ptr<BLC>(new BLC({A81, A87, B81}, {x1, x7, y1}, b8, eq));
+  auto c9 = std::shared_ptr<BLC>(new BLC({A94, B92}, {x4, y2}, b9, eq));
 
   Substitution s1(c1, x9);
   Substitution s2(c2, x2);
-  Substitution s3(std::vector<LinearConstraintPtr>{ c3, c6 }, std::vector<VariablePtr>{ x6, x8 });
+  Substitution s3(std::vector<LinearConstraintPtr>{c3, c6}, std::vector<VariablePtr>{x6, x8});
   Substitution s4(c4, x5);
   Substitution s5(c5, x7);
-  //no s6: c3 and c6 are merged
+  // no s6: c3 and c6 are merged
   Substitution s7(c7, x3);
   Substitution s8(c8, x1);
   Substitution s9(c9, x4);
@@ -661,180 +680,179 @@ TEST_CASE("Substitution2")
   subs.add(s9);
 
   subs.finalize();
-  checkEquivalence({ c1,c2,c3,c4,c5,c6,c7,c8,c9 }, subs);
+  checkEquivalence({c1, c2, c3, c4, c5, c6, c7, c8, c9}, subs);
+}
 
-  }
+/** Generate a random number r, min <= r < max*/
+int randI(int min, int max)
+{
+  assert(min < max);
+  return (rand() % (max - min)) + min;
+}
 
-  /** Generate a random number r, min <= r < max*/
-  int randI(int min, int max)
+/** Return true with a probability p*/
+bool randP(double p)
+{
+  assert(0 <= p && p <= 1);
+  return static_cast<double>(rand()) / RAND_MAX < p;
+}
+
+/** Create a random system A [x;y] = b*/
+void randomSubstitutions()
+{
+  using BLC = constraint::BasicLinearConstraint;
+  auto eq = constraint::Type::EQUAL;
+
+  int nxmin = 4;
+  int nxmax = 16;
+  int nymin = 0;
+  int nymax = 9;
+  int nmin = 2;
+  int nmax = 16;
+  double nonFullRankP = 0.33;
+  int nx = randI(nxmin, nxmax); // number of x variables
+  int ny = randI(nymin, nymax); // number of y variables
+  double px = 0.4; // probability to have a non-zero off-diagonal block in the 'x part' of A
+  double py = 0.3; // probability to have a non-zero block in the 'y part' of B
+
+  std::vector<VariablePtr> x;
+  std::vector<VariablePtr> y;
+  std::vector<int> m;
+  std::vector<int> n;
+  std::vector<int> r;
+  std::vector<int> l;
+  std::vector<std::shared_ptr<BLC>> cstr;
+
+  bool fullRankSystem = false;
+
+  // We restart from scratch when we do not get a system that is full rank
+  while(!fullRankSystem)
   {
-    assert(min < max);
-    return (rand() % (max - min)) + min;
-  }
-
-  /** Return true with a probability p*/
-  bool randP(double p)
-  {
-    assert(0 <= p && p <= 1);
-    return static_cast<double>(rand()) / RAND_MAX < p;
-  }
-
-  /** Create a random system A [x;y] = b*/
-  void randomSubstitutions()
-  {
-    using BLC = constraint::BasicLinearConstraint;
-    auto eq = constraint::Type::EQUAL;
-
-    int nxmin = 4;
-    int nxmax = 16;
-    int nymin = 0;
-    int nymax = 9;
-    int nmin = 2;
-    int nmax = 16;
-    double nonFullRankP = 0.33;
-    int nx = randI(nxmin, nxmax); //number of x variables
-    int ny = randI(nymin, nymax); //number of y variables
-    double px = 0.4;              //probability to have a non-zero off-diagonal block in the 'x part' of A
-    double py = 0.3;              //probability to have a non-zero block in the 'y part' of B
-
-    std::vector<VariablePtr> x;
-    std::vector<VariablePtr> y;
-    std::vector<int> m;
-    std::vector<int> n;
-    std::vector<int> r;
-    std::vector<int> l;
-    std::vector<std::shared_ptr<BLC>> cstr;
-
-    bool fullRankSystem = false;
-
-    // We restart from scratch when we do not get a system that is full rank
-    while (!fullRankSystem)
+    int ma = 0;
+    int na = 0;
+    x.clear();
+    y.clear();
+    m.clear();
+    n.clear();
+    r.clear();
+    l.clear();
+    cstr.clear();
+    for(int i = 0; i < nx; ++i)
     {
-      int ma = 0;
-      int na = 0;
-      x.clear();
-      y.clear();
-      m.clear();
-      n.clear();
-      r.clear();
-      l.clear();
-      cstr.clear();
-      for (int i = 0; i < nx; ++i)
+      std::stringstream ss;
+      ss << "x" << i;
+      int ni = randI(nmin, nmax);
+      int mi = 1 + randI(1, ni);
+      n.push_back(ni);
+      m.push_back(mi);
+      x.push_back(Space(ni).createVariable(ss.str()));
+      if(randP(nonFullRankP))
       {
-        std::stringstream ss;
-        ss << "x" << i;
-        int ni = randI(nmin, nmax);
-        int mi = 1 + randI(1, ni);
-        n.push_back(ni);
-        m.push_back(mi);
-        x.push_back(Space(ni).createVariable(ss.str()));
-        if (randP(nonFullRankP))
+        r.push_back(randI(mi / 2, mi + 1));
+      }
+      else
+      {
+        r.push_back(mi);
+      }
+      ma += mi;
+      na += ni;
+    }
+    for(int i = 0; i < ny; ++i)
+    {
+      std::stringstream ss;
+      ss << "y" << i;
+      int ni = randI(nmin, nmax);
+      l.push_back(ni);
+      y.push_back(Space(ni).createVariable(ss.str()));
+      na += l.back();
+    }
+
+    for(size_t i = 0; i < static_cast<size_t>(nx); ++i)
+    {
+      std::vector<VariablePtr> v;
+      std::vector<MatrixXd> M;
+      std::vector<MatrixConstRef> Mr;
+      for(size_t j = 0; j < static_cast<size_t>(nx); ++j)
+      {
+        if(i == j)
         {
-          r.push_back(randI(mi / 2, mi + 1));
+          M.push_back(randM(m[i], n[j], r[i]));
+          v.push_back(x[j]);
         }
         else
         {
-          r.push_back(mi);
-        }
-        ma += mi;
-        na += ni;
-      }
-      for (int i = 0; i < ny; ++i)
-      {
-        std::stringstream ss;
-        ss << "y" << i;
-        int ni = randI(nmin, nmax);
-        l.push_back(ni);
-        y.push_back(Space(ni).createVariable(ss.str()));
-        na += l.back();
-      }
-
-      for (size_t i = 0; i < static_cast<size_t>(nx); ++i)
-      {
-        std::vector<VariablePtr> v;
-        std::vector<MatrixXd> M;
-        std::vector<MatrixConstRef> Mr;
-        for (size_t j = 0; j < static_cast<size_t>(nx); ++j)
-        {
-          if (i == j)
+          if(randP(px))
           {
-            M.push_back(randM(m[i], n[j], r[i]));
+            M.push_back(randM(m[i], n[j]));
             v.push_back(x[j]);
           }
-          else
-          {
-            if (randP(px))
-            {
-              M.push_back(randM(m[i], n[j]));
-              v.push_back(x[j]);
-            }
-          }
         }
-        for (size_t j = 0; j < static_cast<size_t>(ny); ++j)
-        {
-          if (randP(py))
-          {
-            M.push_back(randM(m[i], l[j]));
-            v.push_back(y[j]);
-          }
-        }
-        for (const auto& Mi : M)
-        {
-          Mr.push_back(Mi);
-        }
-        VectorXd b = VectorXd::Random(m[i]);
-        auto c = std::shared_ptr<BLC>(new BLC(Mr, v, b, eq));
-        cstr.push_back(c);
       }
-      //check if the system is feasible
-      MatrixXd A = MatrixXd::Zero(ma, na);
-      int ms = 0;
-      for (const auto& c : cstr)
+      for(size_t j = 0; j < static_cast<size_t>(ny); ++j)
       {
-        int ns = 0;
-        int mi = c->size();
-        for (const auto& xi : x)
+        if(randP(py))
         {
-          int ni = xi->size();
-          if (c->variables().contains(*xi))
-          {
-            A.block(ms, ns, mi, ni) = c->jacobian(*xi);
-          }
-          ns += ni;
+          M.push_back(randM(m[i], l[j]));
+          v.push_back(y[j]);
         }
-        for (const auto& yi : y)
-        {
-          int ni = yi->size();
-          if (c->variables().contains(*yi))
-          {
-            A.block(ms, ns, mi, ni) = c->jacobian(*yi);
-          }
-          ns += ni;
-        }
-        ms += mi;
       }
-      auto svd = A.jacobiSvd();
-      fullRankSystem = svd.rank() == A.rows();
+      for(const auto & Mi : M)
+      {
+        Mr.push_back(Mi);
+      }
+      VectorXd b = VectorXd::Random(m[i]);
+      auto c = std::shared_ptr<BLC>(new BLC(Mr, v, b, eq));
+      cstr.push_back(c);
     }
-
-    Substitutions subs;
-    for (size_t i = 0; i < cstr.size(); ++i)
+    // check if the system is feasible
+    MatrixXd A = MatrixXd::Zero(ma, na);
+    int ms = 0;
+    for(const auto & c : cstr)
     {
-      Substitution s(cstr[i], x[i], r[i]);
-      subs.add(s);
+      int ns = 0;
+      int mi = c->size();
+      for(const auto & xi : x)
+      {
+        int ni = xi->size();
+        if(c->variables().contains(*xi))
+        {
+          A.block(ms, ns, mi, ni) = c->jacobian(*xi);
+        }
+        ns += ni;
+      }
+      for(const auto & yi : y)
+      {
+        int ni = yi->size();
+        if(c->variables().contains(*yi))
+        {
+          A.block(ms, ns, mi, ni) = c->jacobian(*yi);
+        }
+        ns += ni;
+      }
+      ms += mi;
     }
-    subs.finalize();
-    checkEquivalence(cstr, subs);
+    auto svd = A.jacobiSvd();
+    fullRankSystem = svd.rank() == A.rows();
   }
 
-  TEST_CASE("Random substitutions")
+  Substitutions subs;
+  for(size_t i = 0; i < cstr.size(); ++i)
   {
-    //In some very rare instance, this test can fail because of rank issues
-    //during the qr decomposition of GenericCalculator. This is because of the
-    //heuristic taken to get the rank of a group of constraints. This is not to
-    //be regarded as an issue.
-    for (int i = 0; i < 10; ++i)
-    {
-      randomSubstitutions();
-    }
+    Substitution s(cstr[i], x[i], r[i]);
+    subs.add(s);
   }
+  subs.finalize();
+  checkEquivalence(cstr, subs);
+}
+
+TEST_CASE("Random substitutions")
+{
+  // In some very rare instance, this test can fail because of rank issues
+  // during the qr decomposition of GenericCalculator. This is because of the
+  // heuristic taken to get the rank of a group of constraints. This is not to
+  // be regarded as an issue.
+  for(int i = 0; i < 10; ++i)
+  {
+    randomSubstitutions();
+  }
+}

--- a/tests/TestData.cpp
+++ b/tests/TestData.cpp
@@ -45,10 +45,7 @@ struct AnotherOutput : public tvm::graph::abstract::Outputs
 
 struct TestInputs : public tvm::graph::internal::Inputs
 {
-  TestInputs(std::shared_ptr<Derived> s)
-  {
-    addInput(s, Derived::Output::O0, Derived::Output::O1);
-  }
+  TestInputs(std::shared_ptr<Derived> s) { addInput(s, Derived::Output::O0, Derived::Output::O1); }
 };
 
 struct Robot : public tvm::graph::abstract::Node<Robot>
@@ -58,8 +55,10 @@ struct Robot : public tvm::graph::abstract::Node<Robot>
 
   Robot()
   {
+    // clang-format off
     registerUpdates(Update::Kinematics, &Robot::updateKinematics,
                     Update::Velocity, &Robot::updateVelocity);
+    // clang-format on
 
     addOutputDependency(Output::K1, Update::Kinematics);
     addOutputDependency(Output::K2, Update::Kinematics);
@@ -70,15 +69,9 @@ struct Robot : public tvm::graph::abstract::Node<Robot>
     addInternalDependency(Update::Velocity, Update::Kinematics);
   }
 
-  virtual void updateKinematics()
-  {
-    k = k.transpose();
-  }
+  virtual void updateKinematics() { k = k.transpose(); }
 
-  virtual void updateVelocity()
-  {
-    v = v*v;
-  }
+  virtual void updateVelocity() { v = v * v; }
 
   Eigen::Matrix3d k = Eigen::Matrix3d::Random();
   Eigen::Matrix3d v = Eigen::Matrix3d::Random();
@@ -99,15 +92,9 @@ struct Robot2 : public Robot
     addInternalDependency<Robot2>(Update::Dynamics, Robot::Update::Velocity);
   }
 
-  void updateKinematics() override
-  {
-    k = k*k;
-  }
+  void updateKinematics() override { k = k * k; }
 
-  virtual void updateDynamics()
-  {
-    d = d*d;
-  }
+  virtual void updateDynamics() { d = d * d; }
 
   Eigen::Matrix3d d = Eigen::Matrix3d::Random();
 };
@@ -124,7 +111,9 @@ void compile_check()
   static_assert(Derived4::OutputSize == 9, "");
   static_assert(tvm::graph::abstract::is_valid_output<Derived3>(Derived::Output::O2), "");
   static_assert(!tvm::graph::abstract::is_valid_output<Derived3>(AnotherOutput::Output::O1), "");
-  static_assert(tvm::graph::abstract::is_valid_output<Derived4>(Derived4::Output::O8, Derived2::Output::O3, Derived::Output::O0), "");
+  static_assert(
+      tvm::graph::abstract::is_valid_output<Derived4>(Derived4::Output::O8, Derived2::Output::O3, Derived::Output::O0),
+      "");
   static_assert(!Derived5::OutputStaticallyEnabled(Derived4::Output::O4), "");
   static_assert(Derived5::OutputStaticallyEnabled(Derived4::Output::O7), "");
   static_assert(!Derived5::OutputStaticallyEnabled(Derived::Output::O0), "");
@@ -145,8 +134,7 @@ static void BM_ManualGraph(benchmark::State & state)
 {
   auto r2 = std::make_shared<Robot2>();
 
-  auto update = [&]()
-  {
+  auto update = [&]() {
     r2->update(static_cast<int>(Robot::Update::Kinematics));
     r2->update(static_cast<int>(Robot::Update::Velocity));
     r2->update(static_cast<int>(Robot2::Update::Dynamics));

--- a/tests/TestData.cpp
+++ b/tests/TestData.cpp
@@ -20,8 +20,7 @@ struct Derived2 : public Derived
 };
 
 struct Derived3 : public Derived2
-{
-};
+{};
 
 struct Derived4 : public Derived3
 {
@@ -100,8 +99,7 @@ struct Robot2 : public Robot
 };
 
 struct RobotFunction : public tvm::graph::abstract::Node<RobotFunction>
-{
-};
+{};
 
 void compile_check()
 {

--- a/tests/TestDisabled.cpp
+++ b/tests/TestDisabled.cpp
@@ -5,8 +5,7 @@
 #include <iostream>
 
 struct FailedTest
-{
-};
+{};
 
 struct RegisterDisabledUpdate : public tvm::graph::abstract::Node<RegisterDisabledUpdate>
 {

--- a/tests/TestDisabled.cpp
+++ b/tests/TestDisabled.cpp
@@ -4,17 +4,16 @@
 
 #include <iostream>
 
-struct FailedTest {};
+struct FailedTest
+{
+};
 
 struct RegisterDisabledUpdate : public tvm::graph::abstract::Node<RegisterDisabledUpdate>
 {
   SET_UPDATES(RegisterDisabledUpdate, U0, U1)
   DISABLE_UPDATES(Update::U0)
 
-  RegisterDisabledUpdate()
-  {
-    registerUpdates(Update::U0, &RegisterDisabledUpdate::updateU0);
-  }
+  RegisterDisabledUpdate() { registerUpdates(Update::U0, &RegisterDisabledUpdate::updateU0); }
 
   void updateU0() {}
 };
@@ -25,10 +24,7 @@ struct DisabledOutputDependency : public tvm::graph::abstract::Node<DisabledOutp
   DISABLE_OUTPUTS(Output::O0)
   SET_UPDATES(DisabledOutputDependency, U0)
 
-  DisabledOutputDependency()
-  {
-    addOutputDependency({Output::O0, Output::O1}, Update::U0);
-  }
+  DisabledOutputDependency() { addOutputDependency({Output::O0, Output::O1}, Update::U0); }
 };
 
 struct DisabledInternalDependency : public tvm::graph::abstract::Node<DisabledInternalDependency>
@@ -36,10 +32,7 @@ struct DisabledInternalDependency : public tvm::graph::abstract::Node<DisabledIn
   SET_UPDATES(DisabledInternalDependency, U0, U1)
   DISABLE_UPDATES(Update::U0)
 
-  DisabledInternalDependency()
-  {
-    addInternalDependency(Update::U0, Update::U1);
-  }
+  DisabledInternalDependency() { addInternalDependency(Update::U0, Update::U1); }
 };
 
 struct DisabledOutput : public tvm::graph::abstract::Node<DisabledOutput>
@@ -67,8 +60,16 @@ struct DisabledOutputInputDependency : public tvm::graph::abstract::Node<Disable
   }
 };
 
-#define TEST(T, ...) \
-  try { T obj{__VA_ARGS__}; throw FailedTest(); } catch(std::runtime_error & exc) { std::cout << #T" threw runtime_error: " << exc.what() << std::endl; }
+#define TEST(T, ...)                                                     \
+  try                                                                    \
+  {                                                                      \
+    T obj{__VA_ARGS__};                                                  \
+    throw FailedTest();                                                  \
+  }                                                                      \
+  catch(std::runtime_error & exc)                                        \
+  {                                                                      \
+    std::cout << #T " threw runtime_error: " << exc.what() << std::endl; \
+  }
 
 int main()
 {

--- a/tests/UtilsTest.cpp
+++ b/tests/UtilsTest.cpp
@@ -7,10 +7,10 @@
 #include <tvm/function/IdentityFunction.h>
 #include <tvm/task_dynamics/Proportional.h>
 #include <tvm/task_dynamics/ProportionalDerivative.h>
-#include <tvm/utils/checkFunction.h>
-#include <tvm/utils/graph.h>
 #include <tvm/utils/ProtoTask.h>
 #include <tvm/utils/UpdatelessFunction.h>
+#include <tvm/utils/checkFunction.h>
+#include <tvm/utils/graph.h>
 
 #include <iostream>
 
@@ -22,9 +22,8 @@ using namespace Eigen;
 using namespace tvm;
 using namespace tvm::utils;
 
-
 template<typename T>
-void checkSimpleBoundOnFunction(const T& bound)
+void checkSimpleBoundOnFunction(const T & bound)
 {
   Space s1(2);
   VariablePtr x = s1.createVariable("x");
@@ -86,9 +85,8 @@ void checkSimpleBoundOnFunction(const T& bound)
   }
 }
 
-
 template<typename L, typename U>
-void checkDoubleBoundsOnFunction(const L& l, const U& u)
+void checkDoubleBoundsOnFunction(const L & l, const U & u)
 {
   Space s1(2);
   VariablePtr x = s1.createVariable("x");
@@ -115,7 +113,7 @@ void checkDoubleBoundsOnFunction(const L& l, const U& u)
 }
 
 template<typename T>
-void checkSimpleBoundOnVariable(const T& bound)
+void checkSimpleBoundOnVariable(const T & bound)
 {
   Space s1(2);
   VariablePtr x = s1.createVariable("x");
@@ -176,9 +174,8 @@ void checkSimpleBoundOnVariable(const T& bound)
   }
 }
 
-
 template<typename L, typename U>
-void checkDoubleBoundsOnVariable(const L& l, const U& u)
+void checkDoubleBoundsOnVariable(const L & l, const U & u)
 {
   Space s1(2);
   VariablePtr x = s1.createVariable("x");
@@ -228,22 +225,21 @@ TEST_CASE("Test Proto task")
   // expression
   Matrix2d A = Matrix2d::Identity();
   checkSimpleBoundOnFunction(-l);
-  checkSimpleBoundOnFunction(A*l - u);
+  checkSimpleBoundOnFunction(A * l - u);
   checkSimpleBoundOnVariable(-l);
-  checkSimpleBoundOnVariable(A*l - u);
+  checkSimpleBoundOnVariable(A * l - u);
 }
 
 TEST_CASE("Test UpdatelessFunction")
 {
-  //value
+  // value
   VariablePtr x = Space(2).createVariable("x");
   VariablePtr y = Space(4).createVariable("y");
   VariablePtr z = Space(3).createVariable("z");
   MatrixXd Ax = MatrixXd::Random(3, 2);
   MatrixXd Ay = MatrixXd::Random(3, 4);
   MatrixXd Az = MatrixXd::Random(3, 3);
-  auto f = std::shared_ptr<function::BasicLinearFunction>( 
-    new function::BasicLinearFunction( { Ax, Ay, Az }, {x, y, z} ));
+  auto f = std::shared_ptr<function::BasicLinearFunction>(new function::BasicLinearFunction({Ax, Ay, Az}, {x, y, z}));
 
   UpdatelessFunction uf(f);
 
@@ -257,21 +253,24 @@ TEST_CASE("Test UpdatelessFunction")
   FAST_CHECK_UNARY(y->value().isApprox(yr));
   FAST_CHECK_UNARY(z->value().isApprox(zr));
 
-  VectorXd xm(2); xm << 1, 2;
-  VectorXd ym(4); ym << 3, 4, 5, 6;
-  VectorXd zm(3); zm << 7, 8, 9;
+  VectorXd xm(2);
+  xm << 1, 2;
+  VectorXd ym(4);
+  ym << 3, 4, 5, 6;
+  VectorXd zm(3);
+  zm << 7, 8, 9;
 
   using l = std::initializer_list<double>;
-  v = uf.value(l{ 1,2 }, l{ 3,4,5,6 }, l{ 7., 8., 9. });
+  v = uf.value(l{1, 2}, l{3, 4, 5, 6}, l{7., 8., 9.});
   FAST_CHECK_UNARY(v.isApprox(Ax * xm + Ay * ym + Az * zm));
 
-  v = uf.value(l{ 1,2 }, yr, l{ 7., 8., 9. });
+  v = uf.value(l{1, 2}, yr, l{7., 8., 9.});
   FAST_CHECK_UNARY(v.isApprox(Ax * xm + Ay * yr + Az * zm));
 
   v = uf.value(*x, xr);
   FAST_CHECK_UNARY(v.isApprox(Ax * xr + Ay * yr + Az * zm));
 
-  v = uf.value(*z, l{ 1,2,3 }, *y, l{ 3,4,5,6 }, *z, l{ 7,8,9 }, *x, xr);
+  v = uf.value(*z, l{1, 2, 3}, *y, l{3, 4, 5, 6}, *z, l{7, 8, 9}, *x, xr);
   FAST_CHECK_UNARY(v.isApprox(Ax * xr + Ay * ym + Az * zm));
 
   VectorXd concatr(9);
@@ -279,25 +278,24 @@ TEST_CASE("Test UpdatelessFunction")
   v = uf.value(concatr);
   FAST_CHECK_UNARY(v.isApprox(Ax * xr + Ay * yr + Az * zr));
 
-  v = uf.value(l{ 1,2,3,4,5,6,7,8,9 });
+  v = uf.value(l{1, 2, 3, 4, 5, 6, 7, 8, 9});
   FAST_CHECK_UNARY(v.isApprox(Ax * xm + Ay * ym + Az * zm));
 
-  //errors
+  // errors
   // not enough args
   CHECK_THROWS(uf.value(xr, yr));
-  CHECK_THROWS(uf.value(l{ 1,2 }, l{3,4,5,6}));
-  //uf.value(*x); //does not compile (and that's normal)
+  CHECK_THROWS(uf.value(l{1, 2}, l{3, 4, 5, 6}));
+  // uf.value(*x); //does not compile (and that's normal)
   // too many args
   CHECK_THROWS(uf.value(xr, yr, zr, xm, ym, zm));
-  CHECK_THROWS(uf.value(l{ 1,2 }, l{ 3,4,5,6 }, zr, l{ 7,8,9 }));
-  //uf.value(*x, xr, yr); //does not compile (and that's normal)
+  CHECK_THROWS(uf.value(l{1, 2}, l{3, 4, 5, 6}, zr, l{7, 8, 9}));
+  // uf.value(*x, xr, yr); //does not compile (and that's normal)
   // wrong size
   CHECK_THROWS(uf.value(xr, zr, yr));
-  CHECK_THROWS(uf.value(l{ 1,2,3 }, l{ 3,4,5,6 }, l{ 7., 8., 9. }));
+  CHECK_THROWS(uf.value(l{1, 2, 3}, l{3, 4, 5, 6}, l{7., 8., 9.}));
   CHECK_THROWS(uf.value(*x, zr));
 
-
-  //jacobian
+  // jacobian
   auto s1 = std::make_shared<SphereFunction>(x, Vector2d(0, 0), 1);
   auto s2 = std::make_shared<SphereFunction>(z, Vector3d(0, 0, 1), 1);
   auto df = std::make_shared<Difference>(s1, s2);
@@ -307,38 +305,41 @@ TEST_CASE("Test UpdatelessFunction")
   FAST_CHECK_UNARY(J.isApprox(2 * xr.transpose()));
   J = udf.jacobian(*z, xr, zr);
   FAST_CHECK_UNARY(J.isApprox(-2 * (zr - Vector3d(0, 0, 1)).transpose()));
-  J = udf.jacobian(*x, l{ 1,2 }, l{ 7,8,9 });
+  J = udf.jacobian(*x, l{1, 2}, l{7, 8, 9});
   FAST_CHECK_UNARY(J.isApprox(2 * xm.transpose()));
-  J = udf.jacobian(*x, *x, l{ 1,2 });
+  J = udf.jacobian(*x, *x, l{1, 2});
   FAST_CHECK_UNARY(J.isApprox(2 * xm.transpose()));
-  J = udf.jacobian(*x, l{ 1,2,7,8,9 });
+  J = udf.jacobian(*x, l{1, 2, 7, 8, 9});
   FAST_CHECK_UNARY(J.isApprox(2 * xm.transpose()));
 
-  //velocity
+  // velocity
   VectorXd dxr = VectorXd::Random(2);
   VectorXd dyr = VectorXd::Random(4);
   VectorXd dzr = VectorXd::Random(3);
-  
+
   VectorXd dv = uf.velocity(xr, dxr, yr, dyr, zr, dzr);
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxr + Ay * dyr + Az * dzr));
   FAST_CHECK_UNARY(dot(x)->value().isApprox(dxr));
   FAST_CHECK_UNARY(dot(y)->value().isApprox(dyr));
   FAST_CHECK_UNARY(dot(z)->value().isApprox(dzr));
 
-  VectorXd dxm(2); dxm << -1, -2;
-  VectorXd dym(4); dym << -3, -4, -5, -6;
-  VectorXd dzm(3); dzm << -7, -8, -9;
+  VectorXd dxm(2);
+  dxm << -1, -2;
+  VectorXd dym(4);
+  dym << -3, -4, -5, -6;
+  VectorXd dzm(3);
+  dzm << -7, -8, -9;
 
-  dv = uf.velocity(l{ 1,2 }, l{ -1,-2 }, l{ 3,4,5,6 }, l{ -3,-4,-5,-6 }, l{ 7,8,9 }, l{ -7, -8, -9 });
+  dv = uf.velocity(l{1, 2}, l{-1, -2}, l{3, 4, 5, 6}, l{-3, -4, -5, -6}, l{7, 8, 9}, l{-7, -8, -9});
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxm + Ay * dym + Az * dzm));
 
-  dv = uf.velocity(xr, l{ -1,-2 }, l{ 3,4,5,6 }, dyr, zr, l{ -7,-8,-9 });
+  dv = uf.velocity(xr, l{-1, -2}, l{3, 4, 5, 6}, dyr, zr, l{-7, -8, -9});
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxm + Ay * dyr + Az * dzm));
 
   dv = uf.velocity(*x, xr, dxr);
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxr + Ay * dyr + Az * dzm));
 
-  dv = uf.velocity(*z, l{1,2,3}, l{ -1,-2,-3 }, *y, yr, l{ -3,-4,-5,-6 }, *z, zr, l{ -7,-8,-9 }, *x, xr, dxr);
+  dv = uf.velocity(*z, l{1, 2, 3}, l{-1, -2, -3}, *y, yr, l{-3, -4, -5, -6}, *z, zr, l{-7, -8, -9}, *x, xr, dxr);
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxr + Ay * dym + Az * dzm));
 
   VectorXd concatdr(9);
@@ -346,43 +347,44 @@ TEST_CASE("Test UpdatelessFunction")
   dv = uf.velocity(concatr, concatdr);
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxr + Ay * dyr + Az * dzr));
 
-  dv = uf.velocity(l{ 1,2,3,4,5,6,7,8,9 }, concatdr);
+  dv = uf.velocity(l{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatdr);
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxr + Ay * dyr + Az * dzr));
 
-  dv = uf.velocity(concatr, l{ -1,-2,-3,-4,-5,-6,-7,-8,-9 });
+  dv = uf.velocity(concatr, l{-1, -2, -3, -4, -5, -6, -7, -8, -9});
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxm + Ay * dym + Az * dzm));
 
-  dv = uf.velocity(l{ 1,2,3,4,5,6,7,8,9 }, l{ -1,-2,-3,-4,-5,-6,-7,-8,-9 });
+  dv = uf.velocity(l{1, 2, 3, 4, 5, 6, 7, 8, 9}, l{-1, -2, -3, -4, -5, -6, -7, -8, -9});
   FAST_CHECK_UNARY(dv.isApprox(Ax * dxm + Ay * dym + Az * dzm));
 
-  //errors
+  // errors
   // not enough args
   CHECK_THROWS(uf.velocity(xr, dxr, yr, dyr));
-  //uf.velocity(xr, dxr, yr, dyr, zr); //does not compile (and that's normal)
-  CHECK_THROWS(uf.velocity(l{ 1,2 }, l{-1,-2}, l{ 3,4,5,6 }, l{ -3,-4,-5,-6 }));
-  //uf.value(*x); //does not compile (and that's normal)
+  // uf.velocity(xr, dxr, yr, dyr, zr); //does not compile (and that's normal)
+  CHECK_THROWS(uf.velocity(l{1, 2}, l{-1, -2}, l{3, 4, 5, 6}, l{-3, -4, -5, -6}));
+  // uf.value(*x); //does not compile (and that's normal)
   // too many args
   CHECK_THROWS(uf.velocity(xr, dxr, yr, dyr, zr, dzr, xm, dxm, ym, dym, zm, dzm));
-  CHECK_THROWS(uf.velocity(l{ 1,2 }, dxr, l{ 3,4,5,6 }, l{ -3,-4,-5,-6 }, zr, l{ -7,-8,-9 }, l{ 1,2 }, l{ -1,-2 }, l{ 3,4,5,6 }, l{ -3,-4,-5,-6 }));
-  //uf.value(*x, xr, yr); //does not compile (and that's normal)
+  CHECK_THROWS(uf.velocity(l{1, 2}, dxr, l{3, 4, 5, 6}, l{-3, -4, -5, -6}, zr, l{-7, -8, -9}, l{1, 2}, l{-1, -2},
+                           l{3, 4, 5, 6}, l{-3, -4, -5, -6}));
+  // uf.value(*x, xr, yr); //does not compile (and that's normal)
   // wrong size
   CHECK_THROWS(uf.velocity(xr, dxr, yr, dxr, zr, dzr));
-  CHECK_THROWS(uf.velocity(l{ 1,2,3 }, dxr, l{ 3,4,5,6 }, dyr, l{ 7., 8., 9. }, dzr));
+  CHECK_THROWS(uf.velocity(l{1, 2, 3}, dxr, l{3, 4, 5, 6}, dyr, l{7., 8., 9.}, dzr));
   CHECK_THROWS(uf.velocity(*x, xr, dzr));
 
   // normal acceleration
   VectorXd na = udf.normalAcceleration(xr, dxr, zr, dzr);
-  FAST_CHECK_UNARY(na.isApprox(2*(dxr.transpose()*dxr - dzr.transpose()*dzr)));
-  na = udf.normalAcceleration(l{ 1,2 }, l{ -1,-2 }, l{ 7,8,9 }, l{ -7,-8,-9 });
-  FAST_CHECK_UNARY(na.isApprox(2 * (dxm.transpose()*dxm - dzm.transpose()*dzm)));
-  na = udf.normalAcceleration(l{ 1,2 }, dxr, zr, l{ -7,-8,-9 });
-  FAST_CHECK_UNARY(na.isApprox(2 * (dxr.transpose()*dxr - dzm.transpose()*dzm)));
-  na = udf.normalAcceleration(*z, l{ 7,8,9 }, dzr, *x, l{ 1,2 }, l{ -1,-2 });
-  FAST_CHECK_UNARY(na.isApprox(2 * (dxm.transpose()*dxm - dzr.transpose()*dzr)));
-  na = udf.normalAcceleration(l{ 1,2,7,8,9 }, l{ -1,-2,-7,-8,-9 });
-  FAST_CHECK_UNARY(na.isApprox(2 * (dxm .transpose()*dxm - dzm.transpose()*dzm)));
+  FAST_CHECK_UNARY(na.isApprox(2 * (dxr.transpose() * dxr - dzr.transpose() * dzr)));
+  na = udf.normalAcceleration(l{1, 2}, l{-1, -2}, l{7, 8, 9}, l{-7, -8, -9});
+  FAST_CHECK_UNARY(na.isApprox(2 * (dxm.transpose() * dxm - dzm.transpose() * dzm)));
+  na = udf.normalAcceleration(l{1, 2}, dxr, zr, l{-7, -8, -9});
+  FAST_CHECK_UNARY(na.isApprox(2 * (dxr.transpose() * dxr - dzm.transpose() * dzm)));
+  na = udf.normalAcceleration(*z, l{7, 8, 9}, dzr, *x, l{1, 2}, l{-1, -2});
+  FAST_CHECK_UNARY(na.isApprox(2 * (dxm.transpose() * dxm - dzr.transpose() * dzr)));
+  na = udf.normalAcceleration(l{1, 2, 7, 8, 9}, l{-1, -2, -7, -8, -9});
+  FAST_CHECK_UNARY(na.isApprox(2 * (dxm.transpose() * dxm - dzm.transpose() * dzm)));
 
-  CHECK_THROWS(udf.normalAcceleration(*z, l{ 7,8.9 }, dzr, *x, l{ 1,2 }, l{ -1,-2 }));
+  CHECK_THROWS(udf.normalAcceleration(*z, l{7, 8.9}, dzr, *x, l{1, 2}, l{-1, -2}));
 
   // JDot
   MatrixXd Jd = uf.JDot(*x, xr, dxr, yr, dyr, zr, dzr);
@@ -400,21 +402,21 @@ TEST_CASE("Test checks")
   auto brokenf = std::make_shared<BrokenSphereFunction>(x, Vector3d(1, 0, 0), 3);
   FAST_CHECK_UNARY(checkJacobian(f));
   brokenf->breakJacobian(true);
-  FAST_CHECK_UNARY_FALSE(checkJacobian(brokenf, {1e-7, 1e-6,false}));
+  FAST_CHECK_UNARY_FALSE(checkJacobian(brokenf, {1e-7, 1e-6, false}));
   brokenf->breakJacobian(false);
 
   FAST_CHECK_UNARY(checkVelocity(f));
   brokenf->breakVelocity(true);
-  FAST_CHECK_UNARY_FALSE(checkVelocity(brokenf, { 1e-7, 1e-6,false }));
+  FAST_CHECK_UNARY_FALSE(checkVelocity(brokenf, {1e-7, 1e-6, false}));
   brokenf->breakVelocity(false);
 
   FAST_CHECK_UNARY(checkNormalAcceleration(f));
   brokenf->breakNormalAcceleration(true);
-  FAST_CHECK_UNARY_FALSE(checkNormalAcceleration(brokenf, { 1e-7, 1e-6,false }));
+  FAST_CHECK_UNARY_FALSE(checkNormalAcceleration(brokenf, {1e-7, 1e-6, false}));
   brokenf->breakNormalAcceleration(false);
 }
 
-TEST_CASE("Test graph generation") 
+TEST_CASE("Test graph generation")
 {
   VariablePtr x = Space(3).createVariable("x");
   auto dx = dot(x);
@@ -429,14 +431,14 @@ TEST_CASE("Test graph generation")
   auto f34 = std::make_shared<Difference>(f3, f4);
   auto f = std::make_shared<Difference>(f12, f34);
 
-  //update by hand
-  for (const auto& fi : std::vector<std::shared_ptr<SphereFunction>>{f1, f2, f3, f4})
+  // update by hand
+  for(const auto & fi : std::vector<std::shared_ptr<SphereFunction>>{f1, f2, f3, f4})
   {
     fi->updateValue();
     fi->updateJacobian();
     fi->updateVelocityAndNormalAcc();
   }
-  for (const auto& fi : std::vector<std::shared_ptr<Difference>>{ f12, f34, f })
+  for(const auto & fi : std::vector<std::shared_ptr<Difference>>{f12, f34, f})
   {
     fi->updateValue();
     fi->updateJacobian();
@@ -444,7 +446,7 @@ TEST_CASE("Test graph generation")
     fi->updateJDot();
   }
 
-  //store values
+  // store values
   auto v1 = f1->value();
   auto v2 = f2->value();
   auto v3 = f3->value();
@@ -474,22 +476,22 @@ TEST_CASE("Test graph generation")
   auto na34 = f34->normalAcceleration();
   auto na = f->normalAcceleration();
 
-  //create graphs
+  // create graphs
   auto Value = function::abstract::Function::Output::Value;
   auto Jacobian = function::abstract::Function::Output::Jacobian;
   auto Velocity = function::abstract::Function::Output::Velocity;
   auto NormaAcceleration = function::abstract::Function::Output::NormalAcceleration;
   auto g = utils::generateUpdateGraph(f12, Velocity, f34, Value, Jacobian, f, Value);
 
-  //change variable values
+  // change variable values
   x << Vector3d::Random();
   x << Vector3d::Random();
   dx << Vector3d::Random();
 
-  //update
+  // update
   g->execute();
 
-  //checks: values should be the same if not updated, and different otherwise
+  // checks: values should be the same if not updated, and different otherwise
   FAST_CHECK_NE(f1->value()[0], v1[0]);
   FAST_CHECK_NE(f2->value()[0], v2[0]);
   FAST_CHECK_NE(f3->value()[0], v3[0]);
@@ -509,10 +511,13 @@ TEST_CASE("Test graph generation")
   FAST_CHECK_NE(f3->jacobian(*x)(0), J3(0));
   FAST_CHECK_NE(f4->jacobian(*x)(0), J4(0));
   FAST_CHECK_EQ(f12->jacobian(*x)(0), J12(0));
-  FAST_CHECK_EQ(f34->jacobian(*x)(0), J34(0)); //for the difference of sphere functions, the jacobian is independent of x
+  FAST_CHECK_EQ(f34->jacobian(*x)(0),
+                J34(0)); // for the difference of sphere functions, the jacobian is independent of x
   FAST_CHECK_EQ(f->jacobian(*x)(0), J(0));
-  FAST_CHECK_NE(f1->normalAcceleration()[0], na1[0]);  //for SphereFunction, the normal acceleration is updated when the velocity is updated
-  FAST_CHECK_NE(f2->normalAcceleration()[0], na2[0]);  //for SphereFunction, the normal acceleration is updated when the velocity is updated
+  FAST_CHECK_NE(f1->normalAcceleration()[0],
+                na1[0]); // for SphereFunction, the normal acceleration is updated when the velocity is updated
+  FAST_CHECK_NE(f2->normalAcceleration()[0],
+                na2[0]); // for SphereFunction, the normal acceleration is updated when the velocity is updated
   FAST_CHECK_EQ(f3->normalAcceleration()[0], na3[0]);
   FAST_CHECK_EQ(f4->normalAcceleration()[0], na4[0]);
   FAST_CHECK_EQ(f12->normalAcceleration()[0], na12[0]);

--- a/tests/VariableTest.cpp
+++ b/tests/VariableTest.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Test Variable creation")
   VariablePtr v = Space(3, 4, 3).createVariable("v");
   FAST_CHECK_EQ(v->size(), 4);
   FAST_CHECK_EQ(dot(v)->size(), 3);
-  FAST_CHECK_EQ(dot(v,4)->size(), 3);
+  FAST_CHECK_EQ(dot(v, 4)->size(), 3);
   FAST_CHECK_UNARY(!v->space().isEuclidean());
   FAST_CHECK_EQ(v->space().size(), 3);
   FAST_CHECK_EQ(v->space().rSize(), 4);
@@ -67,24 +67,26 @@ TEST_CASE("Test Variable value")
   }
   {
     VariablePtr v = Space(3).createVariable("v");
-    Eigen::Vector3d val(1,2,3);
+    Eigen::Vector3d val(1, 2, 3);
     v << val;
     FAST_CHECK_UNARY(v->value().isApprox(val));
   }
   {
     VariablePtr v = Space(3).createVariable("v");
-    Eigen::VectorXd val(5); val << 1, 2, 3, 4, 5;
+    Eigen::VectorXd val(5);
+    val << 1, 2, 3, 4, 5;
     v << val.head(3);
     FAST_CHECK_UNARY(v->value().isApprox(Eigen::Vector3d(1, 2, 3)));
   }
   {
     VariablePtr v = Space(3).createVariable("v");
     v << 1, 2, 3;
-    FAST_CHECK_UNARY(v->value().isApprox(Eigen::Vector3d(1,2,3)));
+    FAST_CHECK_UNARY(v->value().isApprox(Eigen::Vector3d(1, 2, 3)));
   }
   {
     VariablePtr v = Space(3).createVariable("v");
-    Eigen::VectorXd val(5); val << 1, 2, 3, 4, 5;
+    Eigen::VectorXd val(5);
+    val << 1, 2, 3, 4, 5;
     v << val.tail(2), 6;
     FAST_CHECK_UNARY(v->value().isApprox(Eigen::Vector3d(4, 5, 6)));
   }
@@ -187,7 +189,7 @@ TEST_CASE("Test VariableVector creation")
   FAST_CHECK_EQ(vv1.indexOf(*v3), -1);
   FAST_CHECK_EQ(vv1.indexOf(*v4), -1);
 
-  VariableVector vv2({ v1, v2, v3 });
+  VariableVector vv2({v1, v2, v3});
   FAST_CHECK_EQ(vv2.numberOfVariables(), 3);
   FAST_CHECK_EQ(vv2.totalSize(), 9);
   FAST_CHECK_EQ(vv2[0], v1);
@@ -197,15 +199,21 @@ TEST_CASE("Test VariableVector creation")
   CHECK(vv2.add(v1) == false);
   CHECK(vv2.remove(*v4) == false);
 
-  std::vector<VariablePtr> vec = { v1, v2 };
-  std::vector<VariablePtr> vec2 = { v1, v3, v4 };
+  std::vector<VariablePtr> vec = {v1, v2};
+  std::vector<VariablePtr> vec2 = {v1, v3, v4};
   VariableVector vv3(vec);
-  for(const auto & v : vec) { vv3.add(v); }
+  for(const auto & v : vec)
+  {
+    vv3.add(v);
+  }
   FAST_CHECK_EQ(vv3.numberOfVariables(), 2);
   FAST_CHECK_EQ(vv3.totalSize(), 7);
   FAST_CHECK_EQ(vv3[0], v1);
   FAST_CHECK_EQ(vv3[1], v2);
-  for(const auto & v : vec2) { vv3.add(v); }
+  for(const auto & v : vec2)
+  {
+    vv3.add(v);
+  }
   FAST_CHECK_EQ(vv3.numberOfVariables(), 4);
   FAST_CHECK_EQ(vv3.totalSize(), 12);
   FAST_CHECK_EQ(vv3[0], v1);
@@ -247,13 +255,13 @@ TEST_CASE("Test Mapping")
   FAST_CHECK_EQ(vv1.stamp(), s + 3);
   FAST_CHECK_EQ(vv2.stamp(), s + 7);
 
-  FAST_CHECK_EQ(v1->getMappingIn(vv1), Range{ 0, 3 });
-  FAST_CHECK_EQ(v2->getMappingIn(vv1), Range{ 3, 4 });
-  FAST_CHECK_EQ(v3->getMappingIn(vv1), Range{ 7, 2 });
+  FAST_CHECK_EQ(v1->getMappingIn(vv1), Range{0, 3});
+  FAST_CHECK_EQ(v2->getMappingIn(vv1), Range{3, 4});
+  FAST_CHECK_EQ(v3->getMappingIn(vv1), Range{7, 2});
   CHECK_THROWS(v4->getMappingIn(vv1));
-  FAST_CHECK_EQ(v1->getMappingIn(vv2), Range{ 6, 3 });
-  FAST_CHECK_EQ(v2->getMappingIn(vv2), Range{ 2, 4 });
-  FAST_CHECK_EQ(v3->getMappingIn(vv2), Range{ 0, 2 });
+  FAST_CHECK_EQ(v1->getMappingIn(vv2), Range{6, 3});
+  FAST_CHECK_EQ(v2->getMappingIn(vv2), Range{2, 4});
+  FAST_CHECK_EQ(v3->getMappingIn(vv2), Range{0, 2});
   CHECK_THROWS(v4->getMappingIn(vv2));
 
   FAST_CHECK_EQ(vv1.stamp(), s + 3);
@@ -261,19 +269,19 @@ TEST_CASE("Test Mapping")
 
   vv1.add(v4);
   FAST_CHECK_EQ(vv1.stamp(), s + 8);
-  FAST_CHECK_EQ(v1->getMappingIn(vv1), Range{ 0, 3 });
-  FAST_CHECK_EQ(v2->getMappingIn(vv1), Range{ 3, 4 });
-  FAST_CHECK_EQ(v3->getMappingIn(vv1), Range{ 7, 2 });
-  FAST_CHECK_EQ(v4->getMappingIn(vv1), Range{ 9, 3 });
+  FAST_CHECK_EQ(v1->getMappingIn(vv1), Range{0, 3});
+  FAST_CHECK_EQ(v2->getMappingIn(vv1), Range{3, 4});
+  FAST_CHECK_EQ(v3->getMappingIn(vv1), Range{7, 2});
+  FAST_CHECK_EQ(v4->getMappingIn(vv1), Range{9, 3});
   vv1.remove(*v2);
   FAST_CHECK_EQ(vv1.stamp(), s + 9);
-  FAST_CHECK_EQ(v1->getMappingIn(vv1), Range{ 0, 3 });
+  FAST_CHECK_EQ(v1->getMappingIn(vv1), Range{0, 3});
   CHECK_THROWS(v2->getMappingIn(vv1));
-  FAST_CHECK_EQ(v3->getMappingIn(vv1), Range{ 3, 2 });
-  FAST_CHECK_EQ(v4->getMappingIn(vv1), Range{ 5, 3 });
-  FAST_CHECK_EQ(v1->getMappingIn(vv2), Range{ 6, 3 });
-  FAST_CHECK_EQ(v2->getMappingIn(vv2), Range{ 2, 4 });
-  FAST_CHECK_EQ(v3->getMappingIn(vv2), Range{ 0, 2 });
+  FAST_CHECK_EQ(v3->getMappingIn(vv1), Range{3, 2});
+  FAST_CHECK_EQ(v4->getMappingIn(vv1), Range{5, 3});
+  FAST_CHECK_EQ(v1->getMappingIn(vv2), Range{6, 3});
+  FAST_CHECK_EQ(v2->getMappingIn(vv2), Range{2, 4});
+  FAST_CHECK_EQ(v3->getMappingIn(vv2), Range{0, 2});
   CHECK_THROWS(v4->getMappingIn(vv2));
 }
 
@@ -315,7 +323,7 @@ TEST_CASE("Test derivative lifetime")
   FAST_CHECK_EQ(dot(x)->value()[2], 4);
 }
 
-VariablePtr createDerivative(const std::string& name, int ndiff)
+VariablePtr createDerivative(const std::string & name, int ndiff)
 {
   VariablePtr x = Space(3).createVariable(name);
   return dot(x, ndiff);
@@ -326,7 +334,7 @@ std::weak_ptr<Variable> testRefCounting()
   // Creating a variable and its derivative, but loosing the ptr on the variable
   VariablePtr dx = createDerivative("x", 1);
   FAST_CHECK_EQ(dx.use_count(), 1);
-  
+
   // Getting back the primitive, checking the ref count
   {
     VariablePtr x = dx->primitive();
@@ -335,18 +343,18 @@ std::weak_ptr<Variable> testRefCounting()
   }
   FAST_CHECK_EQ(dx.use_count(), 1);
 
-  //Creating a derivative, but loosing the shared_ptr on it
+  // Creating a derivative, but loosing the shared_ptr on it
   Variable *pddxa, *pddxb;
   {
     VariablePtr ddx = dot(dx);
     pddxa = ddx.get();
   }
-  //Getting the derivative again, with another way
+  // Getting the derivative again, with another way
   {
-    VariablePtr d3x = dot(dx,2);
+    VariablePtr d3x = dot(dx, 2);
     pddxb = d3x->primitive().get();
   }
-  //Checking the derivative was both time the same
+  // Checking the derivative was both time the same
   FAST_CHECK_EQ(pddxa, pddxb);
 
   return dx;
@@ -355,6 +363,6 @@ std::weak_ptr<Variable> testRefCounting()
 TEST_CASE("Test derivatives ref counting")
 {
   auto dx = testRefCounting();
-  //Checking dx was destroyed.
+  // Checking dx was destroyed.
   FAST_CHECK_UNARY(dx.expired());
 }

--- a/tests/WrenchDistributionTest.cpp
+++ b/tests/WrenchDistributionTest.cpp
@@ -89,13 +89,13 @@ struct RobotState
 
 public:
   Eigen::MatrixXd wrenchFaceMatrix; /**< Inequality matrix of contact wrench cone */
-  Eigen::Vector6d ankleWeights; /**< Ankle anisotropic weights */
-  double lfr; /**< Left foot pressure ratio */
-  sva::ForceVecd w_d; /**< Desired net wrench */
-  sva::PTransformd X_0_la; /**< Plucker transform to left ankle */
-  sva::PTransformd X_0_lc; /**< Plucker transform to left foot center */
-  sva::PTransformd X_0_ra; /**< Plucker transform to right ankle */
-  sva::PTransformd X_0_rc; /**< Plucker transform to right foot center */
+  Eigen::Vector6d ankleWeights;     /**< Ankle anisotropic weights */
+  double lfr;                       /**< Left foot pressure ratio */
+  sva::ForceVecd w_d;               /**< Desired net wrench */
+  sva::PTransformd X_0_la;          /**< Plucker transform to left ankle */
+  sva::PTransformd X_0_lc;          /**< Plucker transform to left foot center */
+  sva::PTransformd X_0_ra;          /**< Plucker transform to right ankle */
+  sva::PTransformd X_0_rc;          /**< Plucker transform to right foot center */
 };
 
 #ifdef TVM_USE_LSSOL

--- a/tests/WrenchDistributionTest.cpp
+++ b/tests/WrenchDistributionTest.cpp
@@ -18,7 +18,7 @@
 #include <tvm/scheme/WeightedLeastSquares.h>
 #include <tvm/solver/defaultLeastSquareSolver.h>
 #ifdef TVM_USE_LSSOL
-# include <tvm/solver/LSSOLLeastSquareSolver.h>
+#  include <tvm/solver/LSSOLLeastSquareSolver.h>
 #endif
 #include <tvm/task_dynamics/None.h>
 #include <tvm/task_dynamics/ProportionalDerivative.h>
@@ -60,8 +60,7 @@ struct RobotState
   /** Default robot state.
    *
    */
-  RobotState()
-    : wrenchFaceMatrix(16, 6)
+  RobotState() : wrenchFaceMatrix(16, 6)
   {
     X_0_lc = Vector3d{0.035, -0.09, 0.0};
     X_0_rc = Vector3d{0.035, 0.09, 0.0};
@@ -78,24 +77,14 @@ struct RobotState
     constexpr double X = 0.112; // [m]
     constexpr double Y = 0.065; // [m]
     constexpr double mu = 0.7;
-    wrenchFaceMatrix << 
-      // mx,  my,  mz,  fx,  fy,            fz,
-          0,   0,   0,  -1,   0,           -mu,
-          0,   0,   0,  +1,   0,           -mu,
-          0,   0,   0,   0,  -1,           -mu,
-          0,   0,   0,   0,  +1,           -mu,
-         -1,   0,   0,   0,   0,            -Y,
-         +1,   0,   0,   0,   0,            -Y,
-          0,  -1,   0,   0,   0,            -X,
-          0,  +1,   0,   0,   0,            -X,
-        +mu, +mu,  -1,  -Y,  -X, -(X + Y) * mu,
-        +mu, -mu,  -1,  -Y,  +X, -(X + Y) * mu,
-        -mu, +mu,  -1,  +Y,  -X, -(X + Y) * mu,
-        -mu, -mu,  -1,  +Y,  +X, -(X + Y) * mu,
-        +mu, +mu,  +1,  +Y,  +X, -(X + Y) * mu,
-        +mu, -mu,  +1,  +Y,  -X, -(X + Y) * mu,
-        -mu, +mu,  +1,  -Y,  +X, -(X + Y) * mu,
-        -mu, -mu,  +1,  -Y,  -X, -(X + Y) * mu;
+    wrenchFaceMatrix <<
+        // mx,  my,  mz,  fx,  fy,            fz,
+        0,
+        0, 0, -1, 0, -mu, 0, 0, 0, +1, 0, -mu, 0, 0, 0, 0, -1, -mu, 0, 0, 0, 0, +1, -mu, -1, 0, 0, 0, 0, -Y, +1, 0, 0,
+        0, 0, -Y, 0, -1, 0, 0, 0, -X, 0, +1, 0, 0, 0, -X, +mu, +mu, -1, -Y, -X, -(X + Y) * mu, +mu, -mu, -1, -Y, +X,
+        -(X + Y) * mu, -mu, +mu, -1, +Y, -X, -(X + Y) * mu, -mu, -mu, -1, +Y, +X, -(X + Y) * mu, +mu, +mu, +1, +Y, +X,
+        -(X + Y) * mu, +mu, -mu, +1, +Y, -X, -(X + Y) * mu, -mu, +mu, +1, -Y, +X, -(X + Y) * mu, -mu, -mu, +1, -Y, -X,
+        -(X + Y) * mu;
   }
 
 public:
@@ -185,7 +174,7 @@ Eigen::VectorXd distributeWrenchGroundTruth(const RobotState & robot)
   A_pressure *= PRESSURE_WEIGHT_SQRT;
 
   constexpr unsigned CONS_DIM = 16 + 16 + 2;
-  Eigen::Matrix<double, CONS_DIM , NB_VAR> C;
+  Eigen::Matrix<double, CONS_DIM, NB_VAR> C;
   Eigen::VectorXd bl, bu;
   C.setZero(CONS_DIM, NB_VAR);
   bl.setConstant(NB_VAR + CONS_DIM, -1e5);
@@ -205,7 +194,7 @@ Eigen::VectorXd distributeWrenchGroundTruth(const RobotState & robot)
   blCons.segment<2>(32).setConstant(MIN_PRESSURE);
   buCons.segment<2>(32).setConstant(+1e5);
 
-  if (VERBOSE)
+  if(VERBOSE)
   {
     std::cout << "A_gt =\n" << A << std::endl;
     std::cout << "b_gt =\t" << b.transpose() << std::endl;
@@ -217,7 +206,7 @@ Eigen::VectorXd distributeWrenchGroundTruth(const RobotState & robot)
   Eigen::LSSOL_LS solver;
   solver.solve(A, b, C, bl, bu);
   Eigen::VectorXd x = solver.result();
-  if (solver.inform() != Eigen::lssol::eStatus::STRONG_MINIMUM)
+  if(solver.inform() != Eigen::lssol::eStatus::STRONG_MINIMUM)
   {
     std::cout << "Wrench distribution QP failed to run" << std::endl;
     solver.print_inform();
@@ -240,7 +229,7 @@ bool checkSolution(const RobotState & robot, Eigen::Vector6d w_l_0, Eigen::Vecto
   Eigen::Vector6d w_l_0_gt = x.segment<6>(0);
   Eigen::Vector6d w_r_0_gt = x.segment<6>(6);
 
-  if (VERBOSE)
+  if(VERBOSE)
   {
     std::cout << "w_l_0 = " << w_l_0.transpose() << std::endl;
     std::cout << "w_r_0 = " << w_r_0.transpose() << std::endl;
@@ -252,9 +241,9 @@ bool checkSolution(const RobotState & robot, Eigen::Vector6d w_l_0, Eigen::Vecto
   return ((w_l_0 - w_l_0_gt).norm() < EPSILON && (w_r_0 - w_r_0_gt).norm() < EPSILON);
 }
 #else
-bool checkSolution(const RobotState& robot, Eigen::Vector6d w_l_0, Eigen::Vector6d w_r_0)
+bool checkSolution(const RobotState & robot, Eigen::Vector6d w_l_0, Eigen::Vector6d w_r_0)
 {
-  if (VERBOSE)
+  if(VERBOSE)
   {
     std::cout << "w_l_0 = " << w_l_0.transpose() << std::endl;
     std::cout << "w_r_0 = " << w_r_0.transpose() << std::endl;
@@ -280,15 +269,23 @@ TEST_CASE("WrenchDistribQP")
   VariablePtr w_r_0 = wrenchSpace.createVariable("w_r_0");
 
   LinearizedControlProblem problem;
-  auto leftFootFricTask         = problem.add(wrenchFaceMatrix * X_0_lc.dualMatrix() * w_l_0 <= 0.           , { PriorityLevel(0) });
-  auto rightFootFricTask        = problem.add(wrenchFaceMatrix * X_0_rc.dualMatrix() * w_r_0 <= 0.           , { PriorityLevel(0) });
-  auto leftFootMinPressureTask  = problem.add(X_0_lc.dualMatrix().bottomRows<1>() * w_l_0 >= MIN_PRESSURE    , { PriorityLevel(0) });
-  auto rightFootMinPressureTask = problem.add(X_0_rc.dualMatrix().bottomRows<1>() * w_r_0 >= MIN_PRESSURE    , { PriorityLevel(0) });
-  auto netWrenchTask            = problem.add(w_l_0 + w_r_0 == w_d.vector()                                  , { PriorityLevel(1), Weight(NET_WRENCH_WEIGHT) });
-  auto leftAnkleWrenchTask      = problem.add(X_0_la.dualMatrix() * w_l_0 == 0.                              , { PriorityLevel(1), AnisotropicWeight(ankleWeights), Weight(COMPLIANCE_WEIGHT) });
-  auto rightAnkleWrenchTask     = problem.add(X_0_ra.dualMatrix() * w_r_0 == 0.                              , { PriorityLevel(1), AnisotropicWeight(ankleWeights), Weight(COMPLIANCE_WEIGHT) });
-  auto pressureRatioTask        = problem.add((1 - robot.lfr) * X_0_lc.dualMatrix().bottomRows<1>() * w_l_0 
-                                               - robot.lfr * X_0_rc.dualMatrix().bottomRows<1>() * w_r_0 == 0, { PriorityLevel(1), Weight(PRESSURE_WEIGHT) });
+  auto leftFootFricTask = problem.add(wrenchFaceMatrix * X_0_lc.dualMatrix() * w_l_0 <= 0., {PriorityLevel(0)});
+  auto rightFootFricTask = problem.add(wrenchFaceMatrix * X_0_rc.dualMatrix() * w_r_0 <= 0., {PriorityLevel(0)});
+  auto leftFootMinPressureTask =
+      problem.add(X_0_lc.dualMatrix().bottomRows<1>() * w_l_0 >= MIN_PRESSURE, {PriorityLevel(0)});
+  auto rightFootMinPressureTask =
+      problem.add(X_0_rc.dualMatrix().bottomRows<1>() * w_r_0 >= MIN_PRESSURE, {PriorityLevel(0)});
+  auto netWrenchTask = problem.add(w_l_0 + w_r_0 == w_d.vector(), {PriorityLevel(1), Weight(NET_WRENCH_WEIGHT)});
+  auto leftAnkleWrenchTask =
+      problem.add(X_0_la.dualMatrix() * w_l_0 == 0.,
+                  {PriorityLevel(1), AnisotropicWeight(ankleWeights), Weight(COMPLIANCE_WEIGHT)});
+  auto rightAnkleWrenchTask =
+      problem.add(X_0_ra.dualMatrix() * w_r_0 == 0.,
+                  {PriorityLevel(1), AnisotropicWeight(ankleWeights), Weight(COMPLIANCE_WEIGHT)});
+  auto pressureRatioTask = problem.add((1 - robot.lfr) * X_0_lc.dualMatrix().bottomRows<1>() * w_l_0
+                                               - robot.lfr * X_0_rc.dualMatrix().bottomRows<1>() * w_r_0
+                                           == 0,
+                                       {PriorityLevel(1), Weight(PRESSURE_WEIGHT)});
 
   // First problem with initial left foot ratio
   scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions().verbose(VERBOSE));

--- a/tests/doctest/doctest.h
+++ b/tests/doctest/doctest.h
@@ -265,7 +265,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#endif // __cplusplus >= 201103L
+#endif   // __cplusplus >= 201103L
 
 // MSVC C++11 feature support table: https://msdn.microsoft.com/en-us/library/hh567368.aspx
 // GCC C++11 feature support table: https://gcc.gnu.org/projects/cxx-status.html
@@ -290,7 +290,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
 #    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
 #  endif // GCC
-#endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#endif   // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
 
 #if defined(DOCTEST_CONFIG_NO_DELETED_FUNCTIONS) && defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS)
 #  undef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
@@ -308,7 +308,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
 #    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 #  endif // GCC
-#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#endif   // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 
 #if defined(DOCTEST_CONFIG_NO_RVALUE_REFERENCES) && defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES)
 #  undef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
@@ -326,7 +326,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
 #    define DOCTEST_CONFIG_WITH_NULLPTR
 #  endif // MSVC
-#endif // DOCTEST_CONFIG_WITH_NULLPTR
+#endif   // DOCTEST_CONFIG_WITH_NULLPTR
 
 #if defined(DOCTEST_CONFIG_NO_NULLPTR) && defined(DOCTEST_CONFIG_WITH_NULLPTR)
 #  undef DOCTEST_CONFIG_WITH_NULLPTR
@@ -341,7 +341,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 1, 0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)
 #    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #  endif // GCC and clang
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif   // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 #if defined(DOCTEST_CONFIG_NO_VARIADIC_MACROS) && defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS)
 #  undef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -356,7 +356,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)
 #    define DOCTEST_CONFIG_WITH_LONG_LONG
 #  endif // GCC and clang
-#endif // DOCTEST_CONFIG_WITH_LONG_LONG
+#endif   // DOCTEST_CONFIG_WITH_LONG_LONG
 
 #if defined(DOCTEST_CONFIG_NO_LONG_LONG) && defined(DOCTEST_CONFIG_WITH_LONG_LONG)
 #  undef DOCTEST_CONFIG_WITH_LONG_LONG
@@ -374,7 +374,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
 #    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
 #  endif // MSVC
-#endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#endif   // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
 #if defined(DOCTEST_CONFIG_NO_STATIC_ASSERT) && defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
 #  undef DOCTEST_CONFIG_WITH_STATIC_ASSERT
@@ -419,7 +419,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #  ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 #    define DOCTEST_CONFIG_NO_EXCEPTIONS
 #  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#endif   // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
 #if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
 #  define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
@@ -437,7 +437,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #    define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
 #    define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
 #  endif // MSVC
-#else // _WIN32
+#else    // _WIN32
 #  define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
 #  define DOCTEST_SYMBOL_IMPORT
 #endif // _WIN32
@@ -448,7 +448,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #  else // DOCTEST_CONFIG_IMPLEMENT
 #    define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
 #  endif // DOCTEST_CONFIG_IMPLEMENT
-#else // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#else    // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 #  define DOCTEST_INTERFACE
 #endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 
@@ -549,7 +549,7 @@ typedef basic_ostream<char, char_traits<char>> ostream;
 #  else // DOCTEST_CONFIG_USE_IOSFWD
 #    include <iosfwd>
 #  endif // DOCTEST_CONFIG_USE_IOSFWD
-#endif // _LIBCPP_VERSION
+#endif   // _LIBCPP_VERSION
 
 // static assert macro - because of the c++98 support requires that the message is an
 // identifier (no spaces and not a C string) - example without quotes: I_am_a_message
@@ -572,13 +572,13 @@ typedef basic_ostream<char, char_traits<char>> ostream;
 #ifdef DOCTEST_CONFIG_WITH_NULLPTR
 #  ifdef _LIBCPP_VERSION
 #    include <cstddef>
-#  else // _LIBCPP_VERSION
+#  else  // _LIBCPP_VERSION
 namespace std
 {
 typedef decltype(nullptr) nullptr_t;
 }
 #  endif // _LIBCPP_VERSION
-#endif // DOCTEST_CONFIG_WITH_NULLPTR
+#endif   // DOCTEST_CONFIG_WITH_NULLPTR
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
@@ -656,7 +656,7 @@ namespace doctest
 // - relational operators as free functions - taking const char* as one of the params
 class DOCTEST_INTERFACE String
 {
-  static const unsigned len = 24; //! OCLINT avoid private static members
+  static const unsigned len = 24;       //! OCLINT avoid private static members
   static const unsigned last = len - 1; //! OCLINT avoid private static members
 
   struct view // len should be more than sizeof(view) - because of the final byte for flags
@@ -903,7 +903,7 @@ struct ForEachType<Typelist<Head, Tail>, Callable> : public ForEachType<Tail, Ca
   {
 #if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 10, 0)
     callable.operator()<value, Head>();
-#else // MSVC
+#else  // MSVC
     callable.template operator()<value, Head>();
 #endif // MSVC
   }
@@ -923,7 +923,7 @@ public:
   {
 #if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 10, 0)
     callable.operator()<value, Head>();
-#else // MSVC
+#else  // MSVC
     callable.template operator()<value, Head>();
 #endif // MSVC
   }
@@ -1382,7 +1382,7 @@ DOCTEST_INTERFACE void throwException();
 struct TestAccessibleContextState
 {
   bool no_throw; // to skip exceptions-related assertion macros
-  bool success; // include successful assertions in output
+  bool success;  // include successful assertions in output
 };
 
 struct ContextState;
@@ -1627,10 +1627,10 @@ struct ExpressionDecomposer
 struct DOCTEST_INTERFACE TestCase
 {
   // not used for determining uniqueness
-  funcType m_test; // a function pointer to the test case
-  String m_full_name; // contains the name (only for templated test cases!) + the template type
-  const char * m_name; // name of the test case
-  const char * m_type; // for templated test cases - gets appended to the real name
+  funcType m_test;           // a function pointer to the test case
+  String m_full_name;        // contains the name (only for templated test cases!) + the template type
+  const char * m_name;       // name of the test case
+  const char * m_type;       // for templated test cases - gets appended to the real name
   const char * m_test_suite; // the test suite in which the test was added
   const char * m_description;
   bool m_skip;
@@ -1641,8 +1641,8 @@ struct DOCTEST_INTERFACE TestCase
 
   // fields by which uniqueness of test cases shall be determined
   const char * m_file; // the file in which the test was registered
-  unsigned m_line; // the line where the test was registered
-  int m_template_id; // an ID used to distinguish between the different versions of a templated test case
+  unsigned m_line;     // the line where the test was registered
+  int m_template_id;   // an ID used to distinguish between the different versions of a templated test case
 
   TestCase(funcType test,
            const char * file,
@@ -1893,14 +1893,14 @@ public:
       // cppcheck-suppress catchExceptionByValue
     }
     catch(T ex)
-    { // NOLINT
+    {                                // NOLINT
       res = m_translateFunction(ex); //! OCLINT parameter reassignment
       return true;
     }
     catch(...)
     {
-    } //! OCLINT -  empty catch statement
-#  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+    }            //! OCLINT -  empty catch statement
+#  endif         // DOCTEST_CONFIG_NO_EXCEPTIONS
     ((void)res); // to silence -Wunused-parameter
     return false;
   }
@@ -2231,7 +2231,7 @@ int registerExceptionTranslator(String (*translateFunction)(T))
   return 0;
 }
 
-#else // DOCTEST_CONFIG_DISABLE
+#else  // DOCTEST_CONFIG_DISABLE
 template<typename T>
 int registerExceptionTranslator(String (*)(T))
 {
@@ -2520,7 +2520,7 @@ constexpr T to_lvalue = x;
 #    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #      define DOCTEST_TO_LVALUE(x) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
 #    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  endif // TO_LVALUE hack for logging macros like INFO()
+#  endif   // TO_LVALUE hack for logging macros like INFO()
 
 // common code in asserts - for convenience
 #  define DOCTEST_ASSERT_LOG_AND_REACT(rb) \
@@ -3566,7 +3566,7 @@ struct Endianness
       char asChar[sizeof(int)];
     } u;
 
-    u.asInt = 1; // NOLINT
+    u.asInt = 1;                                            // NOLINT
     return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
   }
 };
@@ -3605,32 +3605,32 @@ struct ContextState : TestAccessibleContextState //! OCLINT too many fields
 
   std::vector<std::vector<String>> filters;
 
-  String order_by; // how tests should be ordered
+  String order_by;    // how tests should be ordered
   unsigned rand_seed; // the seed for rand ordering
 
   unsigned first; // the first (matching) test to be executed
-  unsigned last; // the last (matching) test to be executed
+  unsigned last;  // the last (matching) test to be executed
 
-  int abort_after; // stop tests after this many failed assertions
+  int abort_after;           // stop tests after this many failed assertions
   int subcase_filter_levels; // apply the subcase filters for the first N levels
-  bool case_sensitive; // if filtering should be case sensitive
-  bool exit; // if the program should be exited after the tests are ran/whatever
-  bool duration; // print the time duration of each test case
-  bool no_exitcode; // if the framework should return 0 as the exitcode
-  bool no_run; // to not run the tests at all (can be done with an "*" exclude)
-  bool no_version; // to not print the version of the framework
-  bool no_colors; // if output to the console should be colorized
-  bool force_colors; // forces the use of colors even when a tty cannot be detected
-  bool no_breaks; // to not break into the debugger
-  bool no_skip; // don't skip test cases which are marked to be skipped
+  bool case_sensitive;       // if filtering should be case sensitive
+  bool exit;                 // if the program should be exited after the tests are ran/whatever
+  bool duration;             // print the time duration of each test case
+  bool no_exitcode;          // if the framework should return 0 as the exitcode
+  bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
+  bool no_version;           // to not print the version of the framework
+  bool no_colors;            // if output to the console should be colorized
+  bool force_colors;         // forces the use of colors even when a tty cannot be detected
+  bool no_breaks;            // to not break into the debugger
+  bool no_skip;              // don't skip test cases which are marked to be skipped
   bool no_path_in_filenames; // if the path to files should be removed from the output
-  bool no_line_numbers; // if source code line numbers should be omitted from the output
-  bool no_skipped_summary; // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+  bool no_line_numbers;      // if source code line numbers should be omitted from the output
+  bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
 
-  bool help; // to print the help
-  bool version; // to print the version
-  bool count; // if only the count of matching tests is to be retreived
-  bool list_test_cases; // to list all tests matching the filters
+  bool help;             // to print the help
+  bool version;          // to print the version
+  bool count;            // if only the count of matching tests is to be retreived
+  bool list_test_cases;  // to list all tests matching the filters
   bool list_test_suites; // to list all suites matching the filters
 
   // == data for the tests being ran
@@ -3646,7 +3646,7 @@ struct ContextState : TestAccessibleContextState //! OCLINT too many fields
   int numFailedAssertions;
   bool hasCurrentTestFailed;
 
-  std::vector<IContextScope *> contexts; // for logging with INFO() and friends
+  std::vector<IContextScope *> contexts;        // for logging with INFO() and friends
   std::vector<std::string> exceptionalContexts; // logging from INFO() due to an exception
 
   // stuff for subcases
@@ -3937,8 +3937,8 @@ int Context::run() { return 0; }
 #        else // linux
 #          define DOCTEST_CONFIG_COLORS_ANSI
 #        endif // platform
-#      endif // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
-#    endif // DOCTEST_CONFIG_COLORS_NONE
+#      endif   // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
+#    endif     // DOCTEST_CONFIG_COLORS_NONE
 
 #    define DOCTEST_PRINTF_COLORED(buffer, color) \
       do                                          \
@@ -3960,7 +3960,7 @@ int Context::run() { return 0; }
 #      endif // MSVC
 extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(DOCTEST_WINDOWS_SAL_IN_OPT const char *);
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
-#    endif // MSVC || __MINGW32__
+#    endif   // MSVC || __MINGW32__
 
 #    ifdef DOCTEST_CONFIG_COLORS_ANSI
 #      include <unistd.h>
@@ -4211,7 +4211,7 @@ int wildcmp(const char * str, const char * wild, bool caseSensitive)
     }
     else
     {
-      wild = mp; //! OCLINT parameter reassignment
+      wild = mp;  //! OCLINT parameter reassignment
       str = cp++; //! OCLINT parameter reassignment
     }
   }
@@ -4259,7 +4259,7 @@ UInt64 getCurrentTicks()
   QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER *>(&t));
   return ((t - hzo) * 1000000) / hz;
 }
-#    else // DOCTEST_PLATFORM_WINDOWS
+#    else  // DOCTEST_PLATFORM_WINDOWS
 
 typedef uint64_t UInt64;
 
@@ -4371,7 +4371,7 @@ int fileOrderComparator(const void * a, const void * b)
   // this is needed because MSVC gives different case for drive letters
   // for __FILE__ when evaluated in a header and a source file
   const int res = stricmp(lhs->m_file, rhs->m_file);
-#    else // MSVC
+#    else  // MSVC
   const int res = std::strcmp(lhs->m_file, rhs->m_file);
 #    endif // MSVC
   if(res != 0)
@@ -4572,7 +4572,7 @@ String translateActiveException()
             return "unknown exception";
         }
 // clang-format on
-#    else // DOCTEST_CONFIG_NO_EXCEPTIONS
+#    else  // DOCTEST_CONFIG_NO_EXCEPTIONS
   return "";
 #    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 }
@@ -4785,7 +4785,7 @@ stack_t FatalConditionHandler::oldSigStack = {};
 char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
 
 #      endif // DOCTEST_PLATFORM_WINDOWS
-#    endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+#    endif   // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
 // depending on the current options this will remove the path of filenames
 const char * fileForOutput(const char * file)
@@ -5330,7 +5330,7 @@ bool parseFlag(int argc, const char * const * argv, const char * pattern)
   if(!parseFlagImpl(argc, argv, pattern))
     return parseFlagImpl(argc, argv, pattern + 3); // 3 for "dt-"
   return true;
-#    else // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+#    else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
   return parseFlagImpl(argc, argv, pattern);
 #    endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
 }
@@ -5381,7 +5381,7 @@ bool parseOption(int argc,
   if(!parseOptionImpl(argc, argv, pattern, res))
     return parseOptionImpl(argc, argv, pattern + 3, res); // 3 for "dt-"
   return true;
-#    else // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+#    else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
   return parseOptionImpl(argc, argv, pattern, res);
 #    endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
 }
@@ -5424,7 +5424,7 @@ bool parseIntOption(int argc, const char * const * argv, const char * pattern, o
   if(type == 0)
   {
     // boolean
-    const char positive[][5] = {"1", "true", "on", "yes"}; // 5 - strlen("true") + 1
+    const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
     const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
 
     // if the value matches any of the positive/negative possibilities

--- a/tests/doctest/doctest.h
+++ b/tests/doctest/doctest.h
@@ -56,8 +56,7 @@
 #define DOCTEST_VERSION_PATCH 6
 #define DOCTEST_VERSION_STR "1.2.6"
 
-#define DOCTEST_VERSION                                                                            \
-    (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
+#define DOCTEST_VERSION (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
 
 // =================================================================================================
 // == COMPILER VERSION =============================================================================
@@ -68,26 +67,25 @@
 #define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
 
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)
-#if _MSC_VER == _MSC_FULL_VER / 10000
-#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
-#else
-#define DOCTEST_MSVC                                                                               \
-    DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
-#endif
+#  if _MSC_VER == _MSC_FULL_VER / 10000
+#    define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
+#  else
+#    define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
+#  endif
 #elif defined(__clang__) && defined(__clang_minor__)
-#define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#  define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#  define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #endif
 
 #ifndef DOCTEST_MSVC
-#define DOCTEST_MSVC 0
+#  define DOCTEST_MSVC 0
 #endif // DOCTEST_MSVC
 #ifndef DOCTEST_CLANG
-#define DOCTEST_CLANG 0
+#  define DOCTEST_CLANG 0
 #endif // DOCTEST_CLANG
 #ifndef DOCTEST_GCC
-#define DOCTEST_GCC 0
+#  define DOCTEST_GCC 0
 #endif // DOCTEST_GCC
 
 // =================================================================================================
@@ -95,72 +93,70 @@
 // =================================================================================================
 
 #if DOCTEST_CLANG
-#ifdef __has_warning
-#define DOCTEST_CLANG_HAS_WARNING(x) __has_warning(x)
-#endif // __has_warning
-#ifdef __has_feature
-#define DOCTEST_CLANG_HAS_FEATURE(x) __has_feature(x)
-#endif // __has_feature
-#define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
-#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
-#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-#define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
-#define DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#define DOCTEST_GCC_SUPPRESS_WARNING(w)
-#define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
-#define DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#define DOCTEST_GCC_SUPPRESS_WARNING_POP
-#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                \
+#  ifdef __has_warning
+#    define DOCTEST_CLANG_HAS_WARNING(x) __has_warning(x)
+#  endif // __has_warning
+#  ifdef __has_feature
+#    define DOCTEST_CLANG_HAS_FEATURE(x) __has_feature(x)
+#  endif // __has_feature
+#  define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#  x)
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+#  define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#  define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
+#  define DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#  define DOCTEST_GCC_SUPPRESS_WARNING(w)
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#  define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w) \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
-#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
+#  define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
 #elif DOCTEST_GCC
-#define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
-#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
-#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
-#else // GCC 4.7+
-#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-#endif // GCC 4.7+
-#define DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#define DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
-#define DOCTEST_CLANG_SUPPRESS_WARNING_POP
-#define DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
-#define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
-#else // GCC 4.7+
-#define DOCTEST_GCC_SUPPRESS_WARNING_POP
-#endif // GCC 4.7+
-#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
-#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
-#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
+#  define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#  x)
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
+#    define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
+#  else // GCC 4.7+
+#    define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#  endif // GCC 4.7+
+#  define DOCTEST_CLANG_SUPPRESS_WARNING(w)
+#  define DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#  define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
+#    define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
+#  else // GCC 4.7+
+#    define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#  endif // GCC 4.7+
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
+#  define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
 #elif DOCTEST_MSVC
-#define DOCTEST_PRAGMA_TO_STR(x)
-#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
-#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-#define DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
-#define DOCTEST_GCC_SUPPRESS_WARNING(w)
-#define DOCTEST_CLANG_SUPPRESS_WARNING_POP
-#define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
-#define DOCTEST_GCC_SUPPRESS_WARNING_POP
-#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
-#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)                                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
+#  define DOCTEST_PRAGMA_TO_STR(x)
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
+#  define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#  define DOCTEST_CLANG_SUPPRESS_WARNING(w)
+#  define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
+#  define DOCTEST_GCC_SUPPRESS_WARNING(w)
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
+#  define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#  define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
+#  define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#  define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
 #endif // different compilers - warning suppression macros
 
 #ifndef DOCTEST_CLANG_HAS_WARNING
-#define DOCTEST_CLANG_HAS_WARNING(x) 1
+#  define DOCTEST_CLANG_HAS_WARNING(x) 1
 #endif // DOCTEST_CLANG_HAS_WARNING
 
 #ifndef DOCTEST_CLANG_HAS_FEATURE
-#define DOCTEST_CLANG_HAS_FEATURE(x) 0
+#  define DOCTEST_CLANG_HAS_FEATURE(x) 0
 #endif // DOCTEST_CLANG_HAS_FEATURE
 
 // =================================================================================================
@@ -229,20 +225,20 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 // - C4710 # function not inlined
 // - C4711 # function 'x' selected for automatic inline expansion
 
-#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4548)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4986)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4350)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4668)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4623)
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN \
+  DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                               \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4548)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4986)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4350)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4668)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4365)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4774)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4820)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4625)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4626)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(5027)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(5026)                              \
+  DOCTEST_MSVC_SUPPRESS_WARNING(4623)
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -251,24 +247,24 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 // =================================================================================================
 
 #if __cplusplus >= 201103L
-#ifndef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#ifndef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#ifndef DOCTEST_CONFIG_WITH_NULLPTR
-#define DOCTEST_CONFIG_WITH_NULLPTR
-#endif // DOCTEST_CONFIG_WITH_NULLPTR
-#ifndef DOCTEST_CONFIG_WITH_LONG_LONG
-#define DOCTEST_CONFIG_WITH_LONG_LONG
-#endif // DOCTEST_CONFIG_WITH_LONG_LONG
-#ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifndef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#  endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#  ifndef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#  endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#  ifndef DOCTEST_CONFIG_WITH_NULLPTR
+#    define DOCTEST_CONFIG_WITH_NULLPTR
+#  endif // DOCTEST_CONFIG_WITH_NULLPTR
+#  ifndef DOCTEST_CONFIG_WITH_LONG_LONG
+#    define DOCTEST_CONFIG_WITH_LONG_LONG
+#  endif // DOCTEST_CONFIG_WITH_LONG_LONG
+#  ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#  endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#  ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #endif // __cplusplus >= 201103L
 
 // MSVC C++11 feature support table: https://msdn.microsoft.com/en-us/library/hh567368.aspx
@@ -285,113 +281,111 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 // deleted functions
 
 #ifndef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(18, 0, 0)
-#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#endif // MSVC
-#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_deleted_functions)
-#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#endif // clang
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#endif // GCC
+#  if DOCTEST_MSVC >= DOCTEST_COMPILER(18, 0, 0)
+#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#  endif // MSVC
+#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_deleted_functions)
+#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#  endif // clang
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#  endif // GCC
 #endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
 
 #if defined(DOCTEST_CONFIG_NO_DELETED_FUNCTIONS) && defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS)
-#undef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#  undef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
 #endif // DOCTEST_CONFIG_NO_DELETED_FUNCTIONS
 
 // rvalue references
 
 #ifndef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
-#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#endif // MSVC
-#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_rvalue_references)
-#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#endif // clang
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#endif // GCC
+#  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
+#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#  endif // MSVC
+#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_rvalue_references)
+#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#  endif // clang
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#  endif // GCC
 #endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 
 #if defined(DOCTEST_CONFIG_NO_RVALUE_REFERENCES) && defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES)
-#undef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#  undef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 #endif // DOCTEST_CONFIG_NO_RVALUE_REFERENCES
 
 // nullptr
 
 #ifndef DOCTEST_CONFIG_WITH_NULLPTR
-#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_nullptr)
-#define DOCTEST_CONFIG_WITH_NULLPTR
-#endif // clang
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#define DOCTEST_CONFIG_WITH_NULLPTR
-#endif // GCC
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
-#define DOCTEST_CONFIG_WITH_NULLPTR
-#endif // MSVC
+#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_nullptr)
+#    define DOCTEST_CONFIG_WITH_NULLPTR
+#  endif // clang
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#    define DOCTEST_CONFIG_WITH_NULLPTR
+#  endif // GCC
+#  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
+#    define DOCTEST_CONFIG_WITH_NULLPTR
+#  endif // MSVC
 #endif // DOCTEST_CONFIG_WITH_NULLPTR
 
 #if defined(DOCTEST_CONFIG_NO_NULLPTR) && defined(DOCTEST_CONFIG_WITH_NULLPTR)
-#undef DOCTEST_CONFIG_WITH_NULLPTR
+#  undef DOCTEST_CONFIG_WITH_NULLPTR
 #endif // DOCTEST_CONFIG_NO_NULLPTR
 
 // variadic macros
 
 #ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0) && !defined(__EDGE__)
-#define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#endif // MSVC
-#if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 1, 0)) &&                                  \
-        defined(__GXX_EXPERIMENTAL_CXX0X__)
-#define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#endif // GCC and clang
+#  if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0) && !defined(__EDGE__)
+#    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  endif // MSVC
+#  if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 1, 0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  endif // GCC and clang
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 #if defined(DOCTEST_CONFIG_NO_VARIADIC_MACROS) && defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS)
-#undef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  undef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #endif // DOCTEST_CONFIG_NO_VARIADIC_MACROS
 
 // long long
 
 #ifndef DOCTEST_CONFIG_WITH_LONG_LONG
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0)
-#define DOCTEST_CONFIG_WITH_LONG_LONG
-#endif // MSVC
-#if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0)) &&                                  \
-        defined(__GXX_EXPERIMENTAL_CXX0X__)
-#define DOCTEST_CONFIG_WITH_LONG_LONG
-#endif // GCC and clang
+#  if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0)
+#    define DOCTEST_CONFIG_WITH_LONG_LONG
+#  endif // MSVC
+#  if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#    define DOCTEST_CONFIG_WITH_LONG_LONG
+#  endif // GCC and clang
 #endif // DOCTEST_CONFIG_WITH_LONG_LONG
 
 #if defined(DOCTEST_CONFIG_NO_LONG_LONG) && defined(DOCTEST_CONFIG_WITH_LONG_LONG)
-#undef DOCTEST_CONFIG_WITH_LONG_LONG
+#  undef DOCTEST_CONFIG_WITH_LONG_LONG
 #endif // DOCTEST_CONFIG_NO_LONG_LONG
 
 // static_assert
 
 #ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_static_assert)
-#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#endif // clang
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#endif // GCC
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
-#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#endif // MSVC
+#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_static_assert)
+#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#  endif // clang
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#  endif // GCC
+#  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
+#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#  endif // MSVC
 #endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
 #if defined(DOCTEST_CONFIG_NO_STATIC_ASSERT) && defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
-#undef DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#  undef DOCTEST_CONFIG_WITH_STATIC_ASSERT
 #endif // DOCTEST_CONFIG_NO_STATIC_ASSERT
 
 // other stuff...
 
-#if defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES) || defined(DOCTEST_CONFIG_WITH_LONG_LONG) ||    \
-        defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS) || defined(DOCTEST_CONFIG_WITH_NULLPTR) ||  \
-        defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS) || defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
-#define DOCTEST_NO_CPP11_COMPAT
+#if defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES) || defined(DOCTEST_CONFIG_WITH_LONG_LONG)  \
+    || defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS) || defined(DOCTEST_CONFIG_WITH_NULLPTR) \
+    || defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS) || defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
+#  define DOCTEST_NO_CPP11_COMPAT
 #endif // c++11 stuff
 
 #if defined(DOCTEST_NO_CPP11_COMPAT)
@@ -400,74 +394,74 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #endif // DOCTEST_NO_CPP11_COMPAT
 
 #if DOCTEST_MSVC && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-#define DOCTEST_CONFIG_WINDOWS_SEH
+#  define DOCTEST_CONFIG_WINDOWS_SEH
 #endif // MSVC
 #if defined(DOCTEST_CONFIG_NO_WINDOWS_SEH) && defined(DOCTEST_CONFIG_WINDOWS_SEH)
-#undef DOCTEST_CONFIG_WINDOWS_SEH
+#  undef DOCTEST_CONFIG_WINDOWS_SEH
 #endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
 #if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS)
-#define DOCTEST_CONFIG_POSIX_SIGNALS
+#  define DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
-#undef DOCTEST_CONFIG_POSIX_SIGNALS
+#  undef DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if(DOCTEST_GCC || DOCTEST_CLANG) && !defined(__EXCEPTIONS)
-#define DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // clang and gcc
+#  if(DOCTEST_GCC || DOCTEST_CLANG) && !defined(__EXCEPTIONS)
+#    define DOCTEST_CONFIG_NO_EXCEPTIONS
+#  endif // clang and gcc
 // in MSVC _HAS_EXCEPTIONS is defined in a header instead of as a project define
 // so we can't do the automatic detection for MSVC without including some header
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#define DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#  ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+#    define DOCTEST_CONFIG_NO_EXCEPTIONS
+#  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
 #if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
-#define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#  define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
-#define DOCTEST_CONFIG_IMPLEMENT
+#  define DOCTEST_CONFIG_IMPLEMENT
 #endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #if defined _WIN32 || defined __CYGWIN__
-#if DOCTEST_MSVC
-#define DOCTEST_SYMBOL_EXPORT __declspec(dllexport)
-#define DOCTEST_SYMBOL_IMPORT __declspec(dllimport)
-#else // MSVC
-#define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
-#define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
-#endif // MSVC
-#else  // _WIN32
-#define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
-#define DOCTEST_SYMBOL_IMPORT
+#  if DOCTEST_MSVC
+#    define DOCTEST_SYMBOL_EXPORT __declspec(dllexport)
+#    define DOCTEST_SYMBOL_IMPORT __declspec(dllimport)
+#  else // MSVC
+#    define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
+#    define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
+#  endif // MSVC
+#else // _WIN32
+#  define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
+#  define DOCTEST_SYMBOL_IMPORT
 #endif // _WIN32
 
 #ifdef DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
-#ifdef DOCTEST_CONFIG_IMPLEMENT
-#define DOCTEST_INTERFACE DOCTEST_SYMBOL_EXPORT
-#else // DOCTEST_CONFIG_IMPLEMENT
-#define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
-#endif // DOCTEST_CONFIG_IMPLEMENT
-#else  // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
-#define DOCTEST_INTERFACE
+#  ifdef DOCTEST_CONFIG_IMPLEMENT
+#    define DOCTEST_INTERFACE DOCTEST_SYMBOL_EXPORT
+#  else // DOCTEST_CONFIG_IMPLEMENT
+#    define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
+#  endif // DOCTEST_CONFIG_IMPLEMENT
+#else // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#  define DOCTEST_INTERFACE
 #endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 
 #if DOCTEST_MSVC
-#define DOCTEST_NOINLINE __declspec(noinline)
-#define DOCTEST_UNUSED
+#  define DOCTEST_NOINLINE __declspec(noinline)
+#  define DOCTEST_UNUSED
 #else // MSVC
-#define DOCTEST_NOINLINE __attribute__((noinline))
-#define DOCTEST_UNUSED __attribute__((unused))
+#  define DOCTEST_NOINLINE __attribute__((noinline))
+#  define DOCTEST_UNUSED __attribute__((unused))
 #endif // MSVC
 
 #ifndef DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
-#define DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK 5
+#  define DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK 5
 #endif // DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
 
 // =================================================================================================
@@ -478,18 +472,18 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
 #define DOCTEST_CAT(s1, s2) DOCTEST_CAT_IMPL(s1, s2)
 #ifdef __COUNTER__ // not standard and may be missing for some compilers
-#define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __COUNTER__)
+#  define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __COUNTER__)
 #else // __COUNTER__
-#define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
+#  define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
 #endif // __COUNTER__
 
 // macro for making a string out of an identifier
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TOSTR_IMPL(...) #__VA_ARGS__
-#define DOCTEST_TOSTR(...) DOCTEST_TOSTR_IMPL(__VA_ARGS__)
+#  define DOCTEST_TOSTR_IMPL(...) #  __VA_ARGS__
+#  define DOCTEST_TOSTR(...) DOCTEST_TOSTR_IMPL(__VA_ARGS__)
 #else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TOSTR_IMPL(x) #x
-#define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
+#  define DOCTEST_TOSTR_IMPL(x) #  x
+#  define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for concatenating literals and making the result a string
@@ -499,132 +493,133 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #define DOCTEST_COUNTOF(x) (sizeof(x) / sizeof(x[0]))
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
-#define DOCTEST_REF_WRAP(x) x&
+#  define DOCTEST_REF_WRAP(x) x &
 #else // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
-#define DOCTEST_REF_WRAP(x) x
+#  define DOCTEST_REF_WRAP(x) x
 #endif // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 
 // not using __APPLE__ because... this is how Catch does it
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-#define DOCTEST_PLATFORM_MAC
+#  define DOCTEST_PLATFORM_MAC
 #elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-#define DOCTEST_PLATFORM_IPHONE
+#  define DOCTEST_PLATFORM_IPHONE
 #elif defined(_WIN32)
-#define DOCTEST_PLATFORM_WINDOWS
+#  define DOCTEST_PLATFORM_WINDOWS
 #else
-#define DOCTEST_PLATFORM_LINUX
+#  define DOCTEST_PLATFORM_LINUX
 #endif
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var)                                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors") static int var DOCTEST_UNUSED
+#define DOCTEST_GLOBAL_NO_WARNINGS(var) \
+  DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors") static int var DOCTEST_UNUSED
 #define DOCTEST_GLOBAL_NO_WARNINGS_END() DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 // should probably take a look at https://github.com/scottt/debugbreak
 #ifdef DOCTEST_PLATFORM_MAC
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
+#  define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
 #elif DOCTEST_MSVC
-#define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
+#  define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
 #elif defined(__MINGW32__)
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();
-#define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
+#  define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
 #else // linux
-#define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
+#  define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
 #endif // linux
 
 #if DOCTEST_CLANG
 // to detect if libc++ is being used with clang (the _LIBCPP_VERSION identifier)
-#include <ciso646>
+#  include <ciso646>
 #endif // clang
 
 #ifdef _LIBCPP_VERSION
 // not forward declaring ostream for libc++ because I had some problems (inline namespaces vs c++98)
 // so the <iosfwd> header is used - also it is very light and doesn't drag a ton of stuff
-#include <iosfwd>
+#  include <iosfwd>
 #else // _LIBCPP_VERSION
-#ifndef DOCTEST_CONFIG_USE_IOSFWD
+#  ifndef DOCTEST_CONFIG_USE_IOSFWD
 namespace std
 {
-template <class charT>
+template<class charT>
 struct char_traits;
-template <>
+template<>
 struct char_traits<char>;
-template <class charT, class traits>
+template<class charT, class traits>
 class basic_ostream;
-typedef basic_ostream<char, char_traits<char> > ostream;
+typedef basic_ostream<char, char_traits<char>> ostream;
 } // namespace std
-#else // DOCTEST_CONFIG_USE_IOSFWD
-#include <iosfwd>
-#endif // DOCTEST_CONFIG_USE_IOSFWD
+#  else // DOCTEST_CONFIG_USE_IOSFWD
+#    include <iosfwd>
+#  endif // DOCTEST_CONFIG_USE_IOSFWD
 #endif // _LIBCPP_VERSION
 
 // static assert macro - because of the c++98 support requires that the message is an
 // identifier (no spaces and not a C string) - example without quotes: I_am_a_message
 // taken from here: http://stackoverflow.com/a/1980156/3162383
 #ifdef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#define DOCTEST_STATIC_ASSERT(expression, message) static_assert(expression, #message)
+#  define DOCTEST_STATIC_ASSERT(expression, message) static_assert(expression, #  message)
 #else // DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#define DOCTEST_STATIC_ASSERT(expression, message)                                                 \
-    struct DOCTEST_CAT(__static_assertion_at_line_, __LINE__)                                      \
-    {                                                                                              \
-        doctest::detail::static_assert_impl::StaticAssertion<static_cast<bool>((expression))>      \
-                DOCTEST_CAT(DOCTEST_CAT(DOCTEST_CAT(STATIC_ASSERTION_FAILED_AT_LINE_, __LINE__),   \
-                                        _),                                                        \
-                            message);                                                              \
-    };                                                                                             \
-    typedef doctest::detail::static_assert_impl::StaticAssertionTest<static_cast<int>(             \
-            sizeof(DOCTEST_CAT(__static_assertion_at_line_, __LINE__)))>                           \
-            DOCTEST_CAT(__static_assertion_test_at_line_, __LINE__)
+#  define DOCTEST_STATIC_ASSERT(expression, message)                                                     \
+    struct DOCTEST_CAT(__static_assertion_at_line_, __LINE__)                                            \
+    {                                                                                                    \
+      doctest::detail::static_assert_impl::StaticAssertion<static_cast<bool>((expression))> DOCTEST_CAT( \
+          DOCTEST_CAT(DOCTEST_CAT(STATIC_ASSERTION_FAILED_AT_LINE_, __LINE__), _),                       \
+          message);                                                                                      \
+    };                                                                                                   \
+    typedef doctest::detail::static_assert_impl::StaticAssertionTest<static_cast<int>(                   \
+        sizeof(DOCTEST_CAT(__static_assertion_at_line_, __LINE__)))>                                     \
+        DOCTEST_CAT(__static_assertion_test_at_line_, __LINE__)
 #endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
 #ifdef DOCTEST_CONFIG_WITH_NULLPTR
-#ifdef _LIBCPP_VERSION
-#include <cstddef>
-#else  // _LIBCPP_VERSION
+#  ifdef _LIBCPP_VERSION
+#    include <cstddef>
+#  else // _LIBCPP_VERSION
 namespace std
 {
 typedef decltype(nullptr) nullptr_t;
 }
-#endif // _LIBCPP_VERSION
+#  endif // _LIBCPP_VERSION
 #endif // DOCTEST_CONFIG_WITH_NULLPTR
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-#include <type_traits>
-#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#  ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#    include <type_traits>
+#  endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
 namespace doctest
 {
 namespace detail
 {
-    struct TestSuite
-    {
-        const char* m_test_suite;
-        const char* m_description;
-        bool        m_skip;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
+struct TestSuite
+{
+  const char * m_test_suite;
+  const char * m_description;
+  bool m_skip;
+  bool m_may_fail;
+  bool m_should_fail;
+  int m_expected_failures;
+  double m_timeout;
 
-        TestSuite& operator*(const char* in) {
-            m_test_suite = in;
-            // clear state
-            m_description       = 0;
-            m_skip              = false;
-            m_may_fail          = false;
-            m_should_fail       = false;
-            m_expected_failures = 0;
-            m_timeout           = 0;
-            return *this;
-        }
+  TestSuite & operator*(const char * in)
+  {
+    m_test_suite = in;
+    // clear state
+    m_description = 0;
+    m_skip = false;
+    m_may_fail = false;
+    m_should_fail = false;
+    m_expected_failures = 0;
+    m_timeout = 0;
+    return *this;
+  }
 
-        template <typename T>
-        TestSuite& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
-    };
+  template<typename T>
+  TestSuite & operator*(const T & in)
+  {
+    in.fill(*this);
+    return *this;
+  }
+};
 } // namespace detail
 } // namespace doctest
 
@@ -632,7 +627,7 @@ namespace detail
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden
 namespace doctest_detail_test_suite_ns
 {
-DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
+DOCTEST_INTERFACE doctest::detail::TestSuite & getCurrentTestSuite();
 } // namespace doctest_detail_test_suite_ns
 
 #endif // DOCTEST_CONFIG_DISABLE
@@ -661,93 +656,100 @@ namespace doctest
 // - relational operators as free functions - taking const char* as one of the params
 class DOCTEST_INTERFACE String
 {
-    static const unsigned len  = 24;      //!OCLINT avoid private static members
-    static const unsigned last = len - 1; //!OCLINT avoid private static members
+  static const unsigned len = 24; //! OCLINT avoid private static members
+  static const unsigned last = len - 1; //! OCLINT avoid private static members
 
-    struct view // len should be more than sizeof(view) - because of the final byte for flags
-    {
-        char*    ptr;
-        unsigned size;
-        unsigned capacity;
-    };
+  struct view // len should be more than sizeof(view) - because of the final byte for flags
+  {
+    char * ptr;
+    unsigned size;
+    unsigned capacity;
+  };
 
-    union
-    {
-        char buf[len];
-        view data;
-    };
+  union {
+    char buf[len];
+    view data;
+  };
 
-    void copy(const String& other);
+  void copy(const String & other);
 
-    void setOnHeap() { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-    void setLast(unsigned in = last) { buf[last] = char(in); }
+  void setOnHeap() { *reinterpret_cast<unsigned char *>(&buf[last]) = 128; }
+  void setLast(unsigned in = last) { buf[last] = char(in); }
 
 public:
-    String() {
-        buf[0] = '\0';
-        setLast();
+  String()
+  {
+    buf[0] = '\0';
+    setLast();
+  }
+
+  String(const char * in);
+
+  String(const String & other) { copy(other); }
+
+  ~String()
+  {
+    if(!isOnStack())
+      delete[] data.ptr;
+  }
+
+  // GCC 4.9/5/6 report Wstrict-overflow when optimizations are ON and it got inlined in the vector class somewhere...
+  // see commit 574ef95f0cd379118be5011704664e4b5351f1e0 and build https://travis-ci.org/onqtam/doctest/builds/230671611
+  DOCTEST_NOINLINE String & operator=(const String & other)
+  {
+    if(this != &other)
+    {
+      if(!isOnStack())
+        delete[] data.ptr;
+
+      copy(other);
     }
 
-    String(const char* in);
+    return *this;
+  }
+  String & operator+=(const String & other);
 
-    String(const String& other) { copy(other); }
-
-    ~String() {
-        if(!isOnStack())
-            delete[] data.ptr;
-    }
-
-    // GCC 4.9/5/6 report Wstrict-overflow when optimizations are ON and it got inlined in the vector class somewhere...
-    // see commit 574ef95f0cd379118be5011704664e4b5351f1e0 and build https://travis-ci.org/onqtam/doctest/builds/230671611
-    DOCTEST_NOINLINE String& operator=(const String& other) {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-
-            copy(other);
-        }
-
-        return *this;
-    }
-    String& operator+=(const String& other);
-
-    String operator+(const String& other) const { return String(*this) += other; }
+  String operator+(const String & other) const { return String(*this) += other; }
 
 #ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-    String(String&& other);
-    String& operator=(String&& other);
+  String(String && other);
+  String & operator=(String && other);
 #endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 
-    bool isOnStack() const { return (buf[last] & 128) == 0; }
+  bool isOnStack() const { return (buf[last] & 128) == 0; }
 
-    char operator[](unsigned i) const { return const_cast<String*>(this)->operator[](i); } // NOLINT
-    char& operator[](unsigned i) {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf)[i];
-        return data.ptr[i];
-    }
+  char operator[](unsigned i) const { return const_cast<String *>(this)->operator[](i); } // NOLINT
+  char & operator[](unsigned i)
+  {
+    if(isOnStack())
+      return reinterpret_cast<char *>(buf)[i];
+    return data.ptr[i];
+  }
 
-    const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-    char*       c_str() {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf);
-        return data.ptr;
-    }
+  const char * c_str() const { return const_cast<String *>(this)->c_str(); } // NOLINT
+  char * c_str()
+  {
+    if(isOnStack())
+      return reinterpret_cast<char *>(buf);
+    return data.ptr;
+  }
 
-    unsigned size() const {
-        if(isOnStack())
-            return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
-        return data.size;
-    }
+  unsigned size() const
+  {
+    if(isOnStack())
+      return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
+    return data.size;
+  }
 
-    unsigned capacity() const {
-        if(isOnStack())
-            return len;
-        return data.capacity;
-    }
+  unsigned capacity() const
+  {
+    if(isOnStack())
+      return len;
+    return data.capacity;
+  }
 
-    int compare(const char* other, bool no_case = false) const;
-    int compare(const String& other, bool no_case = false) const;
+  int compare(const char * other, bool no_case = false) const;
+  int compare(const String & other, bool no_case = false) const;
 };
 
 // clang-format off
@@ -759,247 +761,351 @@ inline bool operator<=(const String& lhs, const String& rhs) { return (lhs != rh
 inline bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
 // clang-format on
 
-DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& stream, const String& in);
+DOCTEST_INTERFACE std::ostream & operator<<(std::ostream & stream, const String & in);
 
 namespace detail
 {
 #ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-    namespace static_assert_impl
-    {
-        template <bool>
-        struct StaticAssertion;
+namespace static_assert_impl
+{
+template<bool>
+struct StaticAssertion;
 
-        template <>
-        struct StaticAssertion<true>
-        {};
+template<>
+struct StaticAssertion<true>
+{
+};
 
-        template <int i>
-        struct StaticAssertionTest
-        {};
-    }  // namespace static_assert_impl
+template<int i>
+struct StaticAssertionTest
+{
+};
+} // namespace static_assert_impl
 #endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
-    template <bool CONDITION, typename TYPE = void>
-    struct enable_if
-    {};
+template<bool CONDITION, typename TYPE = void>
+struct enable_if
+{
+};
 
-    template <typename TYPE>
-    struct enable_if<true, TYPE>
-    { typedef TYPE type; };
+template<typename TYPE>
+struct enable_if<true, TYPE>
+{
+  typedef TYPE type;
+};
 
-    template <typename T>
-    struct deferred_false
-    // cppcheck-suppress unusedStructMember
-    { static const bool value = false; };
+template<typename T>
+struct deferred_false
+// cppcheck-suppress unusedStructMember
+{
+  static const bool value = false;
+};
 
-    // to silence the warning "-Wzero-as-null-pointer-constant" only for gcc 5 for the Approx template ctor - pragmas don't work for it...
-    inline void* getNull() { return 0; }
+// to silence the warning "-Wzero-as-null-pointer-constant" only for gcc 5 for the Approx template ctor - pragmas don't
+// work for it...
+inline void * getNull() { return 0; }
 
-    namespace has_insertion_operator_impl
-    {
-        typedef char no;
-        typedef char yes[2];
+namespace has_insertion_operator_impl
+{
+typedef char no;
+typedef char yes[2];
 
-        struct any_t
-        {
-            template <typename T>
-            // cppcheck-suppress noExplicitConstructor
-            any_t(const DOCTEST_REF_WRAP(T));
-        };
+struct any_t
+{
+  template<typename T>
+  // cppcheck-suppress noExplicitConstructor
+  any_t(const DOCTEST_REF_WRAP(T));
+};
 
-        yes& testStreamable(std::ostream&);
-        no   testStreamable(no);
+yes & testStreamable(std::ostream &);
+no testStreamable(no);
 
-        no operator<<(const std::ostream&, const any_t&);
+no operator<<(const std::ostream &, const any_t &);
 
-        template <typename T>
-        struct has_insertion_operator
-        {
-            static std::ostream& s;
-            static const DOCTEST_REF_WRAP(T) t;
-            static const bool value = sizeof(testStreamable(s << t)) == sizeof(yes);
-        };
-    } // namespace has_insertion_operator_impl
+template<typename T>
+struct has_insertion_operator
+{
+  static std::ostream & s;
+  static const DOCTEST_REF_WRAP(T) t;
+  static const bool value = sizeof(testStreamable(s << t)) == sizeof(yes);
+};
+} // namespace has_insertion_operator_impl
 
-    template <typename T>
-    struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
-    {};
+template<typename T>
+struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
+{
+};
 
-    DOCTEST_INTERFACE void     my_memcpy(void* dest, const void* src, unsigned num);
-    DOCTEST_INTERFACE unsigned my_strlen(const char* in);
+DOCTEST_INTERFACE void my_memcpy(void * dest, const void * src, unsigned num);
+DOCTEST_INTERFACE unsigned my_strlen(const char * in);
 
-    DOCTEST_INTERFACE std::ostream* createStream();
-    DOCTEST_INTERFACE String getStreamResult(std::ostream*);
-    DOCTEST_INTERFACE void   freeStream(std::ostream*);
+DOCTEST_INTERFACE std::ostream * createStream();
+DOCTEST_INTERFACE String getStreamResult(std::ostream *);
+DOCTEST_INTERFACE void freeStream(std::ostream *);
 
-    template <bool C>
-    struct StringMakerBase
-    {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T)) {
-            return "{?}";
-        }
-    };
+template<bool C>
+struct StringMakerBase
+{
+  template<typename T>
+  static String convert(const DOCTEST_REF_WRAP(T))
+  {
+    return "{?}";
+  }
+};
 
-    template <>
-    struct StringMakerBase<true>
-    {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T) in) {
-            std::ostream* stream = createStream();
-            *stream << in;
-            String result = getStreamResult(stream);
-            freeStream(stream);
-            return result;
-        }
-    };
+template<>
+struct StringMakerBase<true>
+{
+  template<typename T>
+  static String convert(const DOCTEST_REF_WRAP(T) in)
+  {
+    std::ostream * stream = createStream();
+    *stream << in;
+    String result = getStreamResult(stream);
+    freeStream(stream);
+    return result;
+  }
+};
 
-    DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
+DOCTEST_INTERFACE String rawMemoryToString(const void * object, unsigned size);
 
-    template <typename T>
-    String rawMemoryToString(const DOCTEST_REF_WRAP(T) object) {
-        return rawMemoryToString(&object, sizeof(object));
-    }
+template<typename T>
+String rawMemoryToString(const DOCTEST_REF_WRAP(T) object)
+{
+  return rawMemoryToString(&object, sizeof(object));
+}
 
-    class NullType
-    {
-    };
+class NullType
+{
+};
 
-    template <class T, class U>
-    struct Typelist
-    {
-        typedef T Head;
-        typedef U Tail;
-    };
+template<class T, class U>
+struct Typelist
+{
+  typedef T Head;
+  typedef U Tail;
+};
 
-    // type of recursive function
-    template <class TList, class Callable>
-    struct ForEachType;
+// type of recursive function
+template<class TList, class Callable>
+struct ForEachType;
 
-    // Recursion rule
-    template <class Head, class Tail, class Callable>
-    struct ForEachType<Typelist<Head, Tail>, Callable> : public ForEachType<Tail, Callable>
-    {
-        enum
-        {
-            value = 1 + ForEachType<Tail, Callable>::value
-        };
+// Recursion rule
+template<class Head, class Tail, class Callable>
+struct ForEachType<Typelist<Head, Tail>, Callable> : public ForEachType<Tail, Callable>
+{
+  enum
+  {
+    value = 1 + ForEachType<Tail, Callable>::value
+  };
 
-        explicit ForEachType(Callable& callable)
-                : ForEachType<Tail, Callable>(callable) {
+  explicit ForEachType(Callable & callable) : ForEachType<Tail, Callable>(callable)
+  {
 #if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 10, 0)
-            callable.operator()<value, Head>();
-#else  // MSVC
-            callable.template operator()<value, Head>();
+    callable.operator()<value, Head>();
+#else // MSVC
+    callable.template operator()<value, Head>();
 #endif // MSVC
-        }
-    };
+  }
+};
 
-    // Recursion end
-    template <class Head, class Callable>
-    struct ForEachType<Typelist<Head, NullType>, Callable>
-    {
-    public:
-        enum
-        {
-            value = 0
-        };
+// Recursion end
+template<class Head, class Callable>
+struct ForEachType<Typelist<Head, NullType>, Callable>
+{
+public:
+  enum
+  {
+    value = 0
+  };
 
-        explicit ForEachType(Callable& callable) {
+  explicit ForEachType(Callable & callable)
+  {
 #if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 10, 0)
-            callable.operator()<value, Head>();
-#else  // MSVC
-            callable.template operator()<value, Head>();
+    callable.operator()<value, Head>();
+#else // MSVC
+    callable.template operator()<value, Head>();
 #endif // MSVC
-        }
-    };
+  }
+};
 
-    template <typename T>
-    const char* type_to_string() {
-        return "<>";
-    }
+template<typename T>
+const char * type_to_string()
+{
+  return "<>";
+}
 } // namespace detail
 
-template <typename T1 = detail::NullType, typename T2 = detail::NullType,
-          typename T3 = detail::NullType, typename T4 = detail::NullType,
-          typename T5 = detail::NullType, typename T6 = detail::NullType,
-          typename T7 = detail::NullType, typename T8 = detail::NullType,
-          typename T9 = detail::NullType, typename T10 = detail::NullType,
-          typename T11 = detail::NullType, typename T12 = detail::NullType,
-          typename T13 = detail::NullType, typename T14 = detail::NullType,
-          typename T15 = detail::NullType, typename T16 = detail::NullType,
-          typename T17 = detail::NullType, typename T18 = detail::NullType,
-          typename T19 = detail::NullType, typename T20 = detail::NullType,
-          typename T21 = detail::NullType, typename T22 = detail::NullType,
-          typename T23 = detail::NullType, typename T24 = detail::NullType,
-          typename T25 = detail::NullType, typename T26 = detail::NullType,
-          typename T27 = detail::NullType, typename T28 = detail::NullType,
-          typename T29 = detail::NullType, typename T30 = detail::NullType,
-          typename T31 = detail::NullType, typename T32 = detail::NullType,
-          typename T33 = detail::NullType, typename T34 = detail::NullType,
-          typename T35 = detail::NullType, typename T36 = detail::NullType,
-          typename T37 = detail::NullType, typename T38 = detail::NullType,
-          typename T39 = detail::NullType, typename T40 = detail::NullType,
-          typename T41 = detail::NullType, typename T42 = detail::NullType,
-          typename T43 = detail::NullType, typename T44 = detail::NullType,
-          typename T45 = detail::NullType, typename T46 = detail::NullType,
-          typename T47 = detail::NullType, typename T48 = detail::NullType,
-          typename T49 = detail::NullType, typename T50 = detail::NullType,
-          typename T51 = detail::NullType, typename T52 = detail::NullType,
-          typename T53 = detail::NullType, typename T54 = detail::NullType,
-          typename T55 = detail::NullType, typename T56 = detail::NullType,
-          typename T57 = detail::NullType, typename T58 = detail::NullType,
-          typename T59 = detail::NullType, typename T60 = detail::NullType>
+template<typename T1 = detail::NullType,
+         typename T2 = detail::NullType,
+         typename T3 = detail::NullType,
+         typename T4 = detail::NullType,
+         typename T5 = detail::NullType,
+         typename T6 = detail::NullType,
+         typename T7 = detail::NullType,
+         typename T8 = detail::NullType,
+         typename T9 = detail::NullType,
+         typename T10 = detail::NullType,
+         typename T11 = detail::NullType,
+         typename T12 = detail::NullType,
+         typename T13 = detail::NullType,
+         typename T14 = detail::NullType,
+         typename T15 = detail::NullType,
+         typename T16 = detail::NullType,
+         typename T17 = detail::NullType,
+         typename T18 = detail::NullType,
+         typename T19 = detail::NullType,
+         typename T20 = detail::NullType,
+         typename T21 = detail::NullType,
+         typename T22 = detail::NullType,
+         typename T23 = detail::NullType,
+         typename T24 = detail::NullType,
+         typename T25 = detail::NullType,
+         typename T26 = detail::NullType,
+         typename T27 = detail::NullType,
+         typename T28 = detail::NullType,
+         typename T29 = detail::NullType,
+         typename T30 = detail::NullType,
+         typename T31 = detail::NullType,
+         typename T32 = detail::NullType,
+         typename T33 = detail::NullType,
+         typename T34 = detail::NullType,
+         typename T35 = detail::NullType,
+         typename T36 = detail::NullType,
+         typename T37 = detail::NullType,
+         typename T38 = detail::NullType,
+         typename T39 = detail::NullType,
+         typename T40 = detail::NullType,
+         typename T41 = detail::NullType,
+         typename T42 = detail::NullType,
+         typename T43 = detail::NullType,
+         typename T44 = detail::NullType,
+         typename T45 = detail::NullType,
+         typename T46 = detail::NullType,
+         typename T47 = detail::NullType,
+         typename T48 = detail::NullType,
+         typename T49 = detail::NullType,
+         typename T50 = detail::NullType,
+         typename T51 = detail::NullType,
+         typename T52 = detail::NullType,
+         typename T53 = detail::NullType,
+         typename T54 = detail::NullType,
+         typename T55 = detail::NullType,
+         typename T56 = detail::NullType,
+         typename T57 = detail::NullType,
+         typename T58 = detail::NullType,
+         typename T59 = detail::NullType,
+         typename T60 = detail::NullType>
 struct Types
 {
 private:
-    typedef typename Types<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17,
-                           T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31,
-                           T32, T33, T34, T35, T36, T37, T38, T39, T40, T41, T42, T43, T44, T45,
-                           T46, T47, T48, T49, T50, T51, T52, T53, T54, T55, T56, T57, T58, T59,
-                           T60>::Result TailResult;
+  typedef typename Types<T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17,
+                         T18,
+                         T19,
+                         T20,
+                         T21,
+                         T22,
+                         T23,
+                         T24,
+                         T25,
+                         T26,
+                         T27,
+                         T28,
+                         T29,
+                         T30,
+                         T31,
+                         T32,
+                         T33,
+                         T34,
+                         T35,
+                         T36,
+                         T37,
+                         T38,
+                         T39,
+                         T40,
+                         T41,
+                         T42,
+                         T43,
+                         T44,
+                         T45,
+                         T46,
+                         T47,
+                         T48,
+                         T49,
+                         T50,
+                         T51,
+                         T52,
+                         T53,
+                         T54,
+                         T55,
+                         T56,
+                         T57,
+                         T58,
+                         T59,
+                         T60>::Result TailResult;
 
 public:
-    typedef detail::Typelist<T1, TailResult> Result;
+  typedef detail::Typelist<T1, TailResult> Result;
 };
 
-template <>
+template<>
 struct Types<>
-{ typedef detail::NullType Result; };
-
-template <typename T>
-struct StringMaker : detail::StringMakerBase<detail::has_insertion_operator<T>::value>
-{};
-
-template <typename T>
-struct StringMaker<T*>
 {
-    template <typename U>
-    static String convert(U* p) {
-        if(p)
-            return detail::rawMemoryToString(p);
-        return "NULL";
-    }
+  typedef detail::NullType Result;
 };
 
-template <typename R, typename C>
+template<typename T>
+struct StringMaker : detail::StringMakerBase<detail::has_insertion_operator<T>::value>
+{
+};
+
+template<typename T>
+struct StringMaker<T *>
+{
+  template<typename U>
+  static String convert(U * p)
+  {
+    if(p)
+      return detail::rawMemoryToString(p);
+    return "NULL";
+  }
+};
+
+template<typename R, typename C>
 struct StringMaker<R C::*>
 {
-    static String convert(R C::*p) {
-        if(p)
-            return detail::rawMemoryToString(p);
-        return "NULL";
-    }
+  static String convert(R C::*p)
+  {
+    if(p)
+      return detail::rawMemoryToString(p);
+    return "NULL";
+  }
 };
 
-template <typename T>
-String toString(const DOCTEST_REF_WRAP(T) value) {
-    return StringMaker<T>::convert(value);
+template<typename T>
+String toString(const DOCTEST_REF_WRAP(T) value)
+{
+  return StringMaker<T>::convert(value);
 }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-DOCTEST_INTERFACE String toString(char* in);
-DOCTEST_INTERFACE String toString(const char* in);
+DOCTEST_INTERFACE String toString(char * in);
+DOCTEST_INTERFACE String toString(const char * in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 DOCTEST_INTERFACE String toString(bool in);
 DOCTEST_INTERFACE String toString(float in);
@@ -1028,25 +1134,27 @@ DOCTEST_INTERFACE String toString(std::nullptr_t in);
 class DOCTEST_INTERFACE Approx
 {
 public:
-    explicit Approx(double value);
+  explicit Approx(double value);
 
-    Approx operator()(double value) const {
-        Approx approx(value);
-        approx.epsilon(m_epsilon);
-        approx.scale(m_scale);
-        return approx;
-    }
+  Approx operator()(double value) const
+  {
+    Approx approx(value);
+    approx.epsilon(m_epsilon);
+    approx.scale(m_scale);
+    return approx;
+  }
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-    template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(detail::getNull())) {
-        *this = Approx(static_cast<double>(value));
-    }
+  template<typename T>
+  explicit Approx(
+      const T & value,
+      typename detail::enable_if<std::is_constructible<double, T>::value>::type * = static_cast<T *>(detail::getNull()))
+  {
+    *this = Approx(static_cast<double>(value));
+  }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    // clang-format off
+  // clang-format off
     // overloads for double - the first one is necessary as it is in the implementation part of doctest
     // as for the others - keeping them for potentially faster compile times
     DOCTEST_INTERFACE friend bool operator==(double lhs, Approx const& rhs);
@@ -1081,174 +1189,177 @@ public:
 #undef DOCTEST_APPROX_PREFIX
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    // clang-format on
+  // clang-format on
 
-    Approx& epsilon(double newEpsilon) {
-        m_epsilon = newEpsilon;
-        return *this;
-    }
+  Approx & epsilon(double newEpsilon)
+  {
+    m_epsilon = newEpsilon;
+    return *this;
+  }
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-    template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
-            const T& newEpsilon) {
-        m_epsilon = static_cast<double>(newEpsilon);
-        return *this;
-    }
+  template<typename T>
+  typename detail::enable_if<std::is_constructible<double, T>::value, Approx &>::type epsilon(const T & newEpsilon)
+  {
+    m_epsilon = static_cast<double>(newEpsilon);
+    return *this;
+  }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& scale(double newScale) {
-        m_scale = newScale;
-        return *this;
-    }
+  Approx & scale(double newScale)
+  {
+    m_scale = newScale;
+    return *this;
+  }
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-    template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
-            const T& newScale) {
-        m_scale = static_cast<double>(newScale);
-        return *this;
-    }
+  template<typename T>
+  typename detail::enable_if<std::is_constructible<double, T>::value, Approx &>::type scale(const T & newScale)
+  {
+    m_scale = static_cast<double>(newScale);
+    return *this;
+  }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    String toString() const;
+  String toString() const;
 
 private:
-    double m_epsilon;
-    double m_scale;
-    double m_value;
+  double m_epsilon;
+  double m_scale;
+  double m_value;
 };
 
-template <>
-inline String toString<Approx>(const DOCTEST_REF_WRAP(Approx) value) {
-    return value.toString();
+template<>
+inline String toString<Approx>(const DOCTEST_REF_WRAP(Approx) value)
+{
+  return value.toString();
 }
 
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
 namespace detail
 {
-    // the function type this library works with
-    typedef void (*funcType)();
+// the function type this library works with
+typedef void (*funcType)();
 
-    namespace assertType
-    {
-        enum Enum
-        {
-            // macro traits
+namespace assertType
+{
+enum Enum
+{
+  // macro traits
 
-            is_warn    = 1,
-            is_check   = 2,
-            is_require = 4,
+  is_warn = 1,
+  is_check = 2,
+  is_require = 4,
 
-            is_throws    = 8,
-            is_throws_as = 16,
-            is_nothrow   = 32,
+  is_throws = 8,
+  is_throws_as = 16,
+  is_nothrow = 32,
 
-            is_fast  = 64, // not checked anywhere - used just to distinguish the types
-            is_false = 128,
-            is_unary = 256,
+  is_fast = 64, // not checked anywhere - used just to distinguish the types
+  is_false = 128,
+  is_unary = 256,
 
-            is_eq = 512,
-            is_ne = 1024,
+  is_eq = 512,
+  is_ne = 1024,
 
-            is_lt = 2048,
-            is_gt = 4096,
+  is_lt = 2048,
+  is_gt = 4096,
 
-            is_ge = 8192,
-            is_le = 16384,
+  is_ge = 8192,
+  is_le = 16384,
 
-            // macro types
+  // macro types
 
-            DT_WARN    = is_warn,
-            DT_CHECK   = is_check,
-            DT_REQUIRE = is_require,
+  DT_WARN = is_warn,
+  DT_CHECK = is_check,
+  DT_REQUIRE = is_require,
 
-            DT_WARN_FALSE    = is_false | is_warn,
-            DT_CHECK_FALSE   = is_false | is_check,
-            DT_REQUIRE_FALSE = is_false | is_require,
+  DT_WARN_FALSE = is_false | is_warn,
+  DT_CHECK_FALSE = is_false | is_check,
+  DT_REQUIRE_FALSE = is_false | is_require,
 
-            DT_WARN_THROWS    = is_throws | is_warn,
-            DT_CHECK_THROWS   = is_throws | is_check,
-            DT_REQUIRE_THROWS = is_throws | is_require,
+  DT_WARN_THROWS = is_throws | is_warn,
+  DT_CHECK_THROWS = is_throws | is_check,
+  DT_REQUIRE_THROWS = is_throws | is_require,
 
-            DT_WARN_THROWS_AS    = is_throws_as | is_warn,
-            DT_CHECK_THROWS_AS   = is_throws_as | is_check,
-            DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
+  DT_WARN_THROWS_AS = is_throws_as | is_warn,
+  DT_CHECK_THROWS_AS = is_throws_as | is_check,
+  DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
 
-            DT_WARN_NOTHROW    = is_nothrow | is_warn,
-            DT_CHECK_NOTHROW   = is_nothrow | is_check,
-            DT_REQUIRE_NOTHROW = is_nothrow | is_require,
+  DT_WARN_NOTHROW = is_nothrow | is_warn,
+  DT_CHECK_NOTHROW = is_nothrow | is_check,
+  DT_REQUIRE_NOTHROW = is_nothrow | is_require,
 
-            DT_WARN_EQ    = is_eq | is_warn,
-            DT_CHECK_EQ   = is_eq | is_check,
-            DT_REQUIRE_EQ = is_eq | is_require,
+  DT_WARN_EQ = is_eq | is_warn,
+  DT_CHECK_EQ = is_eq | is_check,
+  DT_REQUIRE_EQ = is_eq | is_require,
 
-            DT_WARN_NE    = is_ne | is_warn,
-            DT_CHECK_NE   = is_ne | is_check,
-            DT_REQUIRE_NE = is_ne | is_require,
+  DT_WARN_NE = is_ne | is_warn,
+  DT_CHECK_NE = is_ne | is_check,
+  DT_REQUIRE_NE = is_ne | is_require,
 
-            DT_WARN_GT    = is_gt | is_warn,
-            DT_CHECK_GT   = is_gt | is_check,
-            DT_REQUIRE_GT = is_gt | is_require,
+  DT_WARN_GT = is_gt | is_warn,
+  DT_CHECK_GT = is_gt | is_check,
+  DT_REQUIRE_GT = is_gt | is_require,
 
-            DT_WARN_LT    = is_lt | is_warn,
-            DT_CHECK_LT   = is_lt | is_check,
-            DT_REQUIRE_LT = is_lt | is_require,
+  DT_WARN_LT = is_lt | is_warn,
+  DT_CHECK_LT = is_lt | is_check,
+  DT_REQUIRE_LT = is_lt | is_require,
 
-            DT_WARN_GE    = is_ge | is_warn,
-            DT_CHECK_GE   = is_ge | is_check,
-            DT_REQUIRE_GE = is_ge | is_require,
+  DT_WARN_GE = is_ge | is_warn,
+  DT_CHECK_GE = is_ge | is_check,
+  DT_REQUIRE_GE = is_ge | is_require,
 
-            DT_WARN_LE    = is_le | is_warn,
-            DT_CHECK_LE   = is_le | is_check,
-            DT_REQUIRE_LE = is_le | is_require,
+  DT_WARN_LE = is_le | is_warn,
+  DT_CHECK_LE = is_le | is_check,
+  DT_REQUIRE_LE = is_le | is_require,
 
-            DT_WARN_UNARY    = is_unary | is_warn,
-            DT_CHECK_UNARY   = is_unary | is_check,
-            DT_REQUIRE_UNARY = is_unary | is_require,
+  DT_WARN_UNARY = is_unary | is_warn,
+  DT_CHECK_UNARY = is_unary | is_check,
+  DT_REQUIRE_UNARY = is_unary | is_require,
 
-            DT_WARN_UNARY_FALSE    = is_false | is_unary | is_warn,
-            DT_CHECK_UNARY_FALSE   = is_false | is_unary | is_check,
-            DT_REQUIRE_UNARY_FALSE = is_false | is_unary | is_require,
+  DT_WARN_UNARY_FALSE = is_false | is_unary | is_warn,
+  DT_CHECK_UNARY_FALSE = is_false | is_unary | is_check,
+  DT_REQUIRE_UNARY_FALSE = is_false | is_unary | is_require,
 
-            DT_FAST_WARN_EQ    = is_fast | is_eq | is_warn,
-            DT_FAST_CHECK_EQ   = is_fast | is_eq | is_check,
-            DT_FAST_REQUIRE_EQ = is_fast | is_eq | is_require,
+  DT_FAST_WARN_EQ = is_fast | is_eq | is_warn,
+  DT_FAST_CHECK_EQ = is_fast | is_eq | is_check,
+  DT_FAST_REQUIRE_EQ = is_fast | is_eq | is_require,
 
-            DT_FAST_WARN_NE    = is_fast | is_ne | is_warn,
-            DT_FAST_CHECK_NE   = is_fast | is_ne | is_check,
-            DT_FAST_REQUIRE_NE = is_fast | is_ne | is_require,
+  DT_FAST_WARN_NE = is_fast | is_ne | is_warn,
+  DT_FAST_CHECK_NE = is_fast | is_ne | is_check,
+  DT_FAST_REQUIRE_NE = is_fast | is_ne | is_require,
 
-            DT_FAST_WARN_GT    = is_fast | is_gt | is_warn,
-            DT_FAST_CHECK_GT   = is_fast | is_gt | is_check,
-            DT_FAST_REQUIRE_GT = is_fast | is_gt | is_require,
+  DT_FAST_WARN_GT = is_fast | is_gt | is_warn,
+  DT_FAST_CHECK_GT = is_fast | is_gt | is_check,
+  DT_FAST_REQUIRE_GT = is_fast | is_gt | is_require,
 
-            DT_FAST_WARN_LT    = is_fast | is_lt | is_warn,
-            DT_FAST_CHECK_LT   = is_fast | is_lt | is_check,
-            DT_FAST_REQUIRE_LT = is_fast | is_lt | is_require,
+  DT_FAST_WARN_LT = is_fast | is_lt | is_warn,
+  DT_FAST_CHECK_LT = is_fast | is_lt | is_check,
+  DT_FAST_REQUIRE_LT = is_fast | is_lt | is_require,
 
-            DT_FAST_WARN_GE    = is_fast | is_ge | is_warn,
-            DT_FAST_CHECK_GE   = is_fast | is_ge | is_check,
-            DT_FAST_REQUIRE_GE = is_fast | is_ge | is_require,
+  DT_FAST_WARN_GE = is_fast | is_ge | is_warn,
+  DT_FAST_CHECK_GE = is_fast | is_ge | is_check,
+  DT_FAST_REQUIRE_GE = is_fast | is_ge | is_require,
 
-            DT_FAST_WARN_LE    = is_fast | is_le | is_warn,
-            DT_FAST_CHECK_LE   = is_fast | is_le | is_check,
-            DT_FAST_REQUIRE_LE = is_fast | is_le | is_require,
+  DT_FAST_WARN_LE = is_fast | is_le | is_warn,
+  DT_FAST_CHECK_LE = is_fast | is_le | is_check,
+  DT_FAST_REQUIRE_LE = is_fast | is_le | is_require,
 
-            DT_FAST_WARN_UNARY    = is_fast | is_unary | is_warn,
-            DT_FAST_CHECK_UNARY   = is_fast | is_unary | is_check,
-            DT_FAST_REQUIRE_UNARY = is_fast | is_unary | is_require,
+  DT_FAST_WARN_UNARY = is_fast | is_unary | is_warn,
+  DT_FAST_CHECK_UNARY = is_fast | is_unary | is_check,
+  DT_FAST_REQUIRE_UNARY = is_fast | is_unary | is_require,
 
-            DT_FAST_WARN_UNARY_FALSE    = is_fast | is_false | is_unary | is_warn,
-            DT_FAST_CHECK_UNARY_FALSE   = is_fast | is_false | is_unary | is_check,
-            DT_FAST_REQUIRE_UNARY_FALSE = is_fast | is_false | is_unary | is_require
-        };
-    } // namespace assertType
+  DT_FAST_WARN_UNARY_FALSE = is_fast | is_false | is_unary | is_warn,
+  DT_FAST_CHECK_UNARY_FALSE = is_fast | is_false | is_unary | is_check,
+  DT_FAST_REQUIRE_UNARY_FALSE = is_fast | is_false | is_unary | is_require
+};
+} // namespace assertType
 
-    DOCTEST_INTERFACE const char* getAssertString(assertType::Enum val);
+DOCTEST_INTERFACE const char * getAssertString(assertType::Enum val);
 
-    // clang-format off
+// clang-format off
     template<class T>               struct decay_array       { typedef T type; };
     template<class T, unsigned N>   struct decay_array<T[N]> { typedef T* type; };
     template<class T>               struct decay_array<T[]>  { typedef T* type; };
@@ -1258,79 +1369,75 @@ namespace detail
     template<>          struct not_char_pointer<const char*> { enum { value = 0 }; };
 
     template<class T> struct can_use_op : not_char_pointer<typename decay_array<T>::type> {};
-    // clang-format on
+// clang-format on
 
-    struct TestFailureException
-    {
-    };
+struct TestFailureException
+{
+};
 
-    DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum assert_type);
-    DOCTEST_INTERFACE void fastAssertThrowIfFlagSet(int flags);
-    DOCTEST_INTERFACE void throwException();
+DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum assert_type);
+DOCTEST_INTERFACE void fastAssertThrowIfFlagSet(int flags);
+DOCTEST_INTERFACE void throwException();
 
-    struct TestAccessibleContextState
-    {
-        bool no_throw; // to skip exceptions-related assertion macros
-        bool success;  // include successful assertions in output
-    };
+struct TestAccessibleContextState
+{
+  bool no_throw; // to skip exceptions-related assertion macros
+  bool success; // include successful assertions in output
+};
 
-    struct ContextState;
+struct ContextState;
 
-    DOCTEST_INTERFACE TestAccessibleContextState* getTestsContextState();
+DOCTEST_INTERFACE TestAccessibleContextState * getTestsContextState();
 
-    struct DOCTEST_INTERFACE SubcaseSignature
-    {
-        const char* m_name;
-        const char* m_file;
-        int         m_line;
+struct DOCTEST_INTERFACE SubcaseSignature
+{
+  const char * m_name;
+  const char * m_file;
+  int m_line;
 
-        SubcaseSignature(const char* name, const char* file, int line)
-                : m_name(name)
-                , m_file(file)
-                , m_line(line) {}
+  SubcaseSignature(const char * name, const char * file, int line) : m_name(name), m_file(file), m_line(line) {}
 
-        bool operator<(const SubcaseSignature& other) const;
-    };
+  bool operator<(const SubcaseSignature & other) const;
+};
 
-    // cppcheck-suppress copyCtorAndEqOperator
-    struct DOCTEST_INTERFACE Subcase
-    {
-        SubcaseSignature m_signature;
-        bool             m_entered;
+// cppcheck-suppress copyCtorAndEqOperator
+struct DOCTEST_INTERFACE Subcase
+{
+  SubcaseSignature m_signature;
+  bool m_entered;
 
-        Subcase(const char* name, const char* file, int line);
-        Subcase(const Subcase& other);
-        ~Subcase();
+  Subcase(const char * name, const char * file, int line);
+  Subcase(const Subcase & other);
+  ~Subcase();
 
-        operator bool() const { return m_entered; }
-    };
+  operator bool() const { return m_entered; }
+};
 
-    template <typename L, typename R>
-    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
-                               const DOCTEST_REF_WRAP(R) rhs) {
-        return toString(lhs) + op + toString(rhs);
-    }
+template<typename L, typename R>
+String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char * op, const DOCTEST_REF_WRAP(R) rhs)
+{
+  return toString(lhs) + op + toString(rhs);
+}
 
-    struct DOCTEST_INTERFACE Result
-    {
-        bool   m_passed;
-        String m_decomposition;
+struct DOCTEST_INTERFACE Result
+{
+  bool m_passed;
+  String m_decomposition;
 
-        ~Result();
+  ~Result();
 
-        DOCTEST_NOINLINE Result(bool passed = false, const String& decomposition = String())
-                : m_passed(passed)
-                , m_decomposition(decomposition) {}
+  DOCTEST_NOINLINE Result(bool passed = false, const String & decomposition = String())
+  : m_passed(passed), m_decomposition(decomposition)
+  {
+  }
 
-        DOCTEST_NOINLINE Result(const Result& other)
-                : m_passed(other.m_passed)
-                , m_decomposition(other.m_decomposition) {}
+  DOCTEST_NOINLINE Result(const Result & other) : m_passed(other.m_passed), m_decomposition(other.m_decomposition) {}
 
-        Result& operator=(const Result& other);
+  Result & operator=(const Result & other);
 
-        operator bool() { return !m_passed; }
+  operator bool() { return !m_passed; }
 
-        // clang-format off
+  // clang-format off
         // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
         template <typename R> Result& operator&  (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
         template <typename R> Result& operator^  (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
@@ -1354,35 +1461,35 @@ namespace detail
         template <typename R> Result& operator&= (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
         template <typename R> Result& operator^= (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
         template <typename R> Result& operator|= (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
-        // clang-format on
-    };
+  // clang-format on
+};
 
-#ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#  ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
-    //#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0)
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
-    //#endif // GCC
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
+//#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0)
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
+//#endif // GCC
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-    // http://stackoverflow.com/questions/39479163 what's the difference between C4018 and C4389
-    DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
-    //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+// http://stackoverflow.com/questions/39479163 what's the difference between C4018 and C4389
+DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+// DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
 
-#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#  endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
 // clang-format off
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1403,207 +1510,225 @@ namespace detail
     template <typename L, typename R> DOCTEST_COMPARISON_RETURN_TYPE gt(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs >  rhs; }
     template <typename L, typename R> DOCTEST_COMPARISON_RETURN_TYPE le(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs <= rhs; }
     template <typename L, typename R> DOCTEST_COMPARISON_RETURN_TYPE ge(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs >= rhs; }
-    // clang-format on
+// clang-format on
 
-#ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-#define DOCTEST_CMP_EQ(l, r) l == r
-#define DOCTEST_CMP_NE(l, r) l != r
-#define DOCTEST_CMP_GT(l, r) l > r
-#define DOCTEST_CMP_LT(l, r) l < r
-#define DOCTEST_CMP_GE(l, r) l >= r
-#define DOCTEST_CMP_LE(l, r) l <= r
-#else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-#define DOCTEST_CMP_EQ(l, r) eq(l, r)
-#define DOCTEST_CMP_NE(l, r) ne(l, r)
-#define DOCTEST_CMP_GT(l, r) gt(l, r)
-#define DOCTEST_CMP_LT(l, r) lt(l, r)
-#define DOCTEST_CMP_GE(l, r) ge(l, r)
-#define DOCTEST_CMP_LE(l, r) le(l, r)
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#  ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#    define DOCTEST_CMP_EQ(l, r) l == r
+#    define DOCTEST_CMP_NE(l, r) l != r
+#    define DOCTEST_CMP_GT(l, r) l > r
+#    define DOCTEST_CMP_LT(l, r) l < r
+#    define DOCTEST_CMP_GE(l, r) l >= r
+#    define DOCTEST_CMP_LE(l, r) l <= r
+#  else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#    define DOCTEST_CMP_EQ(l, r) eq(l, r)
+#    define DOCTEST_CMP_NE(l, r) ne(l, r)
+#    define DOCTEST_CMP_GT(l, r) gt(l, r)
+#    define DOCTEST_CMP_LT(l, r) lt(l, r)
+#    define DOCTEST_CMP_GE(l, r) ge(l, r)
+#    define DOCTEST_CMP_LE(l, r) le(l, r)
+#  endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
-#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
-    template <typename R>                                                                          \
-    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs) {                           \
-        bool res = op_macro(lhs, rhs);                                                             \
-        if(m_assert_type & assertType::is_false)                                                   \
-            res = !res;                                                                            \
-        if(!res || doctest::detail::getTestsContextState()->success)                               \
-            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                             \
-        return Result(res);                                                                        \
+#  define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro) \
+    template<typename R>                                                \
+    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs)  \
+    {                                                                   \
+      bool res = op_macro(lhs, rhs);                                    \
+      if(m_assert_type & assertType::is_false)                          \
+        res = !res;                                                     \
+      if(!res || doctest::detail::getTestsContextState()->success)      \
+        return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));      \
+      return Result(res);                                               \
     }
 
-#define DOCTEST_FORBIT_EXPRESSION(op)                                                              \
-    template <typename R>                                                                          \
-    Expression_lhs& operator op(const R&) {                                                        \
-        DOCTEST_STATIC_ASSERT(deferred_false<R>::value,                                            \
-                              Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison);         \
-        return *this;                                                                              \
+#  define DOCTEST_FORBIT_EXPRESSION(op)                                                                            \
+    template<typename R>                                                                                           \
+    Expression_lhs & operator op(const R &)                                                                        \
+    {                                                                                                              \
+      DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); \
+      return *this;                                                                                                \
     }
 
-    template <typename L>
-    // cppcheck-suppress copyCtorAndEqOperator
-    struct Expression_lhs
-    {
-        L                lhs;
-        assertType::Enum m_assert_type;
+template<typename L>
+// cppcheck-suppress copyCtorAndEqOperator
+struct Expression_lhs
+{
+  L lhs;
+  assertType::Enum m_assert_type;
 
-        explicit Expression_lhs(L in, assertType::Enum assert_type)
-                : lhs(in)
-                , m_assert_type(assert_type) {}
+  explicit Expression_lhs(L in, assertType::Enum assert_type) : lhs(in), m_assert_type(assert_type) {}
 
-        DOCTEST_NOINLINE operator Result() {
-            bool res = !!lhs;
-            if(m_assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
-                res = !res;
+  DOCTEST_NOINLINE operator Result()
+  {
+    bool res = !!lhs;
+    if(m_assert_type & assertType::is_false) //! OCLINT bitwise operator in conditional
+      res = !res;
 
-            if(!res || getTestsContextState()->success)
-                return Result(res, toString(lhs));
-            return Result(res);
-        }
+    if(!res || getTestsContextState()->success)
+      return Result(res, toString(lhs));
+    return Result(res);
+  }
 
-        // clang-format off
+  // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>, " >  ", DOCTEST_CMP_GT) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<, " <  ", DOCTEST_CMP_LT) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>=, " >= ", DOCTEST_CMP_GE) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE) //!OCLINT bitwise operator in conditional
-        // clang-format on
+  // clang-format on
 
-        // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
-        DOCTEST_FORBIT_EXPRESSION(&)
-        DOCTEST_FORBIT_EXPRESSION (^)
-        DOCTEST_FORBIT_EXPRESSION(|)
-        DOCTEST_FORBIT_EXPRESSION(&&)
-        DOCTEST_FORBIT_EXPRESSION(||)
-        DOCTEST_FORBIT_EXPRESSION(=)
-        DOCTEST_FORBIT_EXPRESSION(+=)
-        DOCTEST_FORBIT_EXPRESSION(-=)
-        DOCTEST_FORBIT_EXPRESSION(*=)
-        DOCTEST_FORBIT_EXPRESSION(/=)
-        DOCTEST_FORBIT_EXPRESSION(%=)
-        DOCTEST_FORBIT_EXPRESSION(<<=)
-        DOCTEST_FORBIT_EXPRESSION(>>=)
-        DOCTEST_FORBIT_EXPRESSION(&=)
-        DOCTEST_FORBIT_EXPRESSION(^=)
-        DOCTEST_FORBIT_EXPRESSION(|=)
-        // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-        // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
-        DOCTEST_FORBIT_EXPRESSION(<<)
-        DOCTEST_FORBIT_EXPRESSION(>>)
-    };
+  // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
+  DOCTEST_FORBIT_EXPRESSION(&)
+  DOCTEST_FORBIT_EXPRESSION (^)
+  DOCTEST_FORBIT_EXPRESSION(|)
+  DOCTEST_FORBIT_EXPRESSION(&&)
+  DOCTEST_FORBIT_EXPRESSION(||)
+  DOCTEST_FORBIT_EXPRESSION(=)
+  DOCTEST_FORBIT_EXPRESSION(+=)
+  DOCTEST_FORBIT_EXPRESSION(-=)
+  DOCTEST_FORBIT_EXPRESSION(*=)
+  DOCTEST_FORBIT_EXPRESSION(/=)
+  DOCTEST_FORBIT_EXPRESSION(%=)
+  DOCTEST_FORBIT_EXPRESSION(<<=)
+  DOCTEST_FORBIT_EXPRESSION(>>=)
+  DOCTEST_FORBIT_EXPRESSION(&=)
+  DOCTEST_FORBIT_EXPRESSION(^=)
+  DOCTEST_FORBIT_EXPRESSION(|=)
+  // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
+  // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+  DOCTEST_FORBIT_EXPRESSION(<<)
+  DOCTEST_FORBIT_EXPRESSION(>>)
+};
 
-#ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#  ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#  endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    struct ExpressionDecomposer
-    {
-        assertType::Enum m_assert_type;
+struct ExpressionDecomposer
+{
+  assertType::Enum m_assert_type;
 
-        ExpressionDecomposer(assertType::Enum assert_type)
-                : m_assert_type(assert_type) {}
+  ExpressionDecomposer(assertType::Enum assert_type) : m_assert_type(assert_type) {}
 
-        // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-        // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
-        // https://github.com/philsquared/Catch/issues/870
-        // https://github.com/philsquared/Catch/issues/565
-        template <typename L>
-        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand) {
-            return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_assert_type);
-        }
-    };
+  // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
+  // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay
+  // for now... https://github.com/philsquared/Catch/issues/870 https://github.com/philsquared/Catch/issues/565
+  template<typename L>
+  Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand)
+  {
+    return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_assert_type);
+  }
+};
 
-    struct DOCTEST_INTERFACE TestCase
-    {
-        // not used for determining uniqueness
-        funcType m_test;    // a function pointer to the test case
-        String m_full_name; // contains the name (only for templated test cases!) + the template type
-        const char* m_name;       // name of the test case
-        const char* m_type;       // for templated test cases - gets appended to the real name
-        const char* m_test_suite; // the test suite in which the test was added
-        const char* m_description;
-        bool        m_skip;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
+struct DOCTEST_INTERFACE TestCase
+{
+  // not used for determining uniqueness
+  funcType m_test; // a function pointer to the test case
+  String m_full_name; // contains the name (only for templated test cases!) + the template type
+  const char * m_name; // name of the test case
+  const char * m_type; // for templated test cases - gets appended to the real name
+  const char * m_test_suite; // the test suite in which the test was added
+  const char * m_description;
+  bool m_skip;
+  bool m_may_fail;
+  bool m_should_fail;
+  int m_expected_failures;
+  double m_timeout;
 
-        // fields by which uniqueness of test cases shall be determined
-        const char* m_file; // the file in which the test was registered
-        unsigned    m_line; // the line where the test was registered
-        int m_template_id; // an ID used to distinguish between the different versions of a templated test case
+  // fields by which uniqueness of test cases shall be determined
+  const char * m_file; // the file in which the test was registered
+  unsigned m_line; // the line where the test was registered
+  int m_template_id; // an ID used to distinguish between the different versions of a templated test case
 
-        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                 const char* type = "", int template_id = -1);
+  TestCase(funcType test,
+           const char * file,
+           unsigned line,
+           const TestSuite & test_suite,
+           const char * type = "",
+           int template_id = -1);
 
-        // for gcc 4.7
-        DOCTEST_NOINLINE ~TestCase() {}
+  // for gcc 4.7
+  DOCTEST_NOINLINE ~TestCase() {}
 
-        TestCase& operator*(const char* in);
+  TestCase & operator*(const char * in);
 
-        template <typename T>
-        TestCase& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
+  template<typename T>
+  TestCase & operator*(const T & in)
+  {
+    in.fill(*this);
+    return *this;
+  }
 
-        TestCase(const TestCase& other) { *this = other; }
+  TestCase(const TestCase & other) { *this = other; }
 
-        TestCase& operator=(const TestCase& other);
+  TestCase & operator=(const TestCase & other);
 
-        bool operator<(const TestCase& other) const;
-    };
+  bool operator<(const TestCase & other) const;
+};
 
-    // forward declarations of functions used by the macros
-    DOCTEST_INTERFACE int regTest(const TestCase& tc);
-    DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int regTest(const TestCase & tc);
+DOCTEST_INTERFACE int setTestSuite(const TestSuite & ts);
 
-    DOCTEST_INTERFACE void addFailedAssert(assertType::Enum assert_type);
+DOCTEST_INTERFACE void addFailedAssert(assertType::Enum assert_type);
 
-    DOCTEST_INTERFACE void logTestStart(const TestCase& tc);
-    DOCTEST_INTERFACE void logTestEnd();
+DOCTEST_INTERFACE void logTestStart(const TestCase & tc);
+DOCTEST_INTERFACE void logTestEnd();
 
-    DOCTEST_INTERFACE void logTestException(const String& what, bool crash = false);
+DOCTEST_INTERFACE void logTestException(const String & what, bool crash = false);
 
-    DOCTEST_INTERFACE void logAssert(bool passed, const char* decomposition, bool threw,
-                                     const String& exception, const char* expr,
-                                     assertType::Enum assert_type, const char* file, int line);
+DOCTEST_INTERFACE void logAssert(bool passed,
+                                 const char * decomposition,
+                                 bool threw,
+                                 const String & exception,
+                                 const char * expr,
+                                 assertType::Enum assert_type,
+                                 const char * file,
+                                 int line);
 
-    DOCTEST_INTERFACE void logAssertThrows(bool threw, const char* expr,
-                                           assertType::Enum assert_type, const char* file,
-                                           int line);
+DOCTEST_INTERFACE void logAssertThrows(bool threw,
+                                       const char * expr,
+                                       assertType::Enum assert_type,
+                                       const char * file,
+                                       int line);
 
-    DOCTEST_INTERFACE void logAssertThrowsAs(bool threw, bool threw_as, const char* as,
-                                             const String& exception, const char* expr,
-                                             assertType::Enum assert_type, const char* file,
-                                             int line);
+DOCTEST_INTERFACE void logAssertThrowsAs(bool threw,
+                                         bool threw_as,
+                                         const char * as,
+                                         const String & exception,
+                                         const char * expr,
+                                         assertType::Enum assert_type,
+                                         const char * file,
+                                         int line);
 
-    DOCTEST_INTERFACE void logAssertNothrow(bool threw, const String& exception, const char* expr,
-                                            assertType::Enum assert_type, const char* file,
-                                            int line);
+DOCTEST_INTERFACE void logAssertNothrow(bool threw,
+                                        const String & exception,
+                                        const char * expr,
+                                        assertType::Enum assert_type,
+                                        const char * file,
+                                        int line);
 
-    DOCTEST_INTERFACE bool isDebuggerActive();
-    DOCTEST_INTERFACE void writeToDebugConsole(const String&);
+DOCTEST_INTERFACE bool isDebuggerActive();
+DOCTEST_INTERFACE void writeToDebugConsole(const String &);
 
-    namespace binaryAssertComparison
-    {
-        enum Enum
-        {
-            eq = 0,
-            ne,
-            gt,
-            lt,
-            ge,
-            le
-        };
-    } // namespace binaryAssertComparison
+namespace binaryAssertComparison
+{
+enum Enum
+{
+  eq = 0,
+  ne,
+  gt,
+  lt,
+  ge,
+  le
+};
+} // namespace binaryAssertComparison
 
-    // clang-format off
+// clang-format off
     template <int, class L, class R> struct RelationalComparator     { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
     template <class L, class R> struct RelationalComparator<0, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return eq(lhs, rhs); } };
     template <class L, class R> struct RelationalComparator<1, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return ne(lhs, rhs); } };
@@ -1611,481 +1736,506 @@ namespace detail
     template <class L, class R> struct RelationalComparator<3, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return lt(lhs, rhs); } };
     template <class L, class R> struct RelationalComparator<4, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return ge(lhs, rhs); } };
     template <class L, class R> struct RelationalComparator<5, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return le(lhs, rhs); } };
-    // clang-format on
+// clang-format on
 
-    struct DOCTEST_INTERFACE ResultBuilder
+struct DOCTEST_INTERFACE ResultBuilder
+{
+  assertType::Enum m_assert_type;
+  const char * m_file;
+  int m_line;
+  const char * m_expr;
+  const char * m_exception_type;
+
+  Result m_result;
+  bool m_threw;
+  bool m_threw_as;
+  bool m_failed;
+  String m_exception;
+
+  ResultBuilder(assertType::Enum assert_type,
+                const char * file,
+                int line,
+                const char * expr,
+                const char * exception_type = "");
+
+  ~ResultBuilder();
+
+  void setResult(const Result & res) { m_result = res; }
+
+  template<int comparison, typename L, typename R>
+  DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs)
+  {
+    m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
+    if(!m_result.m_passed || getTestsContextState()->success)
+      m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
+  }
+
+  template<typename L>
+  DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val)
+  {
+    m_result.m_passed = !!val;
+
+    if(m_assert_type & assertType::is_false) //! OCLINT bitwise operator in conditional
+      m_result.m_passed = !m_result.m_passed;
+
+    if(!m_result.m_passed || getTestsContextState()->success)
+      m_result.m_decomposition = toString(val);
+  }
+
+  void unexpectedExceptionOccurred();
+
+  bool log();
+  void react() const;
+};
+
+namespace assertAction
+{
+enum Enum
+{
+  nothing = 0,
+  dbgbreak = 1,
+  shouldthrow = 2
+};
+} // namespace assertAction
+
+template<int comparison, typename L, typename R>
+DOCTEST_NOINLINE int fast_binary_assert(assertType::Enum assert_type,
+                                        const char * file,
+                                        int line,
+                                        const char * expr,
+                                        const DOCTEST_REF_WRAP(L) lhs,
+                                        const DOCTEST_REF_WRAP(R) rhs)
+{
+  ResultBuilder rb(assert_type, file, line, expr);
+
+  rb.m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
+
+  if(!rb.m_result.m_passed || getTestsContextState()->success)
+    rb.m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
+
+  int res = 0;
+
+  if(rb.log())
+    res |= assertAction::dbgbreak;
+
+  if(rb.m_failed && checkIfShouldThrow(assert_type))
+    res |= assertAction::shouldthrow;
+
+#  ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+  // #########################################################################################
+  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
+  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+  // #########################################################################################
+  if(res & assertAction::dbgbreak)
+    DOCTEST_BREAK_INTO_DEBUGGER();
+  fastAssertThrowIfFlagSet(res);
+#  endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+  return res;
+}
+
+template<typename L>
+DOCTEST_NOINLINE int fast_unary_assert(assertType::Enum assert_type,
+                                       const char * file,
+                                       int line,
+                                       const char * val_str,
+                                       const DOCTEST_REF_WRAP(L) val)
+{
+  ResultBuilder rb(assert_type, file, line, val_str);
+
+  rb.m_result.m_passed = !!val;
+
+  if(assert_type & assertType::is_false) //! OCLINT bitwise operator in conditional
+    rb.m_result.m_passed = !rb.m_result.m_passed;
+
+  if(!rb.m_result.m_passed || getTestsContextState()->success)
+    rb.m_result.m_decomposition = toString(val);
+
+  int res = 0;
+
+  if(rb.log())
+    res |= assertAction::dbgbreak;
+
+  if(rb.m_failed && checkIfShouldThrow(assert_type))
+    res |= assertAction::shouldthrow;
+
+#  ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+  // #########################################################################################
+  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
+  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+  // #########################################################################################
+  if(res & assertAction::dbgbreak)
+    DOCTEST_BREAK_INTO_DEBUGGER();
+  fastAssertThrowIfFlagSet(res);
+#  endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+  return res;
+}
+
+struct DOCTEST_INTERFACE IExceptionTranslator
+{
+  virtual ~IExceptionTranslator() {}
+  virtual bool translate(String &) const = 0;
+};
+
+template<typename T>
+class ExceptionTranslator : public IExceptionTranslator //! OCLINT destructor of virtual class
+{
+public:
+  explicit ExceptionTranslator(String (*translateFunction)(T)) : m_translateFunction(translateFunction) {}
+
+  bool translate(String & res) const
+  {
+#  ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+    try
     {
-        assertType::Enum m_assert_type;
-        const char*      m_file;
-        int              m_line;
-        const char*      m_expr;
-        const char*      m_exception_type;
-
-        Result m_result;
-        bool   m_threw;
-        bool   m_threw_as;
-        bool   m_failed;
-        String m_exception;
-
-        ResultBuilder(assertType::Enum assert_type, const char* file, int line, const char* expr,
-                      const char* exception_type = "");
-
-        ~ResultBuilder();
-
-        void setResult(const Result& res) { m_result = res; }
-
-        template <int comparison, typename L, typename R>
-        DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
-                                            const DOCTEST_REF_WRAP(R) rhs) {
-            m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if(!m_result.m_passed || getTestsContextState()->success)
-                m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
-        }
-
-        template <typename L>
-        DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val) {
-            m_result.m_passed = !!val;
-
-            if(m_assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
-                m_result.m_passed = !m_result.m_passed;
-
-            if(!m_result.m_passed || getTestsContextState()->success)
-                m_result.m_decomposition = toString(val);
-        }
-
-        void unexpectedExceptionOccurred();
-
-        bool log();
-        void react() const;
-    };
-
-    namespace assertAction
-    {
-        enum Enum
-        {
-            nothing     = 0,
-            dbgbreak    = 1,
-            shouldthrow = 2
-        };
-    } // namespace assertAction
-
-    template <int comparison, typename L, typename R>
-    DOCTEST_NOINLINE int fast_binary_assert(assertType::Enum assert_type, const char* file,
-                                            int line, const char* expr,
-                                            const DOCTEST_REF_WRAP(L) lhs,
-                                            const DOCTEST_REF_WRAP(R) rhs) {
-        ResultBuilder rb(assert_type, file, line, expr);
-
-        rb.m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
-
-        if(!rb.m_result.m_passed || getTestsContextState()->success)
-            rb.m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
-
-        int res = 0;
-
-        if(rb.log())
-            res |= assertAction::dbgbreak;
-
-        if(rb.m_failed && checkIfShouldThrow(assert_type))
-            res |= assertAction::shouldthrow;
-
-#ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-        // #########################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // #########################################################################################
-        if(res & assertAction::dbgbreak)
-            DOCTEST_BREAK_INTO_DEBUGGER();
-        fastAssertThrowIfFlagSet(res);
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-        return res;
+      throw;
+      // cppcheck-suppress catchExceptionByValue
     }
-
-    template <typename L>
-    DOCTEST_NOINLINE int fast_unary_assert(assertType::Enum assert_type, const char* file, int line,
-                                           const char* val_str, const DOCTEST_REF_WRAP(L) val) {
-        ResultBuilder rb(assert_type, file, line, val_str);
-
-        rb.m_result.m_passed = !!val;
-
-        if(assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
-            rb.m_result.m_passed = !rb.m_result.m_passed;
-
-        if(!rb.m_result.m_passed || getTestsContextState()->success)
-            rb.m_result.m_decomposition = toString(val);
-
-        int res = 0;
-
-        if(rb.log())
-            res |= assertAction::dbgbreak;
-
-        if(rb.m_failed && checkIfShouldThrow(assert_type))
-            res |= assertAction::shouldthrow;
-
-#ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-        // #########################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // #########################################################################################
-        if(res & assertAction::dbgbreak)
-            DOCTEST_BREAK_INTO_DEBUGGER();
-        fastAssertThrowIfFlagSet(res);
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-        return res;
+    catch(T ex)
+    { // NOLINT
+      res = m_translateFunction(ex); //! OCLINT parameter reassignment
+      return true;
     }
-
-    struct DOCTEST_INTERFACE IExceptionTranslator
+    catch(...)
     {
-        virtual ~IExceptionTranslator() {}
-        virtual bool translate(String&) const = 0;
-    };
+    } //! OCLINT -  empty catch statement
+#  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+    ((void)res); // to silence -Wunused-parameter
+    return false;
+  }
 
-    template <typename T>
-    class ExceptionTranslator : public IExceptionTranslator //!OCLINT destructor of virtual class
-    {
-    public:
-        explicit ExceptionTranslator(String (*translateFunction)(T))
-                : m_translateFunction(translateFunction) {}
+protected:
+  String (*m_translateFunction)(T);
+};
 
-        bool translate(String& res) const {
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-            try {
-                throw;
-                // cppcheck-suppress catchExceptionByValue
-            } catch(T ex) {                    // NOLINT
-                res = m_translateFunction(ex); //!OCLINT parameter reassignment
-                return true;
-            } catch(...) {} //!OCLINT -  empty catch statement
-#endif                      // DOCTEST_CONFIG_NO_EXCEPTIONS
-            ((void)res);    // to silence -Wunused-parameter
-            return false;
-        }
+DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator * translateFunction);
 
-    protected:
-        String (*m_translateFunction)(T);
-    };
+// FIX FOR VISUAL STUDIO VERSIONS PRIOR TO 2015 - they failed to compile the call to operator<< with
+// std::ostream passed as a reference noting that there is a use of an undefined type (which there isn't)
+DOCTEST_INTERFACE void writeStringToStream(std::ostream * stream, const String & str);
 
-    DOCTEST_INTERFACE void registerExceptionTranslatorImpl(
-            const IExceptionTranslator* translateFunction);
+template<bool C>
+struct StringStreamBase
+{
+  template<typename T>
+  static void convert(std::ostream * stream, const T & in)
+  {
+    writeStringToStream(stream, toString(in));
+  }
 
-    // FIX FOR VISUAL STUDIO VERSIONS PRIOR TO 2015 - they failed to compile the call to operator<< with
-    // std::ostream passed as a reference noting that there is a use of an undefined type (which there isn't)
-    DOCTEST_INTERFACE void writeStringToStream(std::ostream* stream, const String& str);
+  // always treat char* as a string in this context - no matter
+  // if DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING is defined
+  static void convert(std::ostream * stream, const char * in) { writeStringToStream(stream, String(in)); }
+};
 
-    template <bool C>
-    struct StringStreamBase
-    {
-        template <typename T>
-        static void convert(std::ostream* stream, const T& in) {
-            writeStringToStream(stream, toString(in));
-        }
+template<>
+struct StringStreamBase<true>
+{
+  template<typename T>
+  static void convert(std::ostream * stream, const T & in)
+  {
+    *stream << in;
+  }
+};
 
-        // always treat char* as a string in this context - no matter
-        // if DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING is defined
-        static void convert(std::ostream* stream, const char* in) {
-            writeStringToStream(stream, String(in));
-        }
-    };
+template<typename T>
+struct StringStream : StringStreamBase<has_insertion_operator<T>::value>
+{
+};
 
-    template <>
-    struct StringStreamBase<true>
-    {
-        template <typename T>
-        static void convert(std::ostream* stream, const T& in) {
-            *stream << in;
-        }
-    };
+template<typename T>
+void toStream(std::ostream * stream, const T & value)
+{
+  StringStream<T>::convert(stream, value);
+}
 
-    template <typename T>
-    struct StringStream : StringStreamBase<has_insertion_operator<T>::value>
-    {};
+#  ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+DOCTEST_INTERFACE void toStream(std::ostream * stream, char * in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, const char * in);
+#  endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+DOCTEST_INTERFACE void toStream(std::ostream * stream, bool in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, float in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, double in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, double long in);
 
-    template <typename T>
-    void toStream(std::ostream* stream, const T& value) {
-        StringStream<T>::convert(stream, value);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, char in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, char signed in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, char unsigned in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int short in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int short unsigned in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int unsigned in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int long in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int long unsigned in);
+
+#  ifdef DOCTEST_CONFIG_WITH_LONG_LONG
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int long long in);
+DOCTEST_INTERFACE void toStream(std::ostream * stream, int long long unsigned in);
+#  endif // DOCTEST_CONFIG_WITH_LONG_LONG
+
+struct IContextScope
+{
+  virtual ~IContextScope() {}
+  virtual void build(std::ostream *) = 0;
+};
+
+DOCTEST_INTERFACE void addToContexts(IContextScope * ptr);
+DOCTEST_INTERFACE void popFromContexts();
+DOCTEST_INTERFACE void useContextIfExceptionOccurred(IContextScope * ptr);
+
+// cppcheck-suppress copyCtorAndEqOperator
+class ContextBuilder
+{
+  friend class ContextScope;
+
+  struct ICapture
+  {
+    virtual ~ICapture() {}
+    virtual void toStream(std::ostream *) const = 0;
+  };
+
+  template<typename T>
+  struct Capture : ICapture //! OCLINT destructor of virtual class
+  {
+    const T * capture;
+
+    explicit Capture(const T * in) : capture(in) {}
+    virtual void toStream(std::ostream * stream) const
+    { // override
+      detail::toStream(stream, *capture);
     }
+  };
 
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, char* in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, const char* in);
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, bool in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, float in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, double in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, double long in);
+  struct Chunk
+  {
+    char buf[sizeof(Capture<char>)]; // place to construct a Capture<T>
+  };
 
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, char in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, char signed in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, char unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int short in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int short unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long unsigned in);
+  struct Node
+  {
+    Chunk chunk;
+    Node * next;
+  };
 
-#ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long long in);
-    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long long unsigned in);
-#endif // DOCTEST_CONFIG_WITH_LONG_LONG
+  Chunk stackChunks[DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK];
+  int numCaptures;
+  Node * head;
+  Node * tail;
 
-    struct IContextScope
+  void build(std::ostream * stream) const
+  {
+    int curr = 0;
+    // iterate over small buffer
+    while(curr < numCaptures && curr < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
+      reinterpret_cast<const ICapture *>(stackChunks[curr++].buf)->toStream(stream);
+    // iterate over list
+    Node * curr_elem = head;
+    while(curr < numCaptures)
     {
-        virtual ~IContextScope() {}
-        virtual void build(std::ostream*) = 0;
-    };
+      reinterpret_cast<const ICapture *>(curr_elem->chunk.buf)->toStream(stream);
+      curr_elem = curr_elem->next;
+      ++curr;
+    }
+  }
 
-    DOCTEST_INTERFACE void addToContexts(IContextScope* ptr);
-    DOCTEST_INTERFACE void popFromContexts();
-    DOCTEST_INTERFACE void useContextIfExceptionOccurred(IContextScope* ptr);
+  // steal the contents of the other - acting as a move constructor...
+  DOCTEST_NOINLINE ContextBuilder(ContextBuilder & other)
+  : numCaptures(other.numCaptures), head(other.head), tail(other.tail)
+  {
+    other.numCaptures = 0;
+    other.head = 0;
+    other.tail = 0;
+    my_memcpy(stackChunks, other.stackChunks, unsigned(int(sizeof(Chunk)) * DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK));
+  }
 
-    // cppcheck-suppress copyCtorAndEqOperator
-    class ContextBuilder
+  ContextBuilder & operator=(const ContextBuilder &); // NOLINT
+
+public:
+  // cppcheck-suppress uninitMemberVar
+  DOCTEST_NOINLINE ContextBuilder() // NOLINT
+  : numCaptures(0), head(0), tail(0)
+  {
+  }
+
+  template<typename T>
+  DOCTEST_NOINLINE ContextBuilder & operator<<(T & in)
+  {
+    Capture<T> temp(&in);
+
+    // construct either on stack or on heap
+    // copy the bytes for the whole object - including the vtable because we cant construct
+    // the object directly in the buffer using placement new - need the <new> header...
+    if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
     {
-        friend class ContextScope;
-
-        struct ICapture
-        {
-            virtual ~ICapture() {}
-            virtual void toStream(std::ostream*) const = 0;
-        };
-
-        template <typename T>
-        struct Capture : ICapture //!OCLINT destructor of virtual class
-        {
-            const T* capture;
-
-            explicit Capture(const T* in)
-                    : capture(in) {}
-            virtual void toStream(std::ostream* stream) const { // override
-                detail::toStream(stream, *capture);
-            }
-        };
-
-        struct Chunk
-        {
-            char buf[sizeof(Capture<char>)]; // place to construct a Capture<T>
-        };
-
-        struct Node
-        {
-            Chunk chunk;
-            Node* next;
-        };
-
-        Chunk stackChunks[DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK];
-        int   numCaptures;
-        Node* head;
-        Node* tail;
-
-        void build(std::ostream* stream) const {
-            int curr = 0;
-            // iterate over small buffer
-            while(curr < numCaptures && curr < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
-                reinterpret_cast<const ICapture*>(stackChunks[curr++].buf)->toStream(stream);
-            // iterate over list
-            Node* curr_elem = head;
-            while(curr < numCaptures) {
-                reinterpret_cast<const ICapture*>(curr_elem->chunk.buf)->toStream(stream);
-                curr_elem = curr_elem->next;
-                ++curr;
-            }
-        }
-
-        // steal the contents of the other - acting as a move constructor...
-        DOCTEST_NOINLINE ContextBuilder(ContextBuilder& other)
-                : numCaptures(other.numCaptures)
-                , head(other.head)
-                , tail(other.tail) {
-            other.numCaptures = 0;
-            other.head        = 0;
-            other.tail        = 0;
-            my_memcpy(stackChunks, other.stackChunks,
-                      unsigned(int(sizeof(Chunk)) * DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK));
-        }
-
-        ContextBuilder& operator=(const ContextBuilder&); // NOLINT
-
-    public:
-        // cppcheck-suppress uninitMemberVar
-        DOCTEST_NOINLINE ContextBuilder() // NOLINT
-                : numCaptures(0)
-                , head(0)
-                , tail(0) {}
-
-        template <typename T>
-        DOCTEST_NOINLINE ContextBuilder& operator<<(T& in) {
-            Capture<T> temp(&in);
-
-            // construct either on stack or on heap
-            // copy the bytes for the whole object - including the vtable because we cant construct
-            // the object directly in the buffer using placement new - need the <new> header...
-            if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK) {
-                my_memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
-            } else {
-                Node* curr = new Node;
-                curr->next = 0;
-                if(tail) {
-                    tail->next = curr;
-                    tail       = curr;
-                } else {
-                    head = tail = curr;
-                }
-
-                my_memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
-            }
-            ++numCaptures;
-            return *this;
-        }
-
-        DOCTEST_NOINLINE ~ContextBuilder() {
-            // free the linked list - the ones on the stack are left as-is
-            // no destructors are called at all - there is no need
-            while(head) {
-                Node* next = head->next;
-                delete head;
-                head = next;
-            }
-        }
-
-#ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-        template <typename T>
-        ContextBuilder& operator<<(const T&&) {
-            DOCTEST_STATIC_ASSERT(
-                    deferred_false<T>::value,
-                    Cannot_pass_temporaries_or_rvalues_to_the_streaming_operator_because_it_caches_pointers_to_the_passed_objects_for_lazy_evaluation);
-            return *this;
-        }
-#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-    };
-
-    class ContextScope : public IContextScope
+      my_memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
+    }
+    else
     {
-        ContextBuilder contextBuilder;
-        bool           built;
+      Node * curr = new Node;
+      curr->next = 0;
+      if(tail)
+      {
+        tail->next = curr;
+        tail = curr;
+      }
+      else
+      {
+        head = tail = curr;
+      }
 
-    public:
-        DOCTEST_NOINLINE explicit ContextScope(ContextBuilder& temp)
-                : contextBuilder(temp)
-                , built(false) {
-            addToContexts(this);
-        }
+      my_memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
+    }
+    ++numCaptures;
+    return *this;
+  }
 
-        DOCTEST_NOINLINE ~ContextScope() {
-            if(!built)
-                useContextIfExceptionOccurred(this);
-            popFromContexts();
-        }
-
-        void build(std::ostream* stream) {
-            built = true;
-            contextBuilder.build(stream);
-        }
-    };
-
-    class DOCTEST_INTERFACE MessageBuilder
+  DOCTEST_NOINLINE ~ContextBuilder()
+  {
+    // free the linked list - the ones on the stack are left as-is
+    // no destructors are called at all - there is no need
+    while(head)
     {
-        std::ostream*    m_stream;
-        const char*      m_file;
-        int              m_line;
-        assertType::Enum m_severity;
+      Node * next = head->next;
+      delete head;
+      head = next;
+    }
+  }
 
-    public:
-        MessageBuilder(const char* file, int line, assertType::Enum severity);
-        ~MessageBuilder();
+#  ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+  template<typename T>
+  ContextBuilder & operator<<(const T &&)
+  {
+    DOCTEST_STATIC_ASSERT(
+        deferred_false<T>::value,
+        Cannot_pass_temporaries_or_rvalues_to_the_streaming_operator_because_it_caches_pointers_to_the_passed_objects_for_lazy_evaluation);
+    return *this;
+  }
+#  endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+};
 
-        template <typename T>
-        MessageBuilder& operator<<(const T& in) {
-            toStream(m_stream, in);
-            return *this;
-        }
+class ContextScope : public IContextScope
+{
+  ContextBuilder contextBuilder;
+  bool built;
 
-        bool log();
-        void react();
-    };
+public:
+  DOCTEST_NOINLINE explicit ContextScope(ContextBuilder & temp) : contextBuilder(temp), built(false)
+  {
+    addToContexts(this);
+  }
+
+  DOCTEST_NOINLINE ~ContextScope()
+  {
+    if(!built)
+      useContextIfExceptionOccurred(this);
+    popFromContexts();
+  }
+
+  void build(std::ostream * stream)
+  {
+    built = true;
+    contextBuilder.build(stream);
+  }
+};
+
+class DOCTEST_INTERFACE MessageBuilder
+{
+  std::ostream * m_stream;
+  const char * m_file;
+  int m_line;
+  assertType::Enum m_severity;
+
+public:
+  MessageBuilder(const char * file, int line, assertType::Enum severity);
+  ~MessageBuilder();
+
+  template<typename T>
+  MessageBuilder & operator<<(const T & in)
+  {
+    toStream(m_stream, in);
+    return *this;
+  }
+
+  bool log();
+  void react();
+};
 } // namespace detail
 
 struct test_suite
 {
-    const char* data;
-    test_suite(const char* in)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_test_suite = data; }
-    void fill(detail::TestSuite& state) const { state.m_test_suite = data; }
+  const char * data;
+  test_suite(const char * in) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_test_suite = data; }
+  void fill(detail::TestSuite & state) const { state.m_test_suite = data; }
 };
 
 struct description
 {
-    const char* data;
-    description(const char* in)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_description = data; }
-    void fill(detail::TestSuite& state) const { state.m_description = data; }
+  const char * data;
+  description(const char * in) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_description = data; }
+  void fill(detail::TestSuite & state) const { state.m_description = data; }
 };
 
 struct skip
 {
-    bool data;
-    skip(bool in = true)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_skip = data; }
-    void fill(detail::TestSuite& state) const { state.m_skip = data; }
+  bool data;
+  skip(bool in = true) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_skip = data; }
+  void fill(detail::TestSuite & state) const { state.m_skip = data; }
 };
 
 struct timeout
 {
-    double data;
-    timeout(double in)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_timeout = data; }
-    void fill(detail::TestSuite& state) const { state.m_timeout = data; }
+  double data;
+  timeout(double in) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_timeout = data; }
+  void fill(detail::TestSuite & state) const { state.m_timeout = data; }
 };
 
 struct may_fail
 {
-    bool data;
-    may_fail(bool in = true)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_may_fail = data; }
-    void fill(detail::TestSuite& state) const { state.m_may_fail = data; }
+  bool data;
+  may_fail(bool in = true) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_may_fail = data; }
+  void fill(detail::TestSuite & state) const { state.m_may_fail = data; }
 };
 
 struct should_fail
 {
-    bool data;
-    should_fail(bool in = true)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_should_fail = data; }
-    void fill(detail::TestSuite& state) const { state.m_should_fail = data; }
+  bool data;
+  should_fail(bool in = true) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_should_fail = data; }
+  void fill(detail::TestSuite & state) const { state.m_should_fail = data; }
 };
 
 struct expected_failures
 {
-    int data;
-    expected_failures(int in)
-            : data(in) {}
-    void fill(detail::TestCase& state) const { state.m_expected_failures = data; }
-    void fill(detail::TestSuite& state) const { state.m_expected_failures = data; }
+  int data;
+  expected_failures(int in) : data(in) {}
+  void fill(detail::TestCase & state) const { state.m_expected_failures = data; }
+  void fill(detail::TestSuite & state) const { state.m_expected_failures = data; }
 };
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
-template <typename T>
-int registerExceptionTranslator(String (*translateFunction)(T)) {
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
-    static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    detail::registerExceptionTranslatorImpl(&exceptionTranslator);
-    return 0;
+template<typename T>
+int registerExceptionTranslator(String (*translateFunction)(T))
+{
+  DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
+  static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
+  DOCTEST_CLANG_SUPPRESS_WARNING_POP
+  detail::registerExceptionTranslatorImpl(&exceptionTranslator);
+  return 0;
 }
 
-#else  // DOCTEST_CONFIG_DISABLE
-template <typename T>
-int registerExceptionTranslator(String (*)(T)) {
-    return 0;
+#else // DOCTEST_CONFIG_DISABLE
+template<typename T>
+int registerExceptionTranslator(String (*)(T))
+{
+  return 0;
 }
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -2095,27 +2245,27 @@ DOCTEST_INTERFACE bool isRunningInTest();
 class DOCTEST_INTERFACE Context
 {
 #if !defined(DOCTEST_CONFIG_DISABLE)
-    detail::ContextState* p;
+  detail::ContextState * p;
 
-    void parseArgs(int argc, const char* const* argv, bool withDefaults = false);
+  void parseArgs(int argc, const char * const * argv, bool withDefaults = false);
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 public:
-    explicit Context(int argc = 0, const char* const* argv = 0);
+  explicit Context(int argc = 0, const char * const * argv = 0);
 
-    ~Context();
+  ~Context();
 
-    void applyCommandLine(int argc, const char* const* argv);
+  void applyCommandLine(int argc, const char * const * argv);
 
-    void addFilter(const char* filter, const char* value);
-    void clearFilters();
-    void setOption(const char* option, int value);
-    void setOption(const char* option, const char* value);
+  void addFilter(const char * filter, const char * value);
+  void clearFilters();
+  void setOption(const char * option, int value);
+  void setOption(const char * option, const char * value);
 
-    bool shouldExit();
+  bool shouldExit();
 
-    int run();
+  int run();
 };
 
 } // namespace doctest
@@ -2123,232 +2273,231 @@ public:
 // if registering is not disabled
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_EXPAND_VA_ARGS(...) __VA_ARGS__
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_EXPAND_VA_ARGS
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_EXPAND_VA_ARGS(...) __VA_ARGS__
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_EXPAND_VA_ARGS
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_STRIP_PARENS(x) x
-#define DOCTEST_HANDLE_BRACED_VA_ARGS(expr) DOCTEST_STRIP_PARENS(DOCTEST_EXPAND_VA_ARGS expr)
+#  define DOCTEST_STRIP_PARENS(x) x
+#  define DOCTEST_HANDLE_BRACED_VA_ARGS(expr) DOCTEST_STRIP_PARENS(DOCTEST_EXPAND_VA_ARGS expr)
 
 // registers the test by initializing a dummy var with a function
-#define DOCTEST_REGISTER_FUNCTION(f, decorators)                                                   \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) = doctest::detail::regTest(  \
-            doctest::detail::TestCase(f, __FILE__, __LINE__,                                       \
-                                      doctest_detail_test_suite_ns::getCurrentTestSuite()) *       \
-            decorators);                                                                           \
+#  define DOCTEST_REGISTER_FUNCTION(f, decorators)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) = doctest::detail::regTest(             \
+        doctest::detail::TestCase(f, __FILE__, __LINE__, doctest_detail_test_suite_ns::getCurrentTestSuite()) \
+        * decorators);                                                                                        \
     DOCTEST_GLOBAL_NO_WARNINGS_END()
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
-    namespace                                                                                      \
-    {                                                                                              \
-        struct der : base                                                                          \
-        {                                                                                          \
-            void f();                                                                              \
-        };                                                                                         \
-        static void func() {                                                                       \
-            der v;                                                                                 \
-            v.f();                                                                                 \
-        }                                                                                          \
-        DOCTEST_REGISTER_FUNCTION(func, decorators)                                                \
-    }                                                                                              \
+#  define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators) \
+    namespace                                                    \
+    {                                                            \
+    struct der : base                                            \
+    {                                                            \
+      void f();                                                  \
+    };                                                           \
+    static void func()                                           \
+    {                                                            \
+      der v;                                                     \
+      v.f();                                                     \
+    }                                                            \
+    DOCTEST_REGISTER_FUNCTION(func, decorators)                  \
+    }                                                            \
     inline DOCTEST_NOINLINE void der::f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
-    static void f();                                                                               \
-    DOCTEST_REGISTER_FUNCTION(f, decorators)                                                       \
+#  define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators) \
+    static void f();                                          \
+    DOCTEST_REGISTER_FUNCTION(f, decorators)                  \
     static void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(decorators)                                                              \
+#  define DOCTEST_TEST_CASE(decorators) \
     DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
+#  define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                                \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c, DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), \
+                              decorators)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)                                                           \
-    template <>                                                                                    \
-    inline const char* type_to_string<__VA_ARGS__>() {                                             \
-        return "<" #__VA_ARGS__ ">";                                                               \
-    }
-#define DOCTEST_TYPE_TO_STRING(...)                                                                \
-    namespace doctest                                                                              \
-    {                                                                                              \
-        namespace detail                                                                           \
-        {                                                                                          \
-            DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__)                                               \
-        }                                                                                          \
-    }                                                                                              \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TYPE_TO_STRING_IMPL(x)                                                             \
-    template <>                                                                                    \
-    inline const char* type_to_string<x>() {                                                       \
-        return "<" #x ">";                                                                         \
-    }
-#define DOCTEST_TYPE_TO_STRING(x)                                                                  \
-    namespace doctest                                                                              \
-    {                                                                                              \
-        namespace detail                                                                           \
-        {                                                                                          \
-            DOCTEST_TYPE_TO_STRING_IMPL(x)                                                         \
-        }                                                                                          \
-    }                                                                                              \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TYPE_TO_STRING_IMPL(...)            \
+      template<>                                        \
+      inline const char * type_to_string<__VA_ARGS__>() \
+      {                                                 \
+        return "<" #__VA_ARGS__ ">";                    \
+      }
+#    define DOCTEST_TYPE_TO_STRING(...)        \
+      namespace doctest                        \
+      {                                        \
+      namespace detail                         \
+      {                                        \
+      DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__) \
+      }                                        \
+      }                                        \
+      typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TYPE_TO_STRING_IMPL(x)    \
+      template<>                              \
+      inline const char * type_to_string<x>() \
+      {                                       \
+        return "<" #x ">";                    \
+      }
+#    define DOCTEST_TYPE_TO_STRING(x) \
+      namespace doctest               \
+      {                               \
+      namespace detail                \
+      {                               \
+      DOCTEST_TYPE_TO_STRING_IMPL(x)  \
+      }                               \
+      }                               \
+      typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, anon)                                \
-    template <typename T>                                                                          \
-    inline void anon();                                                                            \
-    struct DOCTEST_CAT(anon, FUNCTOR)                                                              \
-    {                                                                                              \
-        template <int Index, typename Type>                                                        \
-        void operator()() {                                                                        \
-            doctest::detail::regTest(                                                              \
-                    doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                      \
-                                              doctest_detail_test_suite_ns::getCurrentTestSuite(), \
-                                              doctest::detail::type_to_string<Type>(), Index) *    \
-                    decorators);                                                                   \
-        }                                                                                          \
-    };                                                                                             \
-    inline int DOCTEST_CAT(anon, REG_FUNC)() {                                                     \
-        DOCTEST_CAT(anon, FUNCTOR) registrar;                                                      \
-        doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result,                 \
-                                     DOCTEST_CAT(anon, FUNCTOR)>                                   \
-                doIt(registrar);                                                                   \
-        return 0;                                                                                  \
-    }                                                                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();          \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
-    template <typename T>                                                                          \
+#  define DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, anon)                                              \
+    template<typename T>                                                                                           \
+    inline void anon();                                                                                            \
+    struct DOCTEST_CAT(anon, FUNCTOR)                                                                              \
+    {                                                                                                              \
+      template<int Index, typename Type>                                                                           \
+      void operator()()                                                                                            \
+      {                                                                                                            \
+        doctest::detail::regTest(doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                         \
+                                                           doctest_detail_test_suite_ns::getCurrentTestSuite(),    \
+                                                           doctest::detail::type_to_string<Type>(), Index)         \
+                                 * decorators);                                                                    \
+      }                                                                                                            \
+    };                                                                                                             \
+    inline int DOCTEST_CAT(anon, REG_FUNC)()                                                                       \
+    {                                                                                                              \
+      DOCTEST_CAT(anon, FUNCTOR) registrar;                                                                        \
+      doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result, DOCTEST_CAT(anon, FUNCTOR)> doIt( \
+          registrar);                                                                                              \
+      return 0;                                                                                                    \
+    }                                                                                                              \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();                          \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                                               \
+    template<typename T>                                                                                           \
     inline void anon()
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, ...)                                             \
-    DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, (__VA_ARGS__),                                  \
-                                    DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, types)                                           \
-    DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, ...) \
+      DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, (__VA_ARGS__), DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, types) \
+      DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(decorators, T, id, anon)                            \
-    template <typename T>                                                                          \
-    inline void anon();                                                                            \
-    struct DOCTEST_CAT(id, _FUNCTOR)                                                               \
-    {                                                                                              \
-        int m_line;                                                                                \
-        DOCTEST_CAT(id, _FUNCTOR)                                                                  \
-        (int line)                                                                                 \
-                : m_line(line) {}                                                                  \
-        template <int Index, typename Type>                                                        \
-        void operator()() {                                                                        \
-            doctest::detail::regTest(                                                              \
-                    doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                      \
-                                              doctest_detail_test_suite_ns::getCurrentTestSuite(), \
-                                              doctest::detail::type_to_string<Type>(),             \
-                                              m_line * 1000 + Index) *                             \
-                    decorators);                                                                   \
-        }                                                                                          \
-    };                                                                                             \
-    template <typename T>                                                                          \
+#  define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(decorators, T, id, anon)                                       \
+    template<typename T>                                                                                        \
+    inline void anon();                                                                                         \
+    struct DOCTEST_CAT(id, _FUNCTOR)                                                                            \
+    {                                                                                                           \
+      int m_line;                                                                                               \
+      DOCTEST_CAT(id, _FUNCTOR)                                                                                 \
+      (int line) : m_line(line) {}                                                                              \
+      template<int Index, typename Type>                                                                        \
+      void operator()()                                                                                         \
+      {                                                                                                         \
+        doctest::detail::regTest(doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                      \
+                                                           doctest_detail_test_suite_ns::getCurrentTestSuite(), \
+                                                           doctest::detail::type_to_string<Type>(),             \
+                                                           m_line * 1000 + Index)                               \
+                                 * decorators);                                                                 \
+      }                                                                                                         \
+    };                                                                                                          \
+    template<typename T>                                                                                        \
     inline void anon()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(decorators, T, id)                                       \
+#  define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(decorators, T, id) \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(decorators, T, id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, anon)                               \
-    static int DOCTEST_CAT(anon, REG_FUNC)() {                                                     \
-        DOCTEST_CAT(id, _FUNCTOR) registrar(__LINE__);                                             \
-        doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result,                 \
-                                     DOCTEST_CAT(id, _FUNCTOR)>                                    \
-                doIt(registrar);                                                                   \
-        return 0;                                                                                  \
-    }                                                                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();          \
+#  define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, anon)                                            \
+    static int DOCTEST_CAT(anon, REG_FUNC)()                                                                      \
+    {                                                                                                             \
+      DOCTEST_CAT(id, _FUNCTOR) registrar(__LINE__);                                                              \
+      doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result, DOCTEST_CAT(id, _FUNCTOR)> doIt( \
+          registrar);                                                                                             \
+      return 0;                                                                                                   \
+    }                                                                                                             \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();                         \
     DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                            \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, (__VA_ARGS__),                                 \
-                                                DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types)                                          \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) \
+      DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, (__VA_ARGS__), DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types) \
+      DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for subcases
-#define DOCTEST_SUBCASE(name)                                                                      \
+#  define DOCTEST_SUBCASE(name)                                                                    \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
-               doctest::detail::Subcase(name, __FILE__, __LINE__))
+           doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
-#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
-    namespace ns_name                                                                              \
-    {                                                                                              \
-        namespace doctest_detail_test_suite_ns                                                     \
-        {                                                                                          \
-            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() {            \
-                static doctest::detail::TestSuite data;                                            \
-                static bool                       inited = false;                                  \
-                if(!inited) {                                                                      \
-                    data* decorators;                                                              \
-                    inited = true;                                                                 \
-                }                                                                                  \
-                return data;                                                                       \
-            }                                                                                      \
-        }                                                                                          \
-    }                                                                                              \
+#  define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                         \
+    namespace ns_name                                                          \
+    {                                                                          \
+    namespace doctest_detail_test_suite_ns                                     \
+    {                                                                          \
+    static DOCTEST_NOINLINE doctest::detail::TestSuite & getCurrentTestSuite() \
+    {                                                                          \
+      static doctest::detail::TestSuite data;                                  \
+      static bool inited = false;                                              \
+      if(!inited)                                                              \
+      {                                                                        \
+        data * decorators;                                                     \
+        inited = true;                                                         \
+      }                                                                        \
+      return data;                                                             \
+    }                                                                          \
+    }                                                                          \
+    }                                                                          \
     namespace ns_name
 
-#define DOCTEST_TEST_SUITE(decorators)                                                             \
-    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
+#  define DOCTEST_TEST_SUITE(decorators) DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators);              \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+#  define DOCTEST_TEST_SUITE_BEGIN(decorators)                                    \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =           \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators); \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                              \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END                                                                     \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * "");                      \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+#  define DOCTEST_TEST_SUITE_END                                          \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =   \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""); \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                      \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for registering exception translators
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
-    inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =                     \
-            doctest::registerExceptionTranslator(translatorName);                                  \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+#  define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature) \
+    inline doctest::String translatorName(signature);                           \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =  \
+        doctest::registerExceptionTranslator(translatorName);                   \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                            \
     doctest::String translatorName(signature)
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_),       \
-                                               signature)
+#  define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature) \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_), signature)
 
 // for logging
-#define DOCTEST_INFO(x)                                                                            \
-    doctest::detail::ContextScope DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_)(                            \
-            doctest::detail::ContextBuilder() << x)
-#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := " << x)
+#  define DOCTEST_INFO(x) \
+    doctest::detail::ContextScope DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_)(doctest::detail::ContextBuilder() << x)
+#  define DOCTEST_CAPTURE(x) DOCTEST_INFO(#  x " := " << x)
 
-#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                               \
-    do {                                                                                           \
-        doctest::detail::MessageBuilder mb(file, line, doctest::detail::assertType::type);         \
-        mb << x;                                                                                   \
-        if(mb.log())                                                                               \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
-        mb.react();                                                                                \
+#  define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                   \
+    do                                                                                   \
+    {                                                                                    \
+      doctest::detail::MessageBuilder mb(file, line, doctest::detail::assertType::type); \
+      mb << x;                                                                           \
+      if(mb.log())                                                                       \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                   \
+      mb.react();                                                                        \
     } while((void)0, 0)
 
 // clang-format off
@@ -2357,68 +2506,73 @@ public:
 #define DOCTEST_ADD_FAIL_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
 // clang-format on
 
-#define DOCTEST_MESSAGE(x) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, x)
-#define DOCTEST_FAIL_CHECK(x) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, x)
-#define DOCTEST_FAIL(x) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, x)
+#  define DOCTEST_MESSAGE(x) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, x)
+#  define DOCTEST_FAIL_CHECK(x) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, x)
+#  define DOCTEST_FAIL(x) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, x)
 
-#if __cplusplus >= 201402L || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 10, 0))
-template <class T, T x>
+#  if __cplusplus >= 201402L || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 10, 0))
+template<class T, T x>
 constexpr T to_lvalue = x;
-#define DOCTEST_TO_LVALUE(...) to_lvalue<decltype(__VA_ARGS__), __VA_ARGS__>
-#else
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TO_LVALUE(...) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TO_LVALUE(x) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#endif // TO_LVALUE hack for logging macros like INFO()
+#    define DOCTEST_TO_LVALUE(...) to_lvalue<decltype(__VA_ARGS__), __VA_ARGS__>
+#  else
+#    ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_TO_LVALUE(...) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
+#    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_TO_LVALUE(x) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
+#    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  endif // TO_LVALUE hack for logging macros like INFO()
 
 // common code in asserts - for convenience
-#define DOCTEST_ASSERT_LOG_AND_REACT(rb)                                                           \
-    if(rb.log())                                                                                   \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
+#  define DOCTEST_ASSERT_LOG_AND_REACT(rb) \
+    if(rb.log())                           \
+      DOCTEST_BREAK_INTO_DEBUGGER();       \
     rb.react()
 
-#ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#define DOCTEST_WRAP_IN_TRY(x) x;
-#else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#define DOCTEST_WRAP_IN_TRY(x)                                                                     \
-    try {                                                                                          \
-        x;                                                                                         \
-    } catch(...) { _DOCTEST_RB.unexpectedExceptionOccurred(); }
-#endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#  ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#    define DOCTEST_WRAP_IN_TRY(x) x;
+#  else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#    define DOCTEST_WRAP_IN_TRY(x)                 \
+      try                                          \
+      {                                            \
+        x;                                         \
+      }                                            \
+      catch(...)                                   \
+      {                                            \
+        _DOCTEST_RB.unexpectedExceptionOccurred(); \
+      }
+#  endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
-#define DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type)                                              \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::ResultBuilder _DOCTEST_RB(                                                    \
-            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                          \
-            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));                                   \
-    DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.setResult(                                                     \
-            doctest::detail::ExpressionDecomposer(doctest::detail::assertType::assert_type)        \
-            << DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                               \
-    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                      \
+#  define DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type)                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                             \
+    doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__,  \
+                                               DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));           \
+    DOCTEST_WRAP_IN_TRY(                                                                                      \
+        _DOCTEST_RB.setResult(doctest::detail::ExpressionDecomposer(doctest::detail::assertType::assert_type) \
+                              << DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                        \
+    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                                 \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(expr, assert_type)                                              \
-    do {                                                                                           \
-        DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type);                                             \
+#  define DOCTEST_ASSERT_IMPLEMENT_1(expr, assert_type) \
+    do                                                  \
+    {                                                   \
+      DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type);    \
     } while((void)0, 0)
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN)
-#define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK)
-#define DOCTEST_REQUIRE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE)
-#define DOCTEST_WARN_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN_FALSE)
-#define DOCTEST_CHECK_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK_FALSE)
-#define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE_FALSE)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN)
-#define DOCTEST_CHECK(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK)
-#define DOCTEST_REQUIRE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE)
-#define DOCTEST_WARN_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN_FALSE)
-#define DOCTEST_CHECK_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK_FALSE)
-#define DOCTEST_REQUIRE_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE_FALSE)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN)
+#    define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK)
+#    define DOCTEST_REQUIRE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE)
+#    define DOCTEST_WARN_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN_FALSE)
+#    define DOCTEST_CHECK_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK_FALSE)
+#    define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE_FALSE)
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN)
+#    define DOCTEST_CHECK(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK)
+#    define DOCTEST_REQUIRE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE)
+#    define DOCTEST_WARN_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN_FALSE)
+#    define DOCTEST_CHECK_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK_FALSE)
+#    define DOCTEST_REQUIRE_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE_FALSE)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // clang-format off
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -2438,49 +2592,71 @@ constexpr T to_lvalue = x;
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 // clang-format on
 
-#define DOCTEST_ASSERT_THROWS(expr, assert_type)                                                   \
-    do {                                                                                           \
-        if(!doctest::detail::getTestsContextState()->no_throw) {                                   \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type,   \
-                                                       __FILE__, __LINE__, #expr);                 \
-            try {                                                                                  \
-                expr;                                                                              \
-            } catch(...) { _DOCTEST_RB.m_threw = true; }                                           \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
+#  define DOCTEST_ASSERT_THROWS(expr, assert_type)                                                               \
+    do                                                                                                           \
+    {                                                                                                            \
+      if(!doctest::detail::getTestsContextState()->no_throw)                                                     \
+      {                                                                                                          \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                                   #expr);                                                       \
+        try                                                                                                      \
+        {                                                                                                        \
+          expr;                                                                                                  \
+        }                                                                                                        \
+        catch(...)                                                                                               \
+        {                                                                                                        \
+          _DOCTEST_RB.m_threw = true;                                                                            \
+        }                                                                                                        \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+      }                                                                                                          \
     } while((void)0, 0)
 
-#define DOCTEST_ASSERT_THROWS_AS(expr, as, assert_type)                                            \
-    do {                                                                                           \
-        if(!doctest::detail::getTestsContextState()->no_throw) {                                   \
-            doctest::detail::ResultBuilder _DOCTEST_RB(                                            \
-                    doctest::detail::assertType::assert_type, __FILE__, __LINE__, #expr,           \
-                    DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(as)));                             \
-            try {                                                                                  \
-                expr;                                                                              \
-            } catch(const DOCTEST_HANDLE_BRACED_VA_ARGS(as)&) {                                    \
-                _DOCTEST_RB.m_threw    = true;                                                     \
-                _DOCTEST_RB.m_threw_as = true;                                                     \
-            } catch(...) { _DOCTEST_RB.unexpectedExceptionOccurred(); }                            \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
+#  define DOCTEST_ASSERT_THROWS_AS(expr, as, assert_type)                                                        \
+    do                                                                                                           \
+    {                                                                                                            \
+      if(!doctest::detail::getTestsContextState()->no_throw)                                                     \
+      {                                                                                                          \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                                   #expr, DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(as)));     \
+        try                                                                                                      \
+        {                                                                                                        \
+          expr;                                                                                                  \
+        }                                                                                                        \
+        catch(const DOCTEST_HANDLE_BRACED_VA_ARGS(as) &)                                                         \
+        {                                                                                                        \
+          _DOCTEST_RB.m_threw = true;                                                                            \
+          _DOCTEST_RB.m_threw_as = true;                                                                         \
+        }                                                                                                        \
+        catch(...)                                                                                               \
+        {                                                                                                        \
+          _DOCTEST_RB.unexpectedExceptionOccurred();                                                             \
+        }                                                                                                        \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+      }                                                                                                          \
     } while((void)0, 0)
 
-#define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                  \
-    do {                                                                                           \
-        if(!doctest::detail::getTestsContextState()->no_throw) {                                   \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type,   \
-                                                       __FILE__, __LINE__, #expr);                 \
-            try {                                                                                  \
-                expr;                                                                              \
-            } catch(...) { _DOCTEST_RB.unexpectedExceptionOccurred(); }                            \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
+#  define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                              \
+    do                                                                                                           \
+    {                                                                                                            \
+      if(!doctest::detail::getTestsContextState()->no_throw)                                                     \
+      {                                                                                                          \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                                   #expr);                                                       \
+        try                                                                                                      \
+        {                                                                                                        \
+          expr;                                                                                                  \
+        }                                                                                                        \
+        catch(...)                                                                                               \
+        {                                                                                                        \
+          _DOCTEST_RB.unexpectedExceptionOccurred();                                                             \
+        }                                                                                                        \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+      }                                                                                                          \
     } while((void)0, 0)
 
-#define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_WARN_THROWS)
-#define DOCTEST_CHECK_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_CHECK_THROWS)
-#define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_REQUIRE_THROWS)
+#  define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_WARN_THROWS)
+#  define DOCTEST_CHECK_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_CHECK_THROWS)
+#  define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_REQUIRE_THROWS)
 
 // clang-format off
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -2494,9 +2670,9 @@ constexpr T to_lvalue = x;
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 // clang-format on
 
-#define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)
-#define DOCTEST_CHECK_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_CHECK_NOTHROW)
-#define DOCTEST_REQUIRE_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_REQUIRE_NOTHROW)
+#  define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)
+#  define DOCTEST_CHECK_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_CHECK_NOTHROW)
+#  define DOCTEST_REQUIRE_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_REQUIRE_NOTHROW)
 
 // clang-format off
 #define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS(expr); } while((void)0, 0)
@@ -2510,152 +2686,147 @@ constexpr T to_lvalue = x;
 #define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_NOTHROW(expr); } while((void)0, 0)
 // clang-format on
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_BINARY_ASSERT(assert_type, expr, comp)                                             \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(                                                \
-                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
-                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));                               \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(          \
-                        DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                      \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_BINARY_ASSERT(assert_type, lhs, rhs, comp)                                         \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type,       \
-                                                   __FILE__, __LINE__, #lhs ", " #rhs);            \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(lhs,      \
-                                                                                         rhs))     \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_BINARY_ASSERT(assert_type, expr, comp)                                                       \
+      do                                                                                                         \
+      {                                                                                                          \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                                   DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));          \
+        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(            \
+            DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                                                \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+      } while((void)0, 0)
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_BINARY_ASSERT(assert_type, lhs, rhs, comp)                                                   \
+      do                                                                                                         \
+      {                                                                                                          \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                                   #lhs ", " #rhs);                                              \
+        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(lhs, rhs))  \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+      } while((void)0, 0)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_UNARY_ASSERT(assert_type, expr)                                                    \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(                                                \
-                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
-                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));                               \
-        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))         \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
+#  define DOCTEST_UNARY_ASSERT(assert_type, expr)                                                              \
+    do                                                                                                         \
+    {                                                                                                          \
+      doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                                 DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));          \
+      DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                       \
+      DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
     } while((void)0, 0)
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, (__VA_ARGS__), eq)
-#define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, (__VA_ARGS__), eq)
-#define DOCTEST_REQUIRE_EQ(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, (__VA_ARGS__), eq)
-#define DOCTEST_WARN_NE(...) DOCTEST_BINARY_ASSERT(DT_WARN_NE, (__VA_ARGS__), ne)
-#define DOCTEST_CHECK_NE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, (__VA_ARGS__), ne)
-#define DOCTEST_REQUIRE_NE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, (__VA_ARGS__), ne)
-#define DOCTEST_WARN_GT(...) DOCTEST_BINARY_ASSERT(DT_WARN_GT, (__VA_ARGS__), gt)
-#define DOCTEST_CHECK_GT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, (__VA_ARGS__), gt)
-#define DOCTEST_REQUIRE_GT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, (__VA_ARGS__), gt)
-#define DOCTEST_WARN_LT(...) DOCTEST_BINARY_ASSERT(DT_WARN_LT, (__VA_ARGS__), lt)
-#define DOCTEST_CHECK_LT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, (__VA_ARGS__), lt)
-#define DOCTEST_REQUIRE_LT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, (__VA_ARGS__), lt)
-#define DOCTEST_WARN_GE(...) DOCTEST_BINARY_ASSERT(DT_WARN_GE, (__VA_ARGS__), ge)
-#define DOCTEST_CHECK_GE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, (__VA_ARGS__), ge)
-#define DOCTEST_REQUIRE_GE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, (__VA_ARGS__), ge)
-#define DOCTEST_WARN_LE(...) DOCTEST_BINARY_ASSERT(DT_WARN_LE, (__VA_ARGS__), le)
-#define DOCTEST_CHECK_LE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, (__VA_ARGS__), le)
-#define DOCTEST_REQUIRE_LE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, (__VA_ARGS__), le)
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, (__VA_ARGS__), eq)
+#    define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, (__VA_ARGS__), eq)
+#    define DOCTEST_REQUIRE_EQ(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, (__VA_ARGS__), eq)
+#    define DOCTEST_WARN_NE(...) DOCTEST_BINARY_ASSERT(DT_WARN_NE, (__VA_ARGS__), ne)
+#    define DOCTEST_CHECK_NE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, (__VA_ARGS__), ne)
+#    define DOCTEST_REQUIRE_NE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, (__VA_ARGS__), ne)
+#    define DOCTEST_WARN_GT(...) DOCTEST_BINARY_ASSERT(DT_WARN_GT, (__VA_ARGS__), gt)
+#    define DOCTEST_CHECK_GT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, (__VA_ARGS__), gt)
+#    define DOCTEST_REQUIRE_GT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, (__VA_ARGS__), gt)
+#    define DOCTEST_WARN_LT(...) DOCTEST_BINARY_ASSERT(DT_WARN_LT, (__VA_ARGS__), lt)
+#    define DOCTEST_CHECK_LT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, (__VA_ARGS__), lt)
+#    define DOCTEST_REQUIRE_LT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, (__VA_ARGS__), lt)
+#    define DOCTEST_WARN_GE(...) DOCTEST_BINARY_ASSERT(DT_WARN_GE, (__VA_ARGS__), ge)
+#    define DOCTEST_CHECK_GE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, (__VA_ARGS__), ge)
+#    define DOCTEST_REQUIRE_GE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, (__VA_ARGS__), ge)
+#    define DOCTEST_WARN_LE(...) DOCTEST_BINARY_ASSERT(DT_WARN_LE, (__VA_ARGS__), le)
+#    define DOCTEST_CHECK_LE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, (__VA_ARGS__), le)
+#    define DOCTEST_REQUIRE_LE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, (__VA_ARGS__), le)
 
-#define DOCTEST_WARN_UNARY(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, (__VA_ARGS__))
-#define DOCTEST_CHECK_UNARY(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, (__VA_ARGS__))
-#define DOCTEST_REQUIRE_UNARY(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, (__VA_ARGS__))
-#define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, (__VA_ARGS__))
-#define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, (__VA_ARGS__))
-#define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, (__VA_ARGS__))
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, lhs, rhs, eq)
-#define DOCTEST_CHECK_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, lhs, rhs, eq)
-#define DOCTEST_REQUIRE_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, lhs, rhs, eq)
-#define DOCTEST_WARN_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_NE, lhs, rhs, ne)
-#define DOCTEST_CHECK_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, lhs, rhs, ne)
-#define DOCTEST_REQUIRE_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, lhs, rhs, ne)
-#define DOCTEST_WARN_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GT, lhs, rhs, gt)
-#define DOCTEST_CHECK_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, lhs, rhs, gt)
-#define DOCTEST_REQUIRE_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, lhs, rhs, gt)
-#define DOCTEST_WARN_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LT, lhs, rhs, lt)
-#define DOCTEST_CHECK_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, lhs, rhs, lt)
-#define DOCTEST_REQUIRE_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, lhs, rhs, lt)
-#define DOCTEST_WARN_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GE, lhs, rhs, ge)
-#define DOCTEST_CHECK_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, lhs, rhs, ge)
-#define DOCTEST_REQUIRE_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, lhs, rhs, ge)
-#define DOCTEST_WARN_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LE, lhs, rhs, le)
-#define DOCTEST_CHECK_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, lhs, rhs, le)
-#define DOCTEST_REQUIRE_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, lhs, rhs, le)
+#    define DOCTEST_WARN_UNARY(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, (__VA_ARGS__))
+#    define DOCTEST_CHECK_UNARY(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, (__VA_ARGS__))
+#    define DOCTEST_REQUIRE_UNARY(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, (__VA_ARGS__))
+#    define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, (__VA_ARGS__))
+#    define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, (__VA_ARGS__))
+#    define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, (__VA_ARGS__))
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, lhs, rhs, eq)
+#    define DOCTEST_CHECK_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, lhs, rhs, eq)
+#    define DOCTEST_REQUIRE_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, lhs, rhs, eq)
+#    define DOCTEST_WARN_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_NE, lhs, rhs, ne)
+#    define DOCTEST_CHECK_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, lhs, rhs, ne)
+#    define DOCTEST_REQUIRE_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, lhs, rhs, ne)
+#    define DOCTEST_WARN_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GT, lhs, rhs, gt)
+#    define DOCTEST_CHECK_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, lhs, rhs, gt)
+#    define DOCTEST_REQUIRE_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, lhs, rhs, gt)
+#    define DOCTEST_WARN_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LT, lhs, rhs, lt)
+#    define DOCTEST_CHECK_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, lhs, rhs, lt)
+#    define DOCTEST_REQUIRE_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, lhs, rhs, lt)
+#    define DOCTEST_WARN_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GE, lhs, rhs, ge)
+#    define DOCTEST_CHECK_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, lhs, rhs, ge)
+#    define DOCTEST_REQUIRE_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, lhs, rhs, ge)
+#    define DOCTEST_WARN_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LE, lhs, rhs, le)
+#    define DOCTEST_CHECK_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, lhs, rhs, le)
+#    define DOCTEST_REQUIRE_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, lhs, rhs, le)
 
-#define DOCTEST_WARN_UNARY(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, v)
-#define DOCTEST_CHECK_UNARY(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, v)
-#define DOCTEST_REQUIRE_UNARY(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, v)
-#define DOCTEST_WARN_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, v)
-#define DOCTEST_CHECK_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, v)
-#define DOCTEST_REQUIRE_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, v)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN_UNARY(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, v)
+#    define DOCTEST_CHECK_UNARY(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, v)
+#    define DOCTEST_REQUIRE_UNARY(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, v)
+#    define DOCTEST_WARN_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, v)
+#    define DOCTEST_CHECK_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, v)
+#    define DOCTEST_REQUIRE_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, v)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#  ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                                  \
-    do {                                                                                           \
-        int _DOCTEST_FAST_RES = doctest::detail::fast_binary_assert<                               \
-                doctest::detail::binaryAssertComparison::comparison>(                              \
-                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
-                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),                                \
-                DOCTEST_HANDLE_BRACED_VA_ARGS(expr));                                              \
-        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                            \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
-        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                              \
-    } while((void)0, 0)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                              \
-    do {                                                                                           \
-        int _DOCTEST_FAST_RES = doctest::detail::fast_binary_assert<                               \
-                doctest::detail::binaryAssertComparison::comparison>(                              \
-                doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs, \
-                rhs);                                                                              \
-        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                            \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
-        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                              \
-    } while((void)0, 0)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                                     \
+        do                                                                                                  \
+        {                                                                                                   \
+          int _DOCTEST_FAST_RES =                                                                           \
+              doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(     \
+                  doctest::detail::assertType::assert_type, __FILE__, __LINE__,                             \
+                  DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)), DOCTEST_HANDLE_BRACED_VA_ARGS(expr)); \
+          if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                                   \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                                  \
+          doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                                     \
+        } while((void)0, 0)
+#    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                                \
+        do                                                                                                 \
+        {                                                                                                  \
+          int _DOCTEST_FAST_RES =                                                                          \
+              doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(    \
+                  doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs, rhs); \
+          if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                                  \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                                 \
+          doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                                    \
+        } while((void)0, 0)
+#    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                               \
-    do {                                                                                           \
-        int _DOCTEST_FAST_RES = doctest::detail::fast_unary_assert(                                \
-                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
-                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),                                \
-                DOCTEST_HANDLE_BRACED_VA_ARGS(expr));                                              \
-        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                            \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
-        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                              \
-    } while((void)0, 0)
+#    define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                              \
+      do                                                                                              \
+      {                                                                                               \
+        int _DOCTEST_FAST_RES = doctest::detail::fast_unary_assert(                                   \
+            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                             \
+            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)), DOCTEST_HANDLE_BRACED_VA_ARGS(expr)); \
+        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                               \
+          DOCTEST_BREAK_INTO_DEBUGGER();                                                              \
+        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                                 \
+      } while((void)0, 0)
 
-#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#  else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                                  \
-    doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(      \
-            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                          \
-            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),                                    \
-            DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                              \
-    doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(      \
-            doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs,     \
-            rhs)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                           \
+        doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>( \
+            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                         \
+            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)), DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
+#    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                       \
+        doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>( \
+            doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs, rhs)
+#    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                               \
-    doctest::detail::fast_unary_assert(doctest::detail::assertType::assert_type, __FILE__,         \
-                                       __LINE__,                                                   \
-                                       DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),         \
-                                       DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
+#    define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                               \
+      doctest::detail::fast_unary_assert(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
+                                         DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),           \
+                                         DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
 
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#  endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 // clang-format off
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -2713,82 +2884,82 @@ constexpr T to_lvalue = x;
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 // clang-format on
 
-#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
+#  ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#undef DOCTEST_WARN_THROWS
-#undef DOCTEST_CHECK_THROWS
-#undef DOCTEST_REQUIRE_THROWS
-#undef DOCTEST_WARN_THROWS_AS
-#undef DOCTEST_CHECK_THROWS_AS
-#undef DOCTEST_REQUIRE_THROWS_AS
-#undef DOCTEST_WARN_NOTHROW
-#undef DOCTEST_CHECK_NOTHROW
-#undef DOCTEST_REQUIRE_NOTHROW
+#    undef DOCTEST_WARN_THROWS
+#    undef DOCTEST_CHECK_THROWS
+#    undef DOCTEST_REQUIRE_THROWS
+#    undef DOCTEST_WARN_THROWS_AS
+#    undef DOCTEST_CHECK_THROWS_AS
+#    undef DOCTEST_REQUIRE_THROWS_AS
+#    undef DOCTEST_WARN_NOTHROW
+#    undef DOCTEST_CHECK_NOTHROW
+#    undef DOCTEST_REQUIRE_NOTHROW
 
-#undef DOCTEST_WARN_THROWS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_MESSAGE
-#undef DOCTEST_WARN_THROWS_AS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_AS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#undef DOCTEST_WARN_NOTHROW_MESSAGE
-#undef DOCTEST_CHECK_NOTHROW_MESSAGE
-#undef DOCTEST_REQUIRE_NOTHROW_MESSAGE
+#    undef DOCTEST_WARN_THROWS_MESSAGE
+#    undef DOCTEST_CHECK_THROWS_MESSAGE
+#    undef DOCTEST_REQUIRE_THROWS_MESSAGE
+#    undef DOCTEST_WARN_THROWS_AS_MESSAGE
+#    undef DOCTEST_CHECK_THROWS_AS_MESSAGE
+#    undef DOCTEST_REQUIRE_THROWS_AS_MESSAGE
+#    undef DOCTEST_WARN_NOTHROW_MESSAGE
+#    undef DOCTEST_CHECK_NOTHROW_MESSAGE
+#    undef DOCTEST_REQUIRE_NOTHROW_MESSAGE
 
-#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#    ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#define DOCTEST_WARN_THROWS(expr) ((void)0)
-#define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
+#      define DOCTEST_WARN_THROWS(expr) ((void)0)
+#      define DOCTEST_CHECK_THROWS(expr) ((void)0)
+#      define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
+#      ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#        define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
+#        define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
+#        define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
+#      else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#        define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
+#        define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
+#        define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
+#      endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#      define DOCTEST_WARN_NOTHROW(expr) ((void)0)
+#      define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
+#      define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
 
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#      define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
+#      define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
+#      define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
+#      define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#      define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#      define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#      define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#      define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#      define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
 
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#    else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#undef DOCTEST_REQUIRE
-#undef DOCTEST_REQUIRE_FALSE
-#undef DOCTEST_REQUIRE_MESSAGE
-#undef DOCTEST_REQUIRE_FALSE_MESSAGE
-#undef DOCTEST_REQUIRE_EQ
-#undef DOCTEST_REQUIRE_NE
-#undef DOCTEST_REQUIRE_GT
-#undef DOCTEST_REQUIRE_LT
-#undef DOCTEST_REQUIRE_GE
-#undef DOCTEST_REQUIRE_LE
-#undef DOCTEST_REQUIRE_UNARY
-#undef DOCTEST_REQUIRE_UNARY_FALSE
-#undef DOCTEST_FAST_REQUIRE_EQ
-#undef DOCTEST_FAST_REQUIRE_NE
-#undef DOCTEST_FAST_REQUIRE_GT
-#undef DOCTEST_FAST_REQUIRE_LT
-#undef DOCTEST_FAST_REQUIRE_GE
-#undef DOCTEST_FAST_REQUIRE_LE
-#undef DOCTEST_FAST_REQUIRE_UNARY
-#undef DOCTEST_FAST_REQUIRE_UNARY_FALSE
+#      undef DOCTEST_REQUIRE
+#      undef DOCTEST_REQUIRE_FALSE
+#      undef DOCTEST_REQUIRE_MESSAGE
+#      undef DOCTEST_REQUIRE_FALSE_MESSAGE
+#      undef DOCTEST_REQUIRE_EQ
+#      undef DOCTEST_REQUIRE_NE
+#      undef DOCTEST_REQUIRE_GT
+#      undef DOCTEST_REQUIRE_LT
+#      undef DOCTEST_REQUIRE_GE
+#      undef DOCTEST_REQUIRE_LE
+#      undef DOCTEST_REQUIRE_UNARY
+#      undef DOCTEST_REQUIRE_UNARY_FALSE
+#      undef DOCTEST_FAST_REQUIRE_EQ
+#      undef DOCTEST_FAST_REQUIRE_NE
+#      undef DOCTEST_FAST_REQUIRE_GT
+#      undef DOCTEST_FAST_REQUIRE_LT
+#      undef DOCTEST_FAST_REQUIRE_GE
+#      undef DOCTEST_FAST_REQUIRE_LE
+#      undef DOCTEST_FAST_REQUIRE_UNARY
+#      undef DOCTEST_FAST_REQUIRE_UNARY_FALSE
 
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 // =================================================================================================
 // == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
@@ -2796,233 +2967,232 @@ constexpr T to_lvalue = x;
 // =================================================================================================
 #else // DOCTEST_CONFIG_DISABLE
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
-    namespace                                                                                      \
-    {                                                                                              \
-        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
-        struct der : base                                                                          \
-        { void f(); };                                                                             \
-    }                                                                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#  define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name) \
+    namespace                                              \
+    {                                                      \
+    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>        \
+    struct der : base                                      \
+    {                                                      \
+      void f();                                            \
+    };                                                     \
+    }                                                      \
+    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>        \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#  define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name) \
+    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>     \
     static inline void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(name)                                                                    \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
+#  define DOCTEST_TEST_CASE(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
+#  define DOCTEST_TEST_CASE_FIXTURE(x, name) \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x, DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_TYPE_TO_STRING(x) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#define DOCTEST_TYPE_TO_STRING_IMPL(x)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#    define DOCTEST_TYPE_TO_STRING_IMPL(...)
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_TYPE_TO_STRING(x) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#    define DOCTEST_TYPE_TO_STRING_IMPL(x)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE(name, type, types)                                              \
-    template <typename type>                                                                       \
+#  define DOCTEST_TEST_CASE_TEMPLATE(name, type, types) \
+    template<typename type>                             \
     inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
-    template <typename type>                                                                       \
+#  define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id) \
+    template<typename type>                                 \
     inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types)                                          \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#  define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for subcases
-#define DOCTEST_SUBCASE(name)
+#  define DOCTEST_SUBCASE(name)
 
 // for a testsuite block
-#define DOCTEST_TEST_SUITE(name) namespace
+#  define DOCTEST_TEST_SUITE(name) namespace
 
 // for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(name) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#  define DOCTEST_TEST_SUITE_BEGIN(name) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#  define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#  define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature) \
+    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>        \
     static inline doctest::String DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)(signature)
 
-#define DOCTEST_INFO(x) ((void)0)
-#define DOCTEST_CAPTURE(x) ((void)0)
-#define DOCTEST_ADD_MESSAGE_AT(file, line, x) ((void)0)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) ((void)0)
-#define DOCTEST_ADD_FAIL_AT(file, line, x) ((void)0)
-#define DOCTEST_MESSAGE(x) ((void)0)
-#define DOCTEST_FAIL_CHECK(x) ((void)0)
-#define DOCTEST_FAIL(x) ((void)0)
+#  define DOCTEST_INFO(x) ((void)0)
+#  define DOCTEST_CAPTURE(x) ((void)0)
+#  define DOCTEST_ADD_MESSAGE_AT(file, line, x) ((void)0)
+#  define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) ((void)0)
+#  define DOCTEST_ADD_FAIL_AT(file, line, x) ((void)0)
+#  define DOCTEST_MESSAGE(x) ((void)0)
+#  define DOCTEST_FAIL_CHECK(x) ((void)0)
+#  define DOCTEST_FAIL(x) ((void)0)
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN(...) ((void)0)
-#define DOCTEST_CHECK(...) ((void)0)
-#define DOCTEST_REQUIRE(...) ((void)0)
-#define DOCTEST_WARN_FALSE(...) ((void)0)
-#define DOCTEST_CHECK_FALSE(...) ((void)0)
-#define DOCTEST_REQUIRE_FALSE(...) ((void)0)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN(expr) ((void)0)
-#define DOCTEST_CHECK(expr) ((void)0)
-#define DOCTEST_REQUIRE(expr) ((void)0)
-#define DOCTEST_WARN_FALSE(expr) ((void)0)
-#define DOCTEST_CHECK_FALSE(expr) ((void)0)
-#define DOCTEST_REQUIRE_FALSE(expr) ((void)0)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN(...) ((void)0)
+#    define DOCTEST_CHECK(...) ((void)0)
+#    define DOCTEST_REQUIRE(...) ((void)0)
+#    define DOCTEST_WARN_FALSE(...) ((void)0)
+#    define DOCTEST_CHECK_FALSE(...) ((void)0)
+#    define DOCTEST_REQUIRE_FALSE(...) ((void)0)
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN(expr) ((void)0)
+#    define DOCTEST_CHECK(expr) ((void)0)
+#    define DOCTEST_REQUIRE(expr) ((void)0)
+#    define DOCTEST_WARN_FALSE(expr) ((void)0)
+#    define DOCTEST_CHECK_FALSE(expr) ((void)0)
+#    define DOCTEST_REQUIRE_FALSE(expr) ((void)0)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_WARN_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_CHECK_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_REQUIRE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) ((void)0)
+#  define DOCTEST_WARN_MESSAGE(cond, msg) ((void)0)
+#  define DOCTEST_CHECK_MESSAGE(cond, msg) ((void)0)
+#  define DOCTEST_REQUIRE_MESSAGE(cond, msg) ((void)0)
+#  define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) ((void)0)
+#  define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) ((void)0)
+#  define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) ((void)0)
 
-#define DOCTEST_WARN_THROWS(expr) ((void)0)
-#define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
+#  define DOCTEST_WARN_THROWS(expr) ((void)0)
+#  define DOCTEST_CHECK_THROWS(expr) ((void)0)
+#  define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
+#    define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
+#    define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#    define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
+#    define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
+#    define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  define DOCTEST_WARN_NOTHROW(expr) ((void)0)
+#  define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
+#  define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
 
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#  define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
+#  define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
+#  define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
+#  define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#  define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#  define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#  define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#  define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#  define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
 
-#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_WARN_EQ(...) ((void)0)
-#define DOCTEST_CHECK_EQ(...) ((void)0)
-#define DOCTEST_REQUIRE_EQ(...) ((void)0)
-#define DOCTEST_WARN_NE(...) ((void)0)
-#define DOCTEST_CHECK_NE(...) ((void)0)
-#define DOCTEST_REQUIRE_NE(...) ((void)0)
-#define DOCTEST_WARN_GT(...) ((void)0)
-#define DOCTEST_CHECK_GT(...) ((void)0)
-#define DOCTEST_REQUIRE_GT(...) ((void)0)
-#define DOCTEST_WARN_LT(...) ((void)0)
-#define DOCTEST_CHECK_LT(...) ((void)0)
-#define DOCTEST_REQUIRE_LT(...) ((void)0)
-#define DOCTEST_WARN_GE(...) ((void)0)
-#define DOCTEST_CHECK_GE(...) ((void)0)
-#define DOCTEST_REQUIRE_GE(...) ((void)0)
-#define DOCTEST_WARN_LE(...) ((void)0)
-#define DOCTEST_CHECK_LE(...) ((void)0)
-#define DOCTEST_REQUIRE_LE(...) ((void)0)
+#    define DOCTEST_WARN_EQ(...) ((void)0)
+#    define DOCTEST_CHECK_EQ(...) ((void)0)
+#    define DOCTEST_REQUIRE_EQ(...) ((void)0)
+#    define DOCTEST_WARN_NE(...) ((void)0)
+#    define DOCTEST_CHECK_NE(...) ((void)0)
+#    define DOCTEST_REQUIRE_NE(...) ((void)0)
+#    define DOCTEST_WARN_GT(...) ((void)0)
+#    define DOCTEST_CHECK_GT(...) ((void)0)
+#    define DOCTEST_REQUIRE_GT(...) ((void)0)
+#    define DOCTEST_WARN_LT(...) ((void)0)
+#    define DOCTEST_CHECK_LT(...) ((void)0)
+#    define DOCTEST_REQUIRE_LT(...) ((void)0)
+#    define DOCTEST_WARN_GE(...) ((void)0)
+#    define DOCTEST_CHECK_GE(...) ((void)0)
+#    define DOCTEST_REQUIRE_GE(...) ((void)0)
+#    define DOCTEST_WARN_LE(...) ((void)0)
+#    define DOCTEST_CHECK_LE(...) ((void)0)
+#    define DOCTEST_REQUIRE_LE(...) ((void)0)
 
-#define DOCTEST_WARN_UNARY(...) ((void)0)
-#define DOCTEST_CHECK_UNARY(...) ((void)0)
-#define DOCTEST_REQUIRE_UNARY(...) ((void)0)
-#define DOCTEST_WARN_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
+#    define DOCTEST_WARN_UNARY(...) ((void)0)
+#    define DOCTEST_CHECK_UNARY(...) ((void)0)
+#    define DOCTEST_REQUIRE_UNARY(...) ((void)0)
+#    define DOCTEST_WARN_UNARY_FALSE(...) ((void)0)
+#    define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
+#    define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
 
-#define DOCTEST_FAST_WARN_EQ(...) ((void)0)
-#define DOCTEST_FAST_CHECK_EQ(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_EQ(...) ((void)0)
-#define DOCTEST_FAST_WARN_NE(...) ((void)0)
-#define DOCTEST_FAST_CHECK_NE(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_NE(...) ((void)0)
-#define DOCTEST_FAST_WARN_GT(...) ((void)0)
-#define DOCTEST_FAST_CHECK_GT(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_GT(...) ((void)0)
-#define DOCTEST_FAST_WARN_LT(...) ((void)0)
-#define DOCTEST_FAST_CHECK_LT(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_LT(...) ((void)0)
-#define DOCTEST_FAST_WARN_GE(...) ((void)0)
-#define DOCTEST_FAST_CHECK_GE(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_GE(...) ((void)0)
-#define DOCTEST_FAST_WARN_LE(...) ((void)0)
-#define DOCTEST_FAST_CHECK_LE(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_LE(...) ((void)0)
+#    define DOCTEST_FAST_WARN_EQ(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_EQ(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_EQ(...) ((void)0)
+#    define DOCTEST_FAST_WARN_NE(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_NE(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_NE(...) ((void)0)
+#    define DOCTEST_FAST_WARN_GT(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_GT(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_GT(...) ((void)0)
+#    define DOCTEST_FAST_WARN_LT(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_LT(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_LT(...) ((void)0)
+#    define DOCTEST_FAST_WARN_GE(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_GE(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_GE(...) ((void)0)
+#    define DOCTEST_FAST_WARN_LE(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_LE(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_LE(...) ((void)0)
 
-#define DOCTEST_FAST_WARN_UNARY(...) ((void)0)
-#define DOCTEST_FAST_CHECK_UNARY(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_UNARY(...) ((void)0)
-#define DOCTEST_FAST_WARN_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_FAST_CHECK_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_FAST_REQUIRE_UNARY_FALSE(...) ((void)0)
+#    define DOCTEST_FAST_WARN_UNARY(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_UNARY(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_UNARY(...) ((void)0)
+#    define DOCTEST_FAST_WARN_UNARY_FALSE(...) ((void)0)
+#    define DOCTEST_FAST_CHECK_UNARY_FALSE(...) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_UNARY_FALSE(...) ((void)0)
 
-#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#define DOCTEST_WARN_EQ(lhs, rhs) ((void)0)
-#define DOCTEST_CHECK_EQ(lhs, rhs) ((void)0)
-#define DOCTEST_REQUIRE_EQ(lhs, rhs) ((void)0)
-#define DOCTEST_WARN_NE(lhs, rhs) ((void)0)
-#define DOCTEST_CHECK_NE(lhs, rhs) ((void)0)
-#define DOCTEST_REQUIRE_NE(lhs, rhs) ((void)0)
-#define DOCTEST_WARN_GT(lhs, rhs) ((void)0)
-#define DOCTEST_CHECK_GT(lhs, rhs) ((void)0)
-#define DOCTEST_REQUIRE_GT(lhs, rhs) ((void)0)
-#define DOCTEST_WARN_LT(lhs, rhs) ((void)0)
-#define DOCTEST_CHECK_LT(lhs, rhs) ((void)0)
-#define DOCTEST_REQUIRE_LT(lhs, rhs) ((void)0)
-#define DOCTEST_WARN_GE(lhs, rhs) ((void)0)
-#define DOCTEST_CHECK_GE(lhs, rhs) ((void)0)
-#define DOCTEST_REQUIRE_GE(lhs, rhs) ((void)0)
-#define DOCTEST_WARN_LE(lhs, rhs) ((void)0)
-#define DOCTEST_CHECK_LE(lhs, rhs) ((void)0)
-#define DOCTEST_REQUIRE_LE(lhs, rhs) ((void)0)
+#    define DOCTEST_WARN_EQ(lhs, rhs) ((void)0)
+#    define DOCTEST_CHECK_EQ(lhs, rhs) ((void)0)
+#    define DOCTEST_REQUIRE_EQ(lhs, rhs) ((void)0)
+#    define DOCTEST_WARN_NE(lhs, rhs) ((void)0)
+#    define DOCTEST_CHECK_NE(lhs, rhs) ((void)0)
+#    define DOCTEST_REQUIRE_NE(lhs, rhs) ((void)0)
+#    define DOCTEST_WARN_GT(lhs, rhs) ((void)0)
+#    define DOCTEST_CHECK_GT(lhs, rhs) ((void)0)
+#    define DOCTEST_REQUIRE_GT(lhs, rhs) ((void)0)
+#    define DOCTEST_WARN_LT(lhs, rhs) ((void)0)
+#    define DOCTEST_CHECK_LT(lhs, rhs) ((void)0)
+#    define DOCTEST_REQUIRE_LT(lhs, rhs) ((void)0)
+#    define DOCTEST_WARN_GE(lhs, rhs) ((void)0)
+#    define DOCTEST_CHECK_GE(lhs, rhs) ((void)0)
+#    define DOCTEST_REQUIRE_GE(lhs, rhs) ((void)0)
+#    define DOCTEST_WARN_LE(lhs, rhs) ((void)0)
+#    define DOCTEST_CHECK_LE(lhs, rhs) ((void)0)
+#    define DOCTEST_REQUIRE_LE(lhs, rhs) ((void)0)
 
-#define DOCTEST_WARN_UNARY(val) ((void)0)
-#define DOCTEST_CHECK_UNARY(val) ((void)0)
-#define DOCTEST_REQUIRE_UNARY(val) ((void)0)
-#define DOCTEST_WARN_UNARY_FALSE(val) ((void)0)
-#define DOCTEST_CHECK_UNARY_FALSE(val) ((void)0)
-#define DOCTEST_REQUIRE_UNARY_FALSE(val) ((void)0)
+#    define DOCTEST_WARN_UNARY(val) ((void)0)
+#    define DOCTEST_CHECK_UNARY(val) ((void)0)
+#    define DOCTEST_REQUIRE_UNARY(val) ((void)0)
+#    define DOCTEST_WARN_UNARY_FALSE(val) ((void)0)
+#    define DOCTEST_CHECK_UNARY_FALSE(val) ((void)0)
+#    define DOCTEST_REQUIRE_UNARY_FALSE(val) ((void)0)
 
-#define DOCTEST_FAST_WARN_EQ(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_CHECK_EQ(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_REQUIRE_EQ(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_WARN_NE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_CHECK_NE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_REQUIRE_NE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_WARN_GT(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_CHECK_GT(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_REQUIRE_GT(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_WARN_LT(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_CHECK_LT(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_REQUIRE_LT(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_WARN_GE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_CHECK_GE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_REQUIRE_GE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_WARN_LE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_CHECK_LE(lhs, rhs) ((void)0)
-#define DOCTEST_FAST_REQUIRE_LE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_WARN_EQ(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_CHECK_EQ(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_EQ(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_WARN_NE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_CHECK_NE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_NE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_WARN_GT(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_CHECK_GT(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_GT(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_WARN_LT(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_CHECK_LT(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_LT(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_WARN_GE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_CHECK_GE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_GE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_WARN_LE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_CHECK_LE(lhs, rhs) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_LE(lhs, rhs) ((void)0)
 
-#define DOCTEST_FAST_WARN_UNARY(val) ((void)0)
-#define DOCTEST_FAST_CHECK_UNARY(val) ((void)0)
-#define DOCTEST_FAST_REQUIRE_UNARY(val) ((void)0)
-#define DOCTEST_FAST_WARN_UNARY_FALSE(val) ((void)0)
-#define DOCTEST_FAST_CHECK_UNARY_FALSE(val) ((void)0)
-#define DOCTEST_FAST_REQUIRE_UNARY_FALSE(val) ((void)0)
+#    define DOCTEST_FAST_WARN_UNARY(val) ((void)0)
+#    define DOCTEST_FAST_CHECK_UNARY(val) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_UNARY(val) ((void)0)
+#    define DOCTEST_FAST_WARN_UNARY_FALSE(val) ((void)0)
+#    define DOCTEST_FAST_CHECK_UNARY_FALSE(val) ((void)0)
+#    define DOCTEST_FAST_REQUIRE_UNARY_FALSE(val) ((void)0)
 
-#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -3046,117 +3216,117 @@ constexpr T to_lvalue = x;
 // == SHORT VERSIONS OF THE MACROS
 #if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
 
-#define TEST_CASE DOCTEST_TEST_CASE
-#define TEST_CASE_FIXTURE DOCTEST_TEST_CASE_FIXTURE
-#define TYPE_TO_STRING DOCTEST_TYPE_TO_STRING
-#define TEST_CASE_TEMPLATE DOCTEST_TEST_CASE_TEMPLATE
-#define TEST_CASE_TEMPLATE_DEFINE DOCTEST_TEST_CASE_TEMPLATE_DEFINE
-#define TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE
-#define SUBCASE DOCTEST_SUBCASE
-#define TEST_SUITE DOCTEST_TEST_SUITE
-#define TEST_SUITE_BEGIN DOCTEST_TEST_SUITE_BEGIN
-#define TEST_SUITE_END DOCTEST_TEST_SUITE_END
-#define REGISTER_EXCEPTION_TRANSLATOR DOCTEST_REGISTER_EXCEPTION_TRANSLATOR
-#define INFO DOCTEST_INFO
-#define CAPTURE DOCTEST_CAPTURE
-#define ADD_MESSAGE_AT DOCTEST_ADD_MESSAGE_AT
-#define ADD_FAIL_CHECK_AT DOCTEST_ADD_FAIL_CHECK_AT
-#define ADD_FAIL_AT DOCTEST_ADD_FAIL_AT
-#define MESSAGE DOCTEST_MESSAGE
-#define FAIL_CHECK DOCTEST_FAIL_CHECK
-#define FAIL DOCTEST_FAIL
-#define TO_LVALUE DOCTEST_TO_LVALUE
+#  define TEST_CASE DOCTEST_TEST_CASE
+#  define TEST_CASE_FIXTURE DOCTEST_TEST_CASE_FIXTURE
+#  define TYPE_TO_STRING DOCTEST_TYPE_TO_STRING
+#  define TEST_CASE_TEMPLATE DOCTEST_TEST_CASE_TEMPLATE
+#  define TEST_CASE_TEMPLATE_DEFINE DOCTEST_TEST_CASE_TEMPLATE_DEFINE
+#  define TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE
+#  define SUBCASE DOCTEST_SUBCASE
+#  define TEST_SUITE DOCTEST_TEST_SUITE
+#  define TEST_SUITE_BEGIN DOCTEST_TEST_SUITE_BEGIN
+#  define TEST_SUITE_END DOCTEST_TEST_SUITE_END
+#  define REGISTER_EXCEPTION_TRANSLATOR DOCTEST_REGISTER_EXCEPTION_TRANSLATOR
+#  define INFO DOCTEST_INFO
+#  define CAPTURE DOCTEST_CAPTURE
+#  define ADD_MESSAGE_AT DOCTEST_ADD_MESSAGE_AT
+#  define ADD_FAIL_CHECK_AT DOCTEST_ADD_FAIL_CHECK_AT
+#  define ADD_FAIL_AT DOCTEST_ADD_FAIL_AT
+#  define MESSAGE DOCTEST_MESSAGE
+#  define FAIL_CHECK DOCTEST_FAIL_CHECK
+#  define FAIL DOCTEST_FAIL
+#  define TO_LVALUE DOCTEST_TO_LVALUE
 
-#define WARN DOCTEST_WARN
-#define WARN_FALSE DOCTEST_WARN_FALSE
-#define WARN_THROWS DOCTEST_WARN_THROWS
-#define WARN_THROWS_AS DOCTEST_WARN_THROWS_AS
-#define WARN_NOTHROW DOCTEST_WARN_NOTHROW
-#define CHECK DOCTEST_CHECK
-#define CHECK_FALSE DOCTEST_CHECK_FALSE
-#define CHECK_THROWS DOCTEST_CHECK_THROWS
-#define CHECK_THROWS_AS DOCTEST_CHECK_THROWS_AS
-#define CHECK_NOTHROW DOCTEST_CHECK_NOTHROW
-#define REQUIRE DOCTEST_REQUIRE
-#define REQUIRE_FALSE DOCTEST_REQUIRE_FALSE
-#define REQUIRE_THROWS DOCTEST_REQUIRE_THROWS
-#define REQUIRE_THROWS_AS DOCTEST_REQUIRE_THROWS_AS
-#define REQUIRE_NOTHROW DOCTEST_REQUIRE_NOTHROW
+#  define WARN DOCTEST_WARN
+#  define WARN_FALSE DOCTEST_WARN_FALSE
+#  define WARN_THROWS DOCTEST_WARN_THROWS
+#  define WARN_THROWS_AS DOCTEST_WARN_THROWS_AS
+#  define WARN_NOTHROW DOCTEST_WARN_NOTHROW
+#  define CHECK DOCTEST_CHECK
+#  define CHECK_FALSE DOCTEST_CHECK_FALSE
+#  define CHECK_THROWS DOCTEST_CHECK_THROWS
+#  define CHECK_THROWS_AS DOCTEST_CHECK_THROWS_AS
+#  define CHECK_NOTHROW DOCTEST_CHECK_NOTHROW
+#  define REQUIRE DOCTEST_REQUIRE
+#  define REQUIRE_FALSE DOCTEST_REQUIRE_FALSE
+#  define REQUIRE_THROWS DOCTEST_REQUIRE_THROWS
+#  define REQUIRE_THROWS_AS DOCTEST_REQUIRE_THROWS_AS
+#  define REQUIRE_NOTHROW DOCTEST_REQUIRE_NOTHROW
 
-#define WARN_MESSAGE DOCTEST_WARN_MESSAGE
-#define WARN_FALSE_MESSAGE DOCTEST_WARN_FALSE_MESSAGE
-#define WARN_THROWS_MESSAGE DOCTEST_WARN_THROWS_MESSAGE
-#define WARN_THROWS_AS_MESSAGE DOCTEST_WARN_THROWS_AS_MESSAGE
-#define WARN_NOTHROW_MESSAGE DOCTEST_WARN_NOTHROW_MESSAGE
-#define CHECK_MESSAGE DOCTEST_CHECK_MESSAGE
-#define CHECK_FALSE_MESSAGE DOCTEST_CHECK_FALSE_MESSAGE
-#define CHECK_THROWS_MESSAGE DOCTEST_CHECK_THROWS_MESSAGE
-#define CHECK_THROWS_AS_MESSAGE DOCTEST_CHECK_THROWS_AS_MESSAGE
-#define CHECK_NOTHROW_MESSAGE DOCTEST_CHECK_NOTHROW_MESSAGE
-#define REQUIRE_MESSAGE DOCTEST_REQUIRE_MESSAGE
-#define REQUIRE_FALSE_MESSAGE DOCTEST_REQUIRE_FALSE_MESSAGE
-#define REQUIRE_THROWS_MESSAGE DOCTEST_REQUIRE_THROWS_MESSAGE
-#define REQUIRE_THROWS_AS_MESSAGE DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
+#  define WARN_MESSAGE DOCTEST_WARN_MESSAGE
+#  define WARN_FALSE_MESSAGE DOCTEST_WARN_FALSE_MESSAGE
+#  define WARN_THROWS_MESSAGE DOCTEST_WARN_THROWS_MESSAGE
+#  define WARN_THROWS_AS_MESSAGE DOCTEST_WARN_THROWS_AS_MESSAGE
+#  define WARN_NOTHROW_MESSAGE DOCTEST_WARN_NOTHROW_MESSAGE
+#  define CHECK_MESSAGE DOCTEST_CHECK_MESSAGE
+#  define CHECK_FALSE_MESSAGE DOCTEST_CHECK_FALSE_MESSAGE
+#  define CHECK_THROWS_MESSAGE DOCTEST_CHECK_THROWS_MESSAGE
+#  define CHECK_THROWS_AS_MESSAGE DOCTEST_CHECK_THROWS_AS_MESSAGE
+#  define CHECK_NOTHROW_MESSAGE DOCTEST_CHECK_NOTHROW_MESSAGE
+#  define REQUIRE_MESSAGE DOCTEST_REQUIRE_MESSAGE
+#  define REQUIRE_FALSE_MESSAGE DOCTEST_REQUIRE_FALSE_MESSAGE
+#  define REQUIRE_THROWS_MESSAGE DOCTEST_REQUIRE_THROWS_MESSAGE
+#  define REQUIRE_THROWS_AS_MESSAGE DOCTEST_REQUIRE_THROWS_AS_MESSAGE
+#  define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
 
-#define SCENARIO DOCTEST_SCENARIO
-#define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
-#define SCENARIO_TEMPLATE_DEFINE DOCTEST_SCENARIO_TEMPLATE_DEFINE
-#define GIVEN DOCTEST_GIVEN
-#define WHEN DOCTEST_WHEN
-#define AND_WHEN DOCTEST_AND_WHEN
-#define THEN DOCTEST_THEN
-#define AND_THEN DOCTEST_AND_THEN
+#  define SCENARIO DOCTEST_SCENARIO
+#  define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
+#  define SCENARIO_TEMPLATE_DEFINE DOCTEST_SCENARIO_TEMPLATE_DEFINE
+#  define GIVEN DOCTEST_GIVEN
+#  define WHEN DOCTEST_WHEN
+#  define AND_WHEN DOCTEST_AND_WHEN
+#  define THEN DOCTEST_THEN
+#  define AND_THEN DOCTEST_AND_THEN
 
-#define WARN_EQ DOCTEST_WARN_EQ
-#define CHECK_EQ DOCTEST_CHECK_EQ
-#define REQUIRE_EQ DOCTEST_REQUIRE_EQ
-#define WARN_NE DOCTEST_WARN_NE
-#define CHECK_NE DOCTEST_CHECK_NE
-#define REQUIRE_NE DOCTEST_REQUIRE_NE
-#define WARN_GT DOCTEST_WARN_GT
-#define CHECK_GT DOCTEST_CHECK_GT
-#define REQUIRE_GT DOCTEST_REQUIRE_GT
-#define WARN_LT DOCTEST_WARN_LT
-#define CHECK_LT DOCTEST_CHECK_LT
-#define REQUIRE_LT DOCTEST_REQUIRE_LT
-#define WARN_GE DOCTEST_WARN_GE
-#define CHECK_GE DOCTEST_CHECK_GE
-#define REQUIRE_GE DOCTEST_REQUIRE_GE
-#define WARN_LE DOCTEST_WARN_LE
-#define CHECK_LE DOCTEST_CHECK_LE
-#define REQUIRE_LE DOCTEST_REQUIRE_LE
-#define WARN_UNARY DOCTEST_WARN_UNARY
-#define CHECK_UNARY DOCTEST_CHECK_UNARY
-#define REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
-#define WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
-#define CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
-#define REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
+#  define WARN_EQ DOCTEST_WARN_EQ
+#  define CHECK_EQ DOCTEST_CHECK_EQ
+#  define REQUIRE_EQ DOCTEST_REQUIRE_EQ
+#  define WARN_NE DOCTEST_WARN_NE
+#  define CHECK_NE DOCTEST_CHECK_NE
+#  define REQUIRE_NE DOCTEST_REQUIRE_NE
+#  define WARN_GT DOCTEST_WARN_GT
+#  define CHECK_GT DOCTEST_CHECK_GT
+#  define REQUIRE_GT DOCTEST_REQUIRE_GT
+#  define WARN_LT DOCTEST_WARN_LT
+#  define CHECK_LT DOCTEST_CHECK_LT
+#  define REQUIRE_LT DOCTEST_REQUIRE_LT
+#  define WARN_GE DOCTEST_WARN_GE
+#  define CHECK_GE DOCTEST_CHECK_GE
+#  define REQUIRE_GE DOCTEST_REQUIRE_GE
+#  define WARN_LE DOCTEST_WARN_LE
+#  define CHECK_LE DOCTEST_CHECK_LE
+#  define REQUIRE_LE DOCTEST_REQUIRE_LE
+#  define WARN_UNARY DOCTEST_WARN_UNARY
+#  define CHECK_UNARY DOCTEST_CHECK_UNARY
+#  define REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
+#  define WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
+#  define CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
+#  define REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
 
-#define FAST_WARN_EQ DOCTEST_FAST_WARN_EQ
-#define FAST_CHECK_EQ DOCTEST_FAST_CHECK_EQ
-#define FAST_REQUIRE_EQ DOCTEST_FAST_REQUIRE_EQ
-#define FAST_WARN_NE DOCTEST_FAST_WARN_NE
-#define FAST_CHECK_NE DOCTEST_FAST_CHECK_NE
-#define FAST_REQUIRE_NE DOCTEST_FAST_REQUIRE_NE
-#define FAST_WARN_GT DOCTEST_FAST_WARN_GT
-#define FAST_CHECK_GT DOCTEST_FAST_CHECK_GT
-#define FAST_REQUIRE_GT DOCTEST_FAST_REQUIRE_GT
-#define FAST_WARN_LT DOCTEST_FAST_WARN_LT
-#define FAST_CHECK_LT DOCTEST_FAST_CHECK_LT
-#define FAST_REQUIRE_LT DOCTEST_FAST_REQUIRE_LT
-#define FAST_WARN_GE DOCTEST_FAST_WARN_GE
-#define FAST_CHECK_GE DOCTEST_FAST_CHECK_GE
-#define FAST_REQUIRE_GE DOCTEST_FAST_REQUIRE_GE
-#define FAST_WARN_LE DOCTEST_FAST_WARN_LE
-#define FAST_CHECK_LE DOCTEST_FAST_CHECK_LE
-#define FAST_REQUIRE_LE DOCTEST_FAST_REQUIRE_LE
-#define FAST_WARN_UNARY DOCTEST_FAST_WARN_UNARY
-#define FAST_CHECK_UNARY DOCTEST_FAST_CHECK_UNARY
-#define FAST_REQUIRE_UNARY DOCTEST_FAST_REQUIRE_UNARY
-#define FAST_WARN_UNARY_FALSE DOCTEST_FAST_WARN_UNARY_FALSE
-#define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
-#define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
+#  define FAST_WARN_EQ DOCTEST_FAST_WARN_EQ
+#  define FAST_CHECK_EQ DOCTEST_FAST_CHECK_EQ
+#  define FAST_REQUIRE_EQ DOCTEST_FAST_REQUIRE_EQ
+#  define FAST_WARN_NE DOCTEST_FAST_WARN_NE
+#  define FAST_CHECK_NE DOCTEST_FAST_CHECK_NE
+#  define FAST_REQUIRE_NE DOCTEST_FAST_REQUIRE_NE
+#  define FAST_WARN_GT DOCTEST_FAST_WARN_GT
+#  define FAST_CHECK_GT DOCTEST_FAST_CHECK_GT
+#  define FAST_REQUIRE_GT DOCTEST_FAST_REQUIRE_GT
+#  define FAST_WARN_LT DOCTEST_FAST_WARN_LT
+#  define FAST_CHECK_LT DOCTEST_FAST_CHECK_LT
+#  define FAST_REQUIRE_LT DOCTEST_FAST_REQUIRE_LT
+#  define FAST_WARN_GE DOCTEST_FAST_WARN_GE
+#  define FAST_CHECK_GE DOCTEST_FAST_CHECK_GE
+#  define FAST_REQUIRE_GE DOCTEST_FAST_REQUIRE_GE
+#  define FAST_WARN_LE DOCTEST_FAST_WARN_LE
+#  define FAST_CHECK_LE DOCTEST_FAST_CHECK_LE
+#  define FAST_REQUIRE_LE DOCTEST_FAST_REQUIRE_LE
+#  define FAST_WARN_UNARY DOCTEST_FAST_WARN_UNARY
+#  define FAST_CHECK_UNARY DOCTEST_FAST_CHECK_UNARY
+#  define FAST_REQUIRE_UNARY DOCTEST_FAST_REQUIRE_UNARY
+#  define FAST_WARN_UNARY_FALSE DOCTEST_FAST_WARN_UNARY_FALSE
+#  define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
+#  define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
 
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
@@ -3168,23 +3338,23 @@ namespace doctest
 {
 namespace detail
 {
-    DOCTEST_TYPE_TO_STRING_IMPL(bool)
-    DOCTEST_TYPE_TO_STRING_IMPL(float)
-    DOCTEST_TYPE_TO_STRING_IMPL(double)
-    DOCTEST_TYPE_TO_STRING_IMPL(long double)
-    DOCTEST_TYPE_TO_STRING_IMPL(char)
-    DOCTEST_TYPE_TO_STRING_IMPL(signed char)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned char)
-    DOCTEST_TYPE_TO_STRING_IMPL(wchar_t)
-    DOCTEST_TYPE_TO_STRING_IMPL(short int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned short int)
-    DOCTEST_TYPE_TO_STRING_IMPL(int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned int)
-    DOCTEST_TYPE_TO_STRING_IMPL(long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
+DOCTEST_TYPE_TO_STRING_IMPL(bool)
+DOCTEST_TYPE_TO_STRING_IMPL(float)
+DOCTEST_TYPE_TO_STRING_IMPL(double)
+DOCTEST_TYPE_TO_STRING_IMPL(long double)
+DOCTEST_TYPE_TO_STRING_IMPL(char)
+DOCTEST_TYPE_TO_STRING_IMPL(signed char)
+DOCTEST_TYPE_TO_STRING_IMPL(unsigned char)
+DOCTEST_TYPE_TO_STRING_IMPL(wchar_t)
+DOCTEST_TYPE_TO_STRING_IMPL(short int)
+DOCTEST_TYPE_TO_STRING_IMPL(unsigned short int)
+DOCTEST_TYPE_TO_STRING_IMPL(int)
+DOCTEST_TYPE_TO_STRING_IMPL(unsigned int)
+DOCTEST_TYPE_TO_STRING_IMPL(long int)
+DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
 #ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-    DOCTEST_TYPE_TO_STRING_IMPL(long long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
+DOCTEST_TYPE_TO_STRING_IMPL(long long int)
+DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
 #endif // DOCTEST_CONFIG_WITH_LONG_LONG
 } // namespace detail
 } // namespace doctest
@@ -3201,11 +3371,11 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT) || !defined(DOCTEST_SINGLE_HEADER)
 #ifndef DOCTEST_LIBRARY_IMPLEMENTATION
-#define DOCTEST_LIBRARY_IMPLEMENTATION
+#  define DOCTEST_LIBRARY_IMPLEMENTATION
 
-#ifndef DOCTEST_SINGLE_HEADER
-#include "doctest_fwd.h"
-#endif // DOCTEST_SINGLE_HEADER
+#  ifndef DOCTEST_SINGLE_HEADER
+#    include "doctest_fwd.h"
+#  endif // DOCTEST_SINGLE_HEADER
 
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
@@ -3225,9 +3395,9 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++11-long-long")
-#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_WARNING("-Wzero-as-null-pointer-constant")
+#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_WARNING("-Wzero-as-null-pointer-constant")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wzero-as-null-pointer-constant")
-#endif // clang - 0 as null
+#  endif // clang - 0 as null
 
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")
@@ -3245,15 +3415,15 @@ DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wlong-long")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
 DOCTEST_GCC_SUPPRESS_WARNING("-Wzero-as-null-pointer-constant")
-#endif // GCC 4.7+
-#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 8, 0)
+#  endif // GCC 4.7+
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 8, 0)
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
-#endif // GCC 4.8+
-#if DOCTEST_GCC >= DOCTEST_COMPILER(5, 4, 0)
+#  endif // GCC 4.8+
+#  if DOCTEST_GCC >= DOCTEST_COMPILER(5, 4, 0)
 DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
-#endif // GCC 5.4+
+#  endif // GCC 5.4+
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
 DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
@@ -3270,53 +3440,55 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4365) // conversion from 'int' to 'unsigned', sign
 DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding in structs
 DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
 
-#if defined(DOCTEST_NO_CPP11_COMPAT)
+#  if defined(DOCTEST_NO_CPP11_COMPAT)
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
-#endif // DOCTEST_NO_CPP11_COMPAT
+#  endif // DOCTEST_NO_CPP11_COMPAT
 
 // snprintf() not in the C++98 standard
-#if DOCTEST_MSVC
-#define DOCTEST_SNPRINTF _snprintf
-#else // MSVC
-#define DOCTEST_SNPRINTF std::snprintf
-#endif // MSVC
+#  if DOCTEST_MSVC
+#    define DOCTEST_SNPRINTF _snprintf
+#  else // MSVC
+#    define DOCTEST_SNPRINTF std::snprintf
+#  endif // MSVC
 
-#define DOCTEST_LOG_START()                                                                        \
-    do {                                                                                           \
-        if(!contextState->hasLoggedCurrentTestStart) {                                             \
-            logTestStart(*contextState->currentTest);                                              \
-            contextState->hasLoggedCurrentTestStart = true;                                        \
-        }                                                                                          \
+#  define DOCTEST_LOG_START()                           \
+    do                                                  \
+    {                                                   \
+      if(!contextState->hasLoggedCurrentTestStart)      \
+      {                                                 \
+        logTestStart(*contextState->currentTest);       \
+        contextState->hasLoggedCurrentTestStart = true; \
+      }                                                 \
     } while(false)
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
 // required includes - will go only in one translation unit!
-#include <ctime>
-#include <cmath>
+#  include <ctime>
+#  include <cmath>
 // borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/onqtam/doctest/pull/37
-#ifdef __BORLANDC__
-#include <math.h>
-#endif // __BORLANDC__
-#include <new>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <limits>
-#include <utility>
-#include <sstream>
-#include <algorithm>
-#include <iomanip>
-#include <vector>
-#include <set>
-#include <exception>
-#include <stdexcept>
-#include <csignal>
-#include <cfloat>
-#if !DOCTEST_MSVC
-#include <stdint.h>
-#endif // !MSVC
+#  ifdef __BORLANDC__
+#    include <math.h>
+#  endif // __BORLANDC__
+#  include <new>
+#  include <cstdio>
+#  include <cstdlib>
+#  include <cstring>
+#  include <limits>
+#  include <utility>
+#  include <sstream>
+#  include <algorithm>
+#  include <iomanip>
+#  include <vector>
+#  include <set>
+#  include <exception>
+#  include <stdexcept>
+#  include <csignal>
+#  include <cfloat>
+#  if !DOCTEST_MSVC
+#    include <stdint.h>
+#  endif // !MSVC
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
@@ -3324,470 +3496,514 @@ namespace doctest
 {
 namespace detail
 {
-    // lowers ascii letters
-    char tolower(const char c) { return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c; }
+// lowers ascii letters
+char tolower(const char c) { return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c; }
 
-    template <typename T>
-    T my_max(const T& lhs, const T& rhs) {
-        return lhs > rhs ? lhs : rhs;
-    }
+template<typename T>
+T my_max(const T & lhs, const T & rhs)
+{
+  return lhs > rhs ? lhs : rhs;
+}
 
-    // case insensitive strcmp
-    int stricmp(char const* a, char const* b) {
-        for(;; a++, b++) {
-            const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
-        }
-    }
+// case insensitive strcmp
+int stricmp(char const * a, char const * b)
+{
+  for(;; a++, b++)
+  {
+    const int d = tolower(*a) - tolower(*b);
+    if(d != 0 || !*a)
+      return d;
+  }
+}
 
-    void my_memcpy(void* dest, const void* src, unsigned num) {
-        const char* csrc  = static_cast<const char*>(src);
-        char*       cdest = static_cast<char*>(dest);
-        for(unsigned i = 0; i < num; ++i)
-            cdest[i] = csrc[i];
-    }
+void my_memcpy(void * dest, const void * src, unsigned num)
+{
+  const char * csrc = static_cast<const char *>(src);
+  char * cdest = static_cast<char *>(dest);
+  for(unsigned i = 0; i < num; ++i)
+    cdest[i] = csrc[i];
+}
 
-    // not using std::strlen() because of valgrind errors when optimizations are turned on
-    // 'Invalid read of size 4' when the test suite len (with '\0') is not a multiple of 4
-    // for details see http://stackoverflow.com/questions/35671155
-    unsigned my_strlen(const char* in) {
-        const char* temp = in;
-        while(temp && *temp)
-            ++temp;
-        return unsigned(temp - in);
-    }
+// not using std::strlen() because of valgrind errors when optimizations are turned on
+// 'Invalid read of size 4' when the test suite len (with '\0') is not a multiple of 4
+// for details see http://stackoverflow.com/questions/35671155
+unsigned my_strlen(const char * in)
+{
+  const char * temp = in;
+  while(temp && *temp)
+    ++temp;
+  return unsigned(temp - in);
+}
 
-    template <typename T>
-    String fpToString(T value, int precision) {
-        std::ostringstream oss;
-        oss << std::setprecision(precision) << std::fixed << value;
-        std::string d = oss.str();
-        size_t      i = d.find_last_not_of('0');
-        if(i != std::string::npos && i != d.size() - 1) {
-            if(d[i] == '.')
-                i++;
-            d = d.substr(0, i + 1);
-        }
-        return d.c_str();
-    }
+template<typename T>
+String fpToString(T value, int precision)
+{
+  std::ostringstream oss;
+  oss << std::setprecision(precision) << std::fixed << value;
+  std::string d = oss.str();
+  size_t i = d.find_last_not_of('0');
+  if(i != std::string::npos && i != d.size() - 1)
+  {
+    if(d[i] == '.')
+      i++;
+    d = d.substr(0, i + 1);
+  }
+  return d.c_str();
+}
 
-    struct Endianness
-    {
-        enum Arch
-        {
-            Big,
-            Little
-        };
+struct Endianness
+{
+  enum Arch
+  {
+    Big,
+    Little
+  };
 
-        static Arch which() {
-            union _
-            {
-                int  asInt;
-                char asChar[sizeof(int)];
-            } u;
+  static Arch which()
+  {
+    union _ {
+      int asInt;
+      char asChar[sizeof(int)];
+    } u;
 
-            u.asInt = 1;                                            // NOLINT
-            return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
-        }
-    };
+    u.asInt = 1; // NOLINT
+    return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
+  }
+};
 
-    String rawMemoryToString(const void* object, unsigned size) {
-        // Reverse order for little endian architectures
-        int i = 0, end = static_cast<int>(size), inc = 1;
-        if(Endianness::which() == Endianness::Little) {
-            i   = end - 1;
-            end = inc = -1;
-        }
+String rawMemoryToString(const void * object, unsigned size)
+{
+  // Reverse order for little endian architectures
+  int i = 0, end = static_cast<int>(size), inc = 1;
+  if(Endianness::which() == Endianness::Little)
+  {
+    i = end - 1;
+    end = inc = -1;
+  }
 
-        unsigned char const* bytes = static_cast<unsigned char const*>(object);
-        std::ostringstream   os;
-        os << "0x" << std::setfill('0') << std::hex;
-        for(; i != end; i += inc)
-            os << std::setw(2) << static_cast<unsigned>(bytes[i]);
-        return os.str().c_str();
-    }
+  unsigned char const * bytes = static_cast<unsigned char const *>(object);
+  std::ostringstream os;
+  os << "0x" << std::setfill('0') << std::hex;
+  for(; i != end; i += inc)
+    os << std::setw(2) << static_cast<unsigned>(bytes[i]);
+  return os.str().c_str();
+}
 
-    std::ostream* createStream() { return new std::ostringstream(); }
-    String        getStreamResult(std::ostream* in) {
-        return static_cast<std::ostringstream*>(in)->str().c_str(); // NOLINT
-    }
-    void freeStream(std::ostream* in) { delete in; }
+std::ostream * createStream() { return new std::ostringstream(); }
+String getStreamResult(std::ostream * in)
+{
+  return static_cast<std::ostringstream *>(in)->str().c_str(); // NOLINT
+}
+void freeStream(std::ostream * in) { delete in; }
 
-#ifndef DOCTEST_CONFIG_DISABLE
+#  ifndef DOCTEST_CONFIG_DISABLE
 
-    // this holds both parameters for the command line and runtime data for tests
-    struct ContextState : TestAccessibleContextState //!OCLINT too many fields
-    {
-        // == parameters from the command line
+// this holds both parameters for the command line and runtime data for tests
+struct ContextState : TestAccessibleContextState //! OCLINT too many fields
+{
+  // == parameters from the command line
 
-        std::vector<std::vector<String> > filters;
+  std::vector<std::vector<String>> filters;
 
-        String   order_by;  // how tests should be ordered
-        unsigned rand_seed; // the seed for rand ordering
+  String order_by; // how tests should be ordered
+  unsigned rand_seed; // the seed for rand ordering
 
-        unsigned first; // the first (matching) test to be executed
-        unsigned last;  // the last (matching) test to be executed
+  unsigned first; // the first (matching) test to be executed
+  unsigned last; // the last (matching) test to be executed
 
-        int  abort_after;           // stop tests after this many failed assertions
-        int  subcase_filter_levels; // apply the subcase filters for the first N levels
-        bool case_sensitive;        // if filtering should be case sensitive
-        bool exit;         // if the program should be exited after the tests are ran/whatever
-        bool duration;     // print the time duration of each test case
-        bool no_exitcode;  // if the framework should return 0 as the exitcode
-        bool no_run;       // to not run the tests at all (can be done with an "*" exclude)
-        bool no_version;   // to not print the version of the framework
-        bool no_colors;    // if output to the console should be colorized
-        bool force_colors; // forces the use of colors even when a tty cannot be detected
-        bool no_breaks;    // to not break into the debugger
-        bool no_skip;      // don't skip test cases which are marked to be skipped
-        bool no_path_in_filenames; // if the path to files should be removed from the output
-        bool no_line_numbers;      // if source code line numbers should be omitted from the output
-        bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+  int abort_after; // stop tests after this many failed assertions
+  int subcase_filter_levels; // apply the subcase filters for the first N levels
+  bool case_sensitive; // if filtering should be case sensitive
+  bool exit; // if the program should be exited after the tests are ran/whatever
+  bool duration; // print the time duration of each test case
+  bool no_exitcode; // if the framework should return 0 as the exitcode
+  bool no_run; // to not run the tests at all (can be done with an "*" exclude)
+  bool no_version; // to not print the version of the framework
+  bool no_colors; // if output to the console should be colorized
+  bool force_colors; // forces the use of colors even when a tty cannot be detected
+  bool no_breaks; // to not break into the debugger
+  bool no_skip; // don't skip test cases which are marked to be skipped
+  bool no_path_in_filenames; // if the path to files should be removed from the output
+  bool no_line_numbers; // if source code line numbers should be omitted from the output
+  bool no_skipped_summary; // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
 
-        bool help;             // to print the help
-        bool version;          // to print the version
-        bool count;            // if only the count of matching tests is to be retreived
-        bool list_test_cases;  // to list all tests matching the filters
-        bool list_test_suites; // to list all suites matching the filters
+  bool help; // to print the help
+  bool version; // to print the version
+  bool count; // if only the count of matching tests is to be retreived
+  bool list_test_cases; // to list all tests matching the filters
+  bool list_test_suites; // to list all suites matching the filters
 
-        // == data for the tests being ran
+  // == data for the tests being ran
 
-        unsigned        numTestsPassingFilters;
-        unsigned        numTestSuitesPassingFilters;
-        unsigned        numFailed;
-        const TestCase* currentTest;
-        bool            hasLoggedCurrentTestStart;
-        int             numAssertionsForCurrentTestcase;
-        int             numAssertions;
-        int             numFailedAssertionsForCurrentTestcase;
-        int             numFailedAssertions;
-        bool            hasCurrentTestFailed;
+  unsigned numTestsPassingFilters;
+  unsigned numTestSuitesPassingFilters;
+  unsigned numFailed;
+  const TestCase * currentTest;
+  bool hasLoggedCurrentTestStart;
+  int numAssertionsForCurrentTestcase;
+  int numAssertions;
+  int numFailedAssertionsForCurrentTestcase;
+  int numFailedAssertions;
+  bool hasCurrentTestFailed;
 
-        std::vector<IContextScope*> contexts;            // for logging with INFO() and friends
-        std::vector<std::string>    exceptionalContexts; // logging from INFO() due to an exception
+  std::vector<IContextScope *> contexts; // for logging with INFO() and friends
+  std::vector<std::string> exceptionalContexts; // logging from INFO() due to an exception
 
-        // stuff for subcases
-        std::set<SubcaseSignature> subcasesPassed;
-        std::set<int>              subcasesEnteredLevels;
-        std::vector<Subcase>       subcasesStack;
-        int                        subcasesCurrentLevel;
-        bool                       subcasesHasSkipped;
+  // stuff for subcases
+  std::set<SubcaseSignature> subcasesPassed;
+  std::set<int> subcasesEnteredLevels;
+  std::vector<Subcase> subcasesStack;
+  int subcasesCurrentLevel;
+  bool subcasesHasSkipped;
 
-        void resetRunData() {
-            numTestsPassingFilters                = 0;
-            numTestSuitesPassingFilters           = 0;
-            numFailed                             = 0;
-            numAssertions                         = 0;
-            numFailedAssertions                   = 0;
-            numFailedAssertionsForCurrentTestcase = 0;
-        }
+  void resetRunData()
+  {
+    numTestsPassingFilters = 0;
+    numTestSuitesPassingFilters = 0;
+    numFailed = 0;
+    numAssertions = 0;
+    numFailedAssertions = 0;
+    numFailedAssertionsForCurrentTestcase = 0;
+  }
 
-        // cppcheck-suppress uninitMemberVar
-        ContextState()
-                : filters(8) // 8 different filters total
-        {
-            resetRunData();
-        }
-    };
+  // cppcheck-suppress uninitMemberVar
+  ContextState() : filters(8) // 8 different filters total
+  {
+    resetRunData();
+  }
+};
 
-    ContextState* contextState = 0;
-#endif // DOCTEST_CONFIG_DISABLE
+ContextState * contextState = 0;
+#  endif // DOCTEST_CONFIG_DISABLE
 } // namespace detail
 
-void String::copy(const String& other) {
-    if(other.isOnStack()) {
-        detail::my_memcpy(buf, other.buf, len);
-    } else {
-        setOnHeap();
-        data.size     = other.data.size;
-        data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
-        detail::my_memcpy(data.ptr, other.data.ptr, data.size + 1);
-    }
+void String::copy(const String & other)
+{
+  if(other.isOnStack())
+  {
+    detail::my_memcpy(buf, other.buf, len);
+  }
+  else
+  {
+    setOnHeap();
+    data.size = other.data.size;
+    data.capacity = data.size + 1;
+    data.ptr = new char[data.capacity];
+    detail::my_memcpy(data.ptr, other.data.ptr, data.size + 1);
+  }
 }
 
-String::String(const char* in) {
-    unsigned in_len = detail::my_strlen(in);
-    if(in_len <= last) {
-        detail::my_memcpy(buf, in, in_len + 1);
-        setLast(last - in_len);
-    } else {
-        setOnHeap();
-        data.size     = in_len;
-        data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
-        detail::my_memcpy(data.ptr, in, in_len + 1);
-    }
+String::String(const char * in)
+{
+  unsigned in_len = detail::my_strlen(in);
+  if(in_len <= last)
+  {
+    detail::my_memcpy(buf, in, in_len + 1);
+    setLast(last - in_len);
+  }
+  else
+  {
+    setOnHeap();
+    data.size = in_len;
+    data.capacity = data.size + 1;
+    data.ptr = new char[data.capacity];
+    detail::my_memcpy(data.ptr, in, in_len + 1);
+  }
 }
 
-String& String::operator+=(const String& other) {
-    const unsigned my_old_size = size();
-    const unsigned other_size  = other.size();
-    const unsigned total_size  = my_old_size + other_size;
-    if(isOnStack()) {
-        if(total_size < len) {
-            // append to the current stack space
-            detail::my_memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-            setLast(last - total_size);
-        } else {
-            // alloc new chunk
-            char* temp = new char[total_size + 1];
-            // copy current data to new location before writing in the union
-            detail::my_memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-            // update data in union
-            setOnHeap();
-            data.size     = total_size;
-            data.capacity = data.size + 1;
-            data.ptr      = temp;
-            // transfer the rest of the data
-            detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        }
-    } else {
-        if(data.capacity > total_size) {
-            // append to the current heap block
-            data.size = total_size;
-            detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        } else {
-            // resize
-            data.capacity *= 2;
-            if(data.capacity <= total_size)
-                data.capacity = total_size + 1;
-            // alloc new chunk
-            char* temp = new char[data.capacity];
-            // copy current data to new location before releasing it
-            detail::my_memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-            // release old chunk
-            delete[] data.ptr;
-            // update the rest of the union members
-            data.size = total_size;
-            data.ptr  = temp;
-            // transfer the rest of the data
-            detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        }
+String & String::operator+=(const String & other)
+{
+  const unsigned my_old_size = size();
+  const unsigned other_size = other.size();
+  const unsigned total_size = my_old_size + other_size;
+  if(isOnStack())
+  {
+    if(total_size < len)
+    {
+      // append to the current stack space
+      detail::my_memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+      setLast(last - total_size);
     }
+    else
+    {
+      // alloc new chunk
+      char * temp = new char[total_size + 1];
+      // copy current data to new location before writing in the union
+      detail::my_memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+      // update data in union
+      setOnHeap();
+      data.size = total_size;
+      data.capacity = data.size + 1;
+      data.ptr = temp;
+      // transfer the rest of the data
+      detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+    }
+  }
+  else
+  {
+    if(data.capacity > total_size)
+    {
+      // append to the current heap block
+      data.size = total_size;
+      detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+    }
+    else
+    {
+      // resize
+      data.capacity *= 2;
+      if(data.capacity <= total_size)
+        data.capacity = total_size + 1;
+      // alloc new chunk
+      char * temp = new char[data.capacity];
+      // copy current data to new location before releasing it
+      detail::my_memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+      // release old chunk
+      delete[] data.ptr;
+      // update the rest of the union members
+      data.size = total_size;
+      data.ptr = temp;
+      // transfer the rest of the data
+      detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+    }
+  }
 
-    return *this;
+  return *this;
 }
 
-#ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-String::String(String&& other) {
+#  ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+String::String(String && other)
+{
+  detail::my_memcpy(buf, other.buf, len);
+  other.buf[0] = '\0';
+  other.setLast();
+}
+
+String & String::operator=(String && other)
+{
+  if(this != &other)
+  {
+    if(!isOnStack())
+      delete[] data.ptr;
     detail::my_memcpy(buf, other.buf, len);
     other.buf[0] = '\0';
     other.setLast();
+  }
+  return *this;
+}
+#  endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+
+int String::compare(const char * other, bool no_case) const
+{
+  if(no_case)
+    return detail::stricmp(c_str(), other);
+  return std::strcmp(c_str(), other);
 }
 
-String& String::operator=(String&& other) {
-    if(this != &other) {
-        if(!isOnStack())
-            delete[] data.ptr;
-        detail::my_memcpy(buf, other.buf, len);
-        other.buf[0] = '\0';
-        other.setLast();
-    }
-    return *this;
-}
-#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+int String::compare(const String & other, bool no_case) const { return compare(other.c_str(), no_case); }
 
-int String::compare(const char* other, bool no_case) const {
-    if(no_case)
-        return detail::stricmp(c_str(), other);
-    return std::strcmp(c_str(), other);
-}
-
-int String::compare(const String& other, bool no_case) const {
-    return compare(other.c_str(), no_case);
-}
-
-std::ostream& operator<<(std::ostream& stream, const String& in) {
-    stream << in.c_str();
-    return stream;
+std::ostream & operator<<(std::ostream & stream, const String & in)
+{
+  stream << in.c_str();
+  return stream;
 }
 
 Approx::Approx(double value)
-        : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
-        , m_scale(1.0)
-        , m_value(value) {}
+: m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value)
+{
+}
 
-bool operator==(double lhs, Approx const& rhs) {
-    // Thanks to Richard Harris for his help refining this formula
-    return std::fabs(lhs - rhs.m_value) <
-           rhs.m_epsilon * (rhs.m_scale + detail::my_max(std::fabs(lhs), std::fabs(rhs.m_value)));
+bool operator==(double lhs, Approx const & rhs)
+{
+  // Thanks to Richard Harris for his help refining this formula
+  return std::fabs(lhs - rhs.m_value)
+         < rhs.m_epsilon * (rhs.m_scale + detail::my_max(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 
 String Approx::toString() const { return String("Approx( ") + doctest::toString(m_value) + " )"; }
 
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(char* in) { return toString(static_cast<const char*>(in)); }
-String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#  ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+String toString(char * in) { return toString(static_cast<const char *>(in)); }
+String toString(const char * in) { return String("\"") + (in ? in : "{null string}") + "\""; }
+#  endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 String toString(bool in) { return in ? "true" : "false"; }
 String toString(float in) { return detail::fpToString(in, 5) + "f"; }
 String toString(double in) { return detail::fpToString(in, 10); }
 String toString(double long in) { return detail::fpToString(in, 15); }
 
-String toString(char in) {
-    char buf[64];
-    std::sprintf(buf, "%d", in);
-    return buf;
+String toString(char in)
+{
+  char buf[64];
+  std::sprintf(buf, "%d", in);
+  return buf;
 }
 
-String toString(char signed in) {
-    char buf[64];
-    std::sprintf(buf, "%d", in);
-    return buf;
+String toString(char signed in)
+{
+  char buf[64];
+  std::sprintf(buf, "%d", in);
+  return buf;
 }
 
-String toString(char unsigned in) {
-    char buf[64];
-    std::sprintf(buf, "%ud", in);
-    return buf;
+String toString(char unsigned in)
+{
+  char buf[64];
+  std::sprintf(buf, "%ud", in);
+  return buf;
 }
 
-String toString(int short in) {
-    char buf[64];
-    std::sprintf(buf, "%d", in);
-    return buf;
+String toString(int short in)
+{
+  char buf[64];
+  std::sprintf(buf, "%d", in);
+  return buf;
 }
 
-String toString(int short unsigned in) {
-    char buf[64];
-    std::sprintf(buf, "%u", in);
-    return buf;
+String toString(int short unsigned in)
+{
+  char buf[64];
+  std::sprintf(buf, "%u", in);
+  return buf;
 }
 
-String toString(int in) {
-    char buf[64];
-    std::sprintf(buf, "%d", in);
-    return buf;
+String toString(int in)
+{
+  char buf[64];
+  std::sprintf(buf, "%d", in);
+  return buf;
 }
 
-String toString(int unsigned in) {
-    char buf[64];
-    std::sprintf(buf, "%u", in);
-    return buf;
+String toString(int unsigned in)
+{
+  char buf[64];
+  std::sprintf(buf, "%u", in);
+  return buf;
 }
 
-String toString(int long in) {
-    char buf[64];
-    std::sprintf(buf, "%ld", in);
-    return buf;
+String toString(int long in)
+{
+  char buf[64];
+  std::sprintf(buf, "%ld", in);
+  return buf;
 }
 
-String toString(int long unsigned in) {
-    char buf[64];
-    std::sprintf(buf, "%lu", in);
-    return buf;
+String toString(int long unsigned in)
+{
+  char buf[64];
+  std::sprintf(buf, "%lu", in);
+  return buf;
 }
 
-#ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-String toString(int long long in) {
-    char buf[64];
-    std::sprintf(buf, "%lld", in);
-    return buf;
+#  ifdef DOCTEST_CONFIG_WITH_LONG_LONG
+String toString(int long long in)
+{
+  char buf[64];
+  std::sprintf(buf, "%lld", in);
+  return buf;
 }
-String toString(int long long unsigned in) {
-    char buf[64];
-    std::sprintf(buf, "%llu", in);
-    return buf;
+String toString(int long long unsigned in)
+{
+  char buf[64];
+  std::sprintf(buf, "%llu", in);
+  return buf;
 }
-#endif // DOCTEST_CONFIG_WITH_LONG_LONG
+#  endif // DOCTEST_CONFIG_WITH_LONG_LONG
 
-#ifdef DOCTEST_CONFIG_WITH_NULLPTR
+#  ifdef DOCTEST_CONFIG_WITH_NULLPTR
 String toString(std::nullptr_t) { return "nullptr"; }
-#endif // DOCTEST_CONFIG_WITH_NULLPTR
+#  endif // DOCTEST_CONFIG_WITH_NULLPTR
 
 } // namespace doctest
 
-#ifdef DOCTEST_CONFIG_DISABLE
+#  ifdef DOCTEST_CONFIG_DISABLE
 namespace doctest
 {
 bool isRunningInTest() { return false; }
-Context::Context(int, const char* const*) {}
+Context::Context(int, const char * const *) {}
 Context::~Context() {}
-void Context::applyCommandLine(int, const char* const*) {}
-void Context::addFilter(const char*, const char*) {}
+void Context::applyCommandLine(int, const char * const *) {}
+void Context::addFilter(const char *, const char *) {}
 void Context::clearFilters() {}
-void Context::setOption(const char*, int) {}
-void Context::setOption(const char*, const char*) {}
+void Context::setOption(const char *, int) {}
+void Context::setOption(const char *, const char *) {}
 bool Context::shouldExit() { return false; }
-int  Context::run() { return 0; }
+int Context::run() { return 0; }
 } // namespace doctest
-#else // DOCTEST_CONFIG_DISABLE
+#  else // DOCTEST_CONFIG_DISABLE
 
-#if !defined(DOCTEST_CONFIG_COLORS_NONE)
-#if !defined(DOCTEST_CONFIG_COLORS_WINDOWS) && !defined(DOCTEST_CONFIG_COLORS_ANSI)
-#ifdef DOCTEST_PLATFORM_WINDOWS
-#define DOCTEST_CONFIG_COLORS_WINDOWS
-#else // linux
-#define DOCTEST_CONFIG_COLORS_ANSI
-#endif // platform
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
-#endif // DOCTEST_CONFIG_COLORS_NONE
+#    if !defined(DOCTEST_CONFIG_COLORS_NONE)
+#      if !defined(DOCTEST_CONFIG_COLORS_WINDOWS) && !defined(DOCTEST_CONFIG_COLORS_ANSI)
+#        ifdef DOCTEST_PLATFORM_WINDOWS
+#          define DOCTEST_CONFIG_COLORS_WINDOWS
+#        else // linux
+#          define DOCTEST_CONFIG_COLORS_ANSI
+#        endif // platform
+#      endif // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
+#    endif // DOCTEST_CONFIG_COLORS_NONE
 
-#define DOCTEST_PRINTF_COLORED(buffer, color)                                                      \
-    do {                                                                                           \
-        Color col(color);                                                                          \
-        std::printf("%s", buffer);                                                                 \
-    } while((void)0, 0)
+#    define DOCTEST_PRINTF_COLORED(buffer, color) \
+      do                                          \
+      {                                           \
+        Color col(color);                         \
+        std::printf("%s", buffer);                \
+      } while((void)0, 0)
 
 // the buffer size used for snprintf() calls
-#if !defined(DOCTEST_SNPRINTF_BUFFER_LENGTH)
-#define DOCTEST_SNPRINTF_BUFFER_LENGTH 1024
-#endif // DOCTEST_SNPRINTF_BUFFER_LENGTH
+#    if !defined(DOCTEST_SNPRINTF_BUFFER_LENGTH)
+#      define DOCTEST_SNPRINTF_BUFFER_LENGTH 1024
+#    endif // DOCTEST_SNPRINTF_BUFFER_LENGTH
 
-#if DOCTEST_MSVC || defined(__MINGW32__)
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(17, 0, 0)
-#define DOCTEST_WINDOWS_SAL_IN_OPT _In_opt_
-#else // MSVC
-#define DOCTEST_WINDOWS_SAL_IN_OPT
-#endif // MSVC
-extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(
-        DOCTEST_WINDOWS_SAL_IN_OPT const char*);
+#    if DOCTEST_MSVC || defined(__MINGW32__)
+#      if DOCTEST_MSVC >= DOCTEST_COMPILER(17, 0, 0)
+#        define DOCTEST_WINDOWS_SAL_IN_OPT _In_opt_
+#      else // MSVC
+#        define DOCTEST_WINDOWS_SAL_IN_OPT
+#      endif // MSVC
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(DOCTEST_WINDOWS_SAL_IN_OPT const char *);
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
-#endif // MSVC || __MINGW32__
+#    endif // MSVC || __MINGW32__
 
-#ifdef DOCTEST_CONFIG_COLORS_ANSI
-#include <unistd.h>
-#endif // DOCTEST_CONFIG_COLORS_ANSI
+#    ifdef DOCTEST_CONFIG_COLORS_ANSI
+#      include <unistd.h>
+#    endif // DOCTEST_CONFIG_COLORS_ANSI
 
-#ifdef DOCTEST_PLATFORM_WINDOWS
+#    ifdef DOCTEST_PLATFORM_WINDOWS
 
 // defines for a leaner windows.h
-#ifndef WIN32_MEAN_AND_LEAN
-#define WIN32_MEAN_AND_LEAN
-#endif // WIN32_MEAN_AND_LEAN
-#ifndef VC_EXTRA_LEAN
-#define VC_EXTRA_LEAN
-#endif // VC_EXTRA_LEAN
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif // NOMINMAX
+#      ifndef WIN32_MEAN_AND_LEAN
+#        define WIN32_MEAN_AND_LEAN
+#      endif // WIN32_MEAN_AND_LEAN
+#      ifndef VC_EXTRA_LEAN
+#        define VC_EXTRA_LEAN
+#      endif // VC_EXTRA_LEAN
+#      ifndef NOMINMAX
+#        define NOMINMAX
+#      endif // NOMINMAX
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
 // not sure what AfxWin.h is for - here I do what Catch does
-#ifdef __AFXDLL
-#include <AfxWin.h>
-#else
-#include <windows.h>
-#endif
-#include <io.h>
+#      ifdef __AFXDLL
+#        include <AfxWin.h>
+#      else
+#        include <windows.h>
+#      endif
+#      include <io.h>
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
-#else // DOCTEST_PLATFORM_WINDOWS
+#    else // DOCTEST_PLATFORM_WINDOWS
 
-#include <sys/time.h>
+#      include <sys/time.h>
 
-#endif // DOCTEST_PLATFORM_WINDOWS
+#    endif // DOCTEST_PLATFORM_WINDOWS
 
 namespace doctest_detail_test_suite_ns
 {
 // holds the current test suite
-doctest::detail::TestSuite& getCurrentTestSuite() {
-    static doctest::detail::TestSuite data;
-    return data;
+doctest::detail::TestSuite & getCurrentTestSuite()
+{
+  static doctest::detail::TestSuite data;
+  return data;
 }
 } // namespace doctest_detail_test_suite_ns
 
@@ -3795,68 +4011,70 @@ namespace doctest
 {
 namespace detail
 {
-    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                       const char* type, int template_id)
-            : m_test(test)
-            , m_name(0)
-            , m_type(type)
-            , m_test_suite(test_suite.m_test_suite)
-            , m_description(test_suite.m_description)
-            , m_skip(test_suite.m_skip)
-            , m_may_fail(test_suite.m_may_fail)
-            , m_should_fail(test_suite.m_should_fail)
-            , m_expected_failures(test_suite.m_expected_failures)
-            , m_timeout(test_suite.m_timeout)
-            , m_file(file)
-            , m_line(line)
-            , m_template_id(template_id) {}
+TestCase::TestCase(funcType test,
+                   const char * file,
+                   unsigned line,
+                   const TestSuite & test_suite,
+                   const char * type,
+                   int template_id)
+: m_test(test), m_name(0), m_type(type), m_test_suite(test_suite.m_test_suite), m_description(test_suite.m_description),
+  m_skip(test_suite.m_skip), m_may_fail(test_suite.m_may_fail), m_should_fail(test_suite.m_should_fail),
+  m_expected_failures(test_suite.m_expected_failures), m_timeout(test_suite.m_timeout), m_file(file), m_line(line),
+  m_template_id(template_id)
+{
+}
 
-    TestCase& TestCase::operator*(const char* in) {
-        m_name = in;
-        // make a new name with an appended type for templated test case
-        if(m_template_id != -1) {
-            m_full_name = String(m_name) + m_type;
-            // redirect the name to point to the newly constructed full name
-            m_name = m_full_name.c_str();
-        }
-        return *this;
-    }
+TestCase & TestCase::operator*(const char * in)
+{
+  m_name = in;
+  // make a new name with an appended type for templated test case
+  if(m_template_id != -1)
+  {
+    m_full_name = String(m_name) + m_type;
+    // redirect the name to point to the newly constructed full name
+    m_name = m_full_name.c_str();
+  }
+  return *this;
+}
 
-    TestCase& TestCase::operator=(const TestCase& other) {
-        m_test              = other.m_test;
-        m_full_name         = other.m_full_name;
-        m_name              = other.m_name;
-        m_type              = other.m_type;
-        m_test_suite        = other.m_test_suite;
-        m_description       = other.m_description;
-        m_skip              = other.m_skip;
-        m_may_fail          = other.m_may_fail;
-        m_should_fail       = other.m_should_fail;
-        m_expected_failures = other.m_expected_failures;
-        m_timeout           = other.m_timeout;
-        m_file              = other.m_file;
-        m_line              = other.m_line;
-        m_template_id       = other.m_template_id;
+TestCase & TestCase::operator=(const TestCase & other)
+{
+  m_test = other.m_test;
+  m_full_name = other.m_full_name;
+  m_name = other.m_name;
+  m_type = other.m_type;
+  m_test_suite = other.m_test_suite;
+  m_description = other.m_description;
+  m_skip = other.m_skip;
+  m_may_fail = other.m_may_fail;
+  m_should_fail = other.m_should_fail;
+  m_expected_failures = other.m_expected_failures;
+  m_timeout = other.m_timeout;
+  m_file = other.m_file;
+  m_line = other.m_line;
+  m_template_id = other.m_template_id;
 
-        if(m_template_id != -1)
-            m_name = m_full_name.c_str();
-        return *this;
-    }
+  if(m_template_id != -1)
+    m_name = m_full_name.c_str();
+  return *this;
+}
 
-    bool TestCase::operator<(const TestCase& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        const int file_cmp = std::strcmp(m_file, other.m_file);
-        if(file_cmp != 0)
-            return file_cmp < 0;
-        return m_template_id < other.m_template_id;
-    }
+bool TestCase::operator<(const TestCase & other) const
+{
+  if(m_line != other.m_line)
+    return m_line < other.m_line;
+  const int file_cmp = std::strcmp(m_file, other.m_file);
+  if(file_cmp != 0)
+    return file_cmp < 0;
+  return m_template_id < other.m_template_id;
+}
 
-    const char* getAssertString(assertType::Enum val) {
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(
-                4062) // enumerator 'x' in switch of enum 'y' is not handled
-        switch(val) { //!OCLINT missing default in switch statements
-            // clang-format off
+const char * getAssertString(assertType::Enum val)
+{
+  DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4062) // enumerator 'x' in switch of enum 'y' is not handled
+  switch(val)
+  { //! OCLINT missing default in switch statements
+    // clang-format off
             case assertType::DT_WARN                    : return "WARN";
             case assertType::DT_CHECK                   : return "CHECK";
             case assertType::DT_REQUIRE                 : return "REQUIRE";
@@ -3928,329 +4146,350 @@ namespace detail
             case assertType::DT_FAST_WARN_UNARY_FALSE   : return "FAST_WARN_UNARY_FALSE";
             case assertType::DT_FAST_CHECK_UNARY_FALSE  : return "FAST_CHECK_UNARY_FALSE";
             case assertType::DT_FAST_REQUIRE_UNARY_FALSE: return "FAST_REQUIRE_UNARY_FALSE";
-                // clang-format on
-        }
-        DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        return "";
-    }
+      // clang-format on
+  }
+  DOCTEST_MSVC_SUPPRESS_WARNING_POP
+  return "";
+}
 
-    bool checkIfShouldThrow(assertType::Enum assert_type) {
-        if(assert_type & assertType::is_require) //!OCLINT bitwise operator in conditional
-            return true;
+bool checkIfShouldThrow(assertType::Enum assert_type)
+{
+  if(assert_type & assertType::is_require) //! OCLINT bitwise operator in conditional
+    return true;
 
-        if((assert_type & assertType::is_check) //!OCLINT bitwise operator in conditional
-           && contextState->abort_after > 0 &&
-           contextState->numFailedAssertions >= contextState->abort_after)
-            return true;
+  if((assert_type & assertType::is_check) //! OCLINT bitwise operator in conditional
+     && contextState->abort_after > 0 && contextState->numFailedAssertions >= contextState->abort_after)
+    return true;
 
-        return false;
-    }
-    void fastAssertThrowIfFlagSet(int flags) {
-        if(flags & assertAction::shouldthrow) //!OCLINT bitwise operator in conditional
-            throwException();
-    }
-    void throwException() {
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        throw TestFailureException();
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
+  return false;
+}
+void fastAssertThrowIfFlagSet(int flags)
+{
+  if(flags & assertAction::shouldthrow) //! OCLINT bitwise operator in conditional
+    throwException();
+}
+void throwException()
+{
+#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+  throw TestFailureException();
+#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+}
 
-    // matching of a string against a wildcard mask (case sensitivity configurable) taken from
-    // http://www.emoticode.net/c/simple-wildcard-string-compare-globbing-function.html
-    int wildcmp(const char* str, const char* wild, bool caseSensitive) {
-        const char* cp = 0;
-        const char* mp = 0;
+// matching of a string against a wildcard mask (case sensitivity configurable) taken from
+// http://www.emoticode.net/c/simple-wildcard-string-compare-globbing-function.html
+int wildcmp(const char * str, const char * wild, bool caseSensitive)
+{
+  const char * cp = 0;
+  const char * mp = 0;
 
-        // rolled my own tolower() to not include more headers
-        while((*str) && (*wild != '*')) {
-            if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
-               (*wild != '?')) {
-                return 0;
-            }
-            wild++;
-            str++;
-        }
-
-        while(*str) {
-            if(*wild == '*') {
-                if(!*++wild) {
-                    return 1;
-                }
-                mp = wild;
-                cp = str + 1;
-            } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
-                      (*wild == '?')) {
-                wild++;
-                str++;
-            } else {
-                wild = mp;   //!OCLINT parameter reassignment
-                str  = cp++; //!OCLINT parameter reassignment
-            }
-        }
-
-        while(*wild == '*') {
-            wild++;
-        }
-        return !*wild;
-    }
-
-    //// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
-    //unsigned hashStr(unsigned const char* str) {
-    //    unsigned long hash = 5381;
-    //    char          c;
-    //    while((c = *str++))
-    //        hash = ((hash << 5) + hash) + c; // hash * 33 + c
-    //    return hash;
-    //}
-
-    // checks if the name matches any of the filters (and can be configured what to do when empty)
-    bool matchesAny(const char* name, const std::vector<String>& filters, int matchEmpty,
-                    bool caseSensitive) {
-        if(filters.empty() && matchEmpty)
-            return true;
-        for(unsigned i = 0; i < filters.size(); ++i)
-            if(wildcmp(name, filters[i].c_str(), caseSensitive))
-                return true;
-        return false;
-    }
-
-#ifdef DOCTEST_PLATFORM_WINDOWS
-
-    typedef unsigned long long UInt64;
-
-    UInt64 getCurrentTicks() {
-        static UInt64 hz = 0, hzo = 0;
-        if(!hz) {
-            QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&hz));
-            QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&hzo));
-        }
-        UInt64 t;
-        QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&t));
-        return ((t - hzo) * 1000000) / hz;
-    }
-#else  // DOCTEST_PLATFORM_WINDOWS
-
-    typedef uint64_t UInt64;
-
-    UInt64 getCurrentTicks() {
-        timeval t;
-        gettimeofday(&t, 0);
-        return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
-    }
-#endif // DOCTEST_PLATFORM_WINDOWS
-
-    class Timer
+  // rolled my own tolower() to not include more headers
+  while((*str) && (*wild != '*'))
+  {
+    if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) && (*wild != '?'))
     {
-    public:
-        Timer()
-                : m_ticks(0) {}
-        void         start() { m_ticks = getCurrentTicks(); }
-        unsigned int getElapsedMicroseconds() const {
-            return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
-        }
-        unsigned int getElapsedMilliseconds() const {
-            return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
-        }
-        double getElapsedSeconds() const { return getElapsedMicroseconds() / 1000000.0; }
-
-    private:
-        UInt64 m_ticks;
-    };
-
-    TestAccessibleContextState* getTestsContextState() { return contextState; }
-
-    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        if(std::strcmp(m_file, other.m_file) != 0)
-            return std::strcmp(m_file, other.m_file) < 0;
-        return std::strcmp(m_name, other.m_name) < 0;
+      return 0;
     }
+    wild++;
+    str++;
+  }
 
-    Subcase::Subcase(const char* name, const char* file, int line)
-            : m_signature(name, file, line)
-            , m_entered(false) {
-        ContextState* s = contextState;
-
-        // if we have already completed it
-        if(s->subcasesPassed.count(m_signature) != 0)
-            return;
-
-        // check subcase filters
-        if(s->subcasesCurrentLevel < s->subcase_filter_levels) {
-            if(!matchesAny(m_signature.m_name, s->filters[6], 1, s->case_sensitive))
-                return;
-            if(matchesAny(m_signature.m_name, s->filters[7], 0, s->case_sensitive))
-                return;
-        }
-
-        // if a Subcase on the same level has already been entered
-        if(s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0) {
-            s->subcasesHasSkipped = true;
-            return;
-        }
-
-        s->subcasesStack.push_back(*this);
-        if(s->hasLoggedCurrentTestStart)
-            logTestEnd();
-        s->hasLoggedCurrentTestStart = false;
-
-        s->subcasesEnteredLevels.insert(s->subcasesCurrentLevel++);
-        m_entered = true;
-    }
-
-    Subcase::Subcase(const Subcase& other)
-            : m_signature(other.m_signature.m_name, other.m_signature.m_file,
-                          other.m_signature.m_line)
-            , m_entered(other.m_entered) {}
-
-    Subcase::~Subcase() {
-        if(m_entered) {
-            ContextState* s = contextState;
-
-            s->subcasesCurrentLevel--;
-            // only mark the subcase as passed if no subcases have been skipped
-            if(s->subcasesHasSkipped == false)
-                s->subcasesPassed.insert(m_signature);
-
-            if(!s->subcasesStack.empty())
-                s->subcasesStack.pop_back();
-            if(s->hasLoggedCurrentTestStart)
-                logTestEnd();
-            s->hasLoggedCurrentTestStart = false;
-        }
-    }
-
-    Result::~Result() {}
-
-    Result& Result::operator=(const Result& other) {
-        m_passed        = other.m_passed;
-        m_decomposition = other.m_decomposition;
-
-        return *this;
-    }
-
-    // for sorting tests by file/line
-    int fileOrderComparator(const void* a, const void* b) {
-        const TestCase* lhs = *static_cast<TestCase* const*>(a);
-        const TestCase* rhs = *static_cast<TestCase* const*>(b);
-#if DOCTEST_MSVC
-        // this is needed because MSVC gives different case for drive letters
-        // for __FILE__ when evaluated in a header and a source file
-        const int res = stricmp(lhs->m_file, rhs->m_file);
-#else  // MSVC
-        const int res = std::strcmp(lhs->m_file, rhs->m_file);
-#endif // MSVC
-        if(res != 0)
-            return res;
-        return static_cast<int>(lhs->m_line - rhs->m_line);
-    }
-
-    // for sorting tests by suite/file/line
-    int suiteOrderComparator(const void* a, const void* b) {
-        const TestCase* lhs = *static_cast<TestCase* const*>(a);
-        const TestCase* rhs = *static_cast<TestCase* const*>(b);
-
-        const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
-        if(res != 0)
-            return res;
-        return fileOrderComparator(a, b);
-    }
-
-    // for sorting tests by name/suite/file/line
-    int nameOrderComparator(const void* a, const void* b) {
-        const TestCase* lhs = *static_cast<TestCase* const*>(a);
-        const TestCase* rhs = *static_cast<TestCase* const*>(b);
-
-        const int res_name = std::strcmp(lhs->m_name, rhs->m_name);
-        if(res_name != 0)
-            return res_name;
-        return suiteOrderComparator(a, b);
-    }
-
-    // sets the current test suite
-    int setTestSuite(const TestSuite& ts) {
-        doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
-        return 0;
-    }
-
-    // all the registered tests
-    std::set<TestCase>& getRegisteredTests() {
-        static std::set<TestCase> data;
-        return data;
-    }
-
-    // used by the macros for registering tests
-    int regTest(const TestCase& tc) {
-        getRegisteredTests().insert(tc);
-        return 0;
-    }
-
-    struct Color
+  while(*str)
+  {
+    if(*wild == '*')
     {
-        enum Code
-        {
-            None = 0,
-            White,
-            Red,
-            Green,
-            Blue,
-            Cyan,
-            Yellow,
-            Grey,
-
-            Bright = 0x10,
-
-            BrightRed   = Bright | Red,
-            BrightGreen = Bright | Green,
-            LightGrey   = Bright | Grey,
-            BrightWhite = Bright | White
-        };
-        explicit Color(Code code) { use(code); }
-        ~Color() { use(None); }
-
-        static void use(Code code);
-        static void init();
-    };
-
-#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-    HANDLE g_stdoutHandle;
-    WORD   g_originalForegroundAttributes;
-    WORD   g_originalBackgroundAttributes;
-    bool   g_attrsInitted = false;
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
-
-    void Color::init() {
-#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-        if(!g_attrsInitted) {
-            g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-            g_attrsInitted = true;
-            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-            GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
-            g_originalForegroundAttributes =
-                    csbiInfo.wAttributes &
-                    ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-            g_originalBackgroundAttributes =
-                    csbiInfo.wAttributes &
-                    ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-        }
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+      if(!*++wild)
+      {
+        return 1;
+      }
+      mp = wild;
+      cp = str + 1;
     }
+    else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) || (*wild == '?'))
+    {
+      wild++;
+      str++;
+    }
+    else
+    {
+      wild = mp; //! OCLINT parameter reassignment
+      str = cp++; //! OCLINT parameter reassignment
+    }
+  }
 
-    void Color::use(Code
-#ifndef DOCTEST_CONFIG_COLORS_NONE
-                            code
-#endif // DOCTEST_CONFIG_COLORS_NONE
-    ) {
-        const ContextState* p = contextState;
-        if(p->no_colors)
-            return;
-#ifdef DOCTEST_CONFIG_COLORS_ANSI
-        if(isatty(STDOUT_FILENO) == false && p->force_colors == false)
-            return;
+  while(*wild == '*')
+  {
+    wild++;
+  }
+  return !*wild;
+}
 
-        const char* col = "";
-        // clang-format off
+//// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+// unsigned hashStr(unsigned const char* str) {
+//    unsigned long hash = 5381;
+//    char          c;
+//    while((c = *str++))
+//        hash = ((hash << 5) + hash) + c; // hash * 33 + c
+//    return hash;
+//}
+
+// checks if the name matches any of the filters (and can be configured what to do when empty)
+bool matchesAny(const char * name, const std::vector<String> & filters, int matchEmpty, bool caseSensitive)
+{
+  if(filters.empty() && matchEmpty)
+    return true;
+  for(unsigned i = 0; i < filters.size(); ++i)
+    if(wildcmp(name, filters[i].c_str(), caseSensitive))
+      return true;
+  return false;
+}
+
+#    ifdef DOCTEST_PLATFORM_WINDOWS
+
+typedef unsigned long long UInt64;
+
+UInt64 getCurrentTicks()
+{
+  static UInt64 hz = 0, hzo = 0;
+  if(!hz)
+  {
+    QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER *>(&hz));
+    QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER *>(&hzo));
+  }
+  UInt64 t;
+  QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER *>(&t));
+  return ((t - hzo) * 1000000) / hz;
+}
+#    else // DOCTEST_PLATFORM_WINDOWS
+
+typedef uint64_t UInt64;
+
+UInt64 getCurrentTicks()
+{
+  timeval t;
+  gettimeofday(&t, 0);
+  return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
+}
+#    endif // DOCTEST_PLATFORM_WINDOWS
+
+class Timer
+{
+public:
+  Timer() : m_ticks(0) {}
+  void start() { m_ticks = getCurrentTicks(); }
+  unsigned int getElapsedMicroseconds() const { return static_cast<unsigned int>(getCurrentTicks() - m_ticks); }
+  unsigned int getElapsedMilliseconds() const { return static_cast<unsigned int>(getElapsedMicroseconds() / 1000); }
+  double getElapsedSeconds() const { return getElapsedMicroseconds() / 1000000.0; }
+
+private:
+  UInt64 m_ticks;
+};
+
+TestAccessibleContextState * getTestsContextState() { return contextState; }
+
+bool SubcaseSignature::operator<(const SubcaseSignature & other) const
+{
+  if(m_line != other.m_line)
+    return m_line < other.m_line;
+  if(std::strcmp(m_file, other.m_file) != 0)
+    return std::strcmp(m_file, other.m_file) < 0;
+  return std::strcmp(m_name, other.m_name) < 0;
+}
+
+Subcase::Subcase(const char * name, const char * file, int line) : m_signature(name, file, line), m_entered(false)
+{
+  ContextState * s = contextState;
+
+  // if we have already completed it
+  if(s->subcasesPassed.count(m_signature) != 0)
+    return;
+
+  // check subcase filters
+  if(s->subcasesCurrentLevel < s->subcase_filter_levels)
+  {
+    if(!matchesAny(m_signature.m_name, s->filters[6], 1, s->case_sensitive))
+      return;
+    if(matchesAny(m_signature.m_name, s->filters[7], 0, s->case_sensitive))
+      return;
+  }
+
+  // if a Subcase on the same level has already been entered
+  if(s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0)
+  {
+    s->subcasesHasSkipped = true;
+    return;
+  }
+
+  s->subcasesStack.push_back(*this);
+  if(s->hasLoggedCurrentTestStart)
+    logTestEnd();
+  s->hasLoggedCurrentTestStart = false;
+
+  s->subcasesEnteredLevels.insert(s->subcasesCurrentLevel++);
+  m_entered = true;
+}
+
+Subcase::Subcase(const Subcase & other)
+: m_signature(other.m_signature.m_name, other.m_signature.m_file, other.m_signature.m_line), m_entered(other.m_entered)
+{
+}
+
+Subcase::~Subcase()
+{
+  if(m_entered)
+  {
+    ContextState * s = contextState;
+
+    s->subcasesCurrentLevel--;
+    // only mark the subcase as passed if no subcases have been skipped
+    if(s->subcasesHasSkipped == false)
+      s->subcasesPassed.insert(m_signature);
+
+    if(!s->subcasesStack.empty())
+      s->subcasesStack.pop_back();
+    if(s->hasLoggedCurrentTestStart)
+      logTestEnd();
+    s->hasLoggedCurrentTestStart = false;
+  }
+}
+
+Result::~Result() {}
+
+Result & Result::operator=(const Result & other)
+{
+  m_passed = other.m_passed;
+  m_decomposition = other.m_decomposition;
+
+  return *this;
+}
+
+// for sorting tests by file/line
+int fileOrderComparator(const void * a, const void * b)
+{
+  const TestCase * lhs = *static_cast<TestCase * const *>(a);
+  const TestCase * rhs = *static_cast<TestCase * const *>(b);
+#    if DOCTEST_MSVC
+  // this is needed because MSVC gives different case for drive letters
+  // for __FILE__ when evaluated in a header and a source file
+  const int res = stricmp(lhs->m_file, rhs->m_file);
+#    else // MSVC
+  const int res = std::strcmp(lhs->m_file, rhs->m_file);
+#    endif // MSVC
+  if(res != 0)
+    return res;
+  return static_cast<int>(lhs->m_line - rhs->m_line);
+}
+
+// for sorting tests by suite/file/line
+int suiteOrderComparator(const void * a, const void * b)
+{
+  const TestCase * lhs = *static_cast<TestCase * const *>(a);
+  const TestCase * rhs = *static_cast<TestCase * const *>(b);
+
+  const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
+  if(res != 0)
+    return res;
+  return fileOrderComparator(a, b);
+}
+
+// for sorting tests by name/suite/file/line
+int nameOrderComparator(const void * a, const void * b)
+{
+  const TestCase * lhs = *static_cast<TestCase * const *>(a);
+  const TestCase * rhs = *static_cast<TestCase * const *>(b);
+
+  const int res_name = std::strcmp(lhs->m_name, rhs->m_name);
+  if(res_name != 0)
+    return res_name;
+  return suiteOrderComparator(a, b);
+}
+
+// sets the current test suite
+int setTestSuite(const TestSuite & ts)
+{
+  doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+  return 0;
+}
+
+// all the registered tests
+std::set<TestCase> & getRegisteredTests()
+{
+  static std::set<TestCase> data;
+  return data;
+}
+
+// used by the macros for registering tests
+int regTest(const TestCase & tc)
+{
+  getRegisteredTests().insert(tc);
+  return 0;
+}
+
+struct Color
+{
+  enum Code
+  {
+    None = 0,
+    White,
+    Red,
+    Green,
+    Blue,
+    Cyan,
+    Yellow,
+    Grey,
+
+    Bright = 0x10,
+
+    BrightRed = Bright | Red,
+    BrightGreen = Bright | Green,
+    LightGrey = Bright | Grey,
+    BrightWhite = Bright | White
+  };
+  explicit Color(Code code) { use(code); }
+  ~Color() { use(None); }
+
+  static void use(Code code);
+  static void init();
+};
+
+#    ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+HANDLE g_stdoutHandle;
+WORD g_originalForegroundAttributes;
+WORD g_originalBackgroundAttributes;
+bool g_attrsInitted = false;
+#    endif // DOCTEST_CONFIG_COLORS_WINDOWS
+
+void Color::init()
+{
+#    ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+  if(!g_attrsInitted)
+  {
+    g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    g_attrsInitted = true;
+    CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+    GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
+    g_originalForegroundAttributes =
+        csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+    g_originalBackgroundAttributes =
+        csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+  }
+#    endif // DOCTEST_CONFIG_COLORS_WINDOWS
+}
+
+void Color::use(Code
+#    ifndef DOCTEST_CONFIG_COLORS_NONE
+                    code
+#    endif // DOCTEST_CONFIG_COLORS_NONE
+)
+{
+  const ContextState * p = contextState;
+  if(p->no_colors)
+    return;
+#    ifdef DOCTEST_CONFIG_COLORS_ANSI
+  if(isatty(STDOUT_FILENO) == false && p->force_colors == false)
+    return;
+
+  const char * col = "";
+  // clang-format off
         switch(code) { //!OCLINT missing break in switch statement / unnecessary default statement in covered switch statement
             case Color::Red:         col = "[0;31m"; break;
             case Color::Green:       col = "[0;32m"; break;
@@ -4267,18 +4506,17 @@ namespace detail
             case Color::White:
             default:                 col = "[0m";
         }
-        // clang-format on
-        std::printf("\033%s", col);
-#endif // DOCTEST_CONFIG_COLORS_ANSI
+  // clang-format on
+  std::printf("\033%s", col);
+#    endif // DOCTEST_CONFIG_COLORS_ANSI
 
-#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-        if(isatty(fileno(stdout)) == false && p->force_colors == false)
-            return;
+#    ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+  if(isatty(fileno(stdout)) == false && p->force_colors == false)
+    return;
 
-#define DOCTEST_SET_ATTR(x)                                                                        \
-    SetConsoleTextAttribute(g_stdoutHandle, x | g_originalBackgroundAttributes)
+#      define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(g_stdoutHandle, x | g_originalBackgroundAttributes)
 
-        // clang-format off
+  // clang-format off
         switch (code) {
             case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
             case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
@@ -4296,29 +4534,32 @@ namespace detail
             default:                 DOCTEST_SET_ATTR(g_originalForegroundAttributes);
         }
 // clang-format on
-#undef DOCTEST_SET_ATTR
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
-    }
+#      undef DOCTEST_SET_ATTR
+#    endif // DOCTEST_CONFIG_COLORS_WINDOWS
+}
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
-        static std::vector<const IExceptionTranslator*> data;
-        return data;
-    }
+std::vector<const IExceptionTranslator *> & getExceptionTranslators()
+{
+  static std::vector<const IExceptionTranslator *> data;
+  return data;
+}
 
-    void registerExceptionTranslatorImpl(const IExceptionTranslator* translateFunction) {
-        if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(),
-                     translateFunction) == getExceptionTranslators().end())
-            getExceptionTranslators().push_back(translateFunction);
-    }
+void registerExceptionTranslatorImpl(const IExceptionTranslator * translateFunction)
+{
+  if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), translateFunction)
+     == getExceptionTranslators().end())
+    getExceptionTranslators().push_back(translateFunction);
+}
 
-    String translateActiveException() {
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        String                                    res;
-        std::vector<const IExceptionTranslator*>& translators = getExceptionTranslators();
-        for(size_t i = 0; i < translators.size(); ++i)
-            if(translators[i]->translate(res))
-                return res;
-        // clang-format off
+String translateActiveException()
+{
+#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+  String res;
+  std::vector<const IExceptionTranslator *> & translators = getExceptionTranslators();
+  for(size_t i = 0; i < translators.size(); ++i)
+    if(translators[i]->translate(res))
+      return res;
+  // clang-format off
         try {
             throw;
         } catch(std::exception& ex) {
@@ -4331,822 +4572,902 @@ namespace detail
             return "unknown exception";
         }
 // clang-format on
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-        return "";
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
+#    else // DOCTEST_CONFIG_NO_EXCEPTIONS
+  return "";
+#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+}
 
-    void writeStringToStream(std::ostream* stream, const String& str) { *stream << str; }
+void writeStringToStream(std::ostream * stream, const String & str) { *stream << str; }
 
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    void toStream(std::ostream* stream, char* in) { *stream << in; }
-    void toStream(std::ostream* stream, const char* in) { *stream << in; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    void toStream(std::ostream* stream, bool in) {
-        *stream << std::boolalpha << in << std::noboolalpha;
-    }
-    void toStream(std::ostream* stream, float in) { *stream << in; }
-    void toStream(std::ostream* stream, double in) { *stream << in; }
-    void toStream(std::ostream* stream, double long in) { *stream << in; }
+#    ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+void toStream(std::ostream * stream, char * in) { *stream << in; }
+void toStream(std::ostream * stream, const char * in) { *stream << in; }
+#    endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+void toStream(std::ostream * stream, bool in) { *stream << std::boolalpha << in << std::noboolalpha; }
+void toStream(std::ostream * stream, float in) { *stream << in; }
+void toStream(std::ostream * stream, double in) { *stream << in; }
+void toStream(std::ostream * stream, double long in) { *stream << in; }
 
-    void toStream(std::ostream* stream, char in) { *stream << in; }
-    void toStream(std::ostream* stream, char signed in) { *stream << in; }
-    void toStream(std::ostream* stream, char unsigned in) { *stream << in; }
-    void toStream(std::ostream* stream, int short in) { *stream << in; }
-    void toStream(std::ostream* stream, int short unsigned in) { *stream << in; }
-    void toStream(std::ostream* stream, int in) { *stream << in; }
-    void toStream(std::ostream* stream, int unsigned in) { *stream << in; }
-    void toStream(std::ostream* stream, int long in) { *stream << in; }
-    void toStream(std::ostream* stream, int long unsigned in) { *stream << in; }
+void toStream(std::ostream * stream, char in) { *stream << in; }
+void toStream(std::ostream * stream, char signed in) { *stream << in; }
+void toStream(std::ostream * stream, char unsigned in) { *stream << in; }
+void toStream(std::ostream * stream, int short in) { *stream << in; }
+void toStream(std::ostream * stream, int short unsigned in) { *stream << in; }
+void toStream(std::ostream * stream, int in) { *stream << in; }
+void toStream(std::ostream * stream, int unsigned in) { *stream << in; }
+void toStream(std::ostream * stream, int long in) { *stream << in; }
+void toStream(std::ostream * stream, int long unsigned in) { *stream << in; }
 
-#ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-    void toStream(std::ostream* stream, int long long in) { *stream << in; }
-    void toStream(std::ostream* stream, int long long unsigned in) { *stream << in; }
-#endif // DOCTEST_CONFIG_WITH_LONG_LONG
+#    ifdef DOCTEST_CONFIG_WITH_LONG_LONG
+void toStream(std::ostream * stream, int long long in) { *stream << in; }
+void toStream(std::ostream * stream, int long long unsigned in) { *stream << in; }
+#    endif // DOCTEST_CONFIG_WITH_LONG_LONG
 
-    void addToContexts(IContextScope* ptr) { contextState->contexts.push_back(ptr); }
-    void popFromContexts() { contextState->contexts.pop_back(); }
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    void useContextIfExceptionOccurred(IContextScope* ptr) {
-        if(std::uncaught_exception()) {
-            std::ostringstream stream;
-            ptr->build(&stream);
-            contextState->exceptionalContexts.push_back(stream.str());
-        }
-    }
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+void addToContexts(IContextScope * ptr) { contextState->contexts.push_back(ptr); }
+void popFromContexts() { contextState->contexts.pop_back(); }
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+void useContextIfExceptionOccurred(IContextScope * ptr)
+{
+  if(std::uncaught_exception())
+  {
+    std::ostringstream stream;
+    ptr->build(&stream);
+    contextState->exceptionalContexts.push_back(stream.str());
+  }
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    void printSummary();
+void printSummary();
 
-#if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string&) {}
-    struct FatalConditionHandler
+#    if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
+void reportFatal(const std::string &) {}
+struct FatalConditionHandler
+{
+  void reset() {}
+};
+#    else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+void reportFatal(const std::string & message)
+{
+  DOCTEST_LOG_START();
+
+  contextState->numAssertions += contextState->numAssertionsForCurrentTestcase;
+  logTestException(message.c_str(), true);
+  logTestEnd();
+  contextState->numFailed++;
+
+  printSummary();
+}
+
+#      ifdef DOCTEST_PLATFORM_WINDOWS
+
+struct SignalDefs
+{
+  DWORD id;
+  const char * name;
+};
+// There is no 1-1 mapping between signals and windows exceptions.
+// Windows can easily distinguish between SO and SigSegV,
+// but SigInt, SigTerm, etc are handled differently.
+SignalDefs signalDefs[] = {
+    {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
+    {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
+    {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
+    {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
+};
+
+struct FatalConditionHandler
+{
+  static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo)
+  {
+    for(size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
     {
-        void reset() {}
-    };
-#else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
-
-    void reportFatal(const std::string& message) {
-        DOCTEST_LOG_START();
-
-        contextState->numAssertions += contextState->numAssertionsForCurrentTestcase;
-        logTestException(message.c_str(), true);
-        logTestEnd();
-        contextState->numFailed++;
-
-        printSummary();
+      if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id)
+      {
+        reportFatal(signalDefs[i].name);
+      }
     }
+    // If its not an exception we care about, pass it along.
+    // This stops us from eating debugger breaks etc.
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
 
-#ifdef DOCTEST_PLATFORM_WINDOWS
+  FatalConditionHandler()
+  {
+    isSet = true;
+    // 32k seems enough for doctest to handle stack overflow,
+    // but the value was found experimentally, so there is no strong guarantee
+    guaranteeSize = 32 * 1024;
+    exceptionHandlerHandle = 0;
+    // Register as first handler in current chain
+    exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+    // Pass in guarantee size to be filled
+    SetThreadStackGuarantee(&guaranteeSize);
+  }
 
-    struct SignalDefs
+  static void reset()
+  {
+    if(isSet)
     {
-        DWORD       id;
-        const char* name;
-    };
-    // There is no 1-1 mapping between signals and windows exceptions.
-    // Windows can easily distinguish between SO and SigSegV,
-    // but SigInt, SigTerm, etc are handled differently.
-    SignalDefs signalDefs[] = {
-            {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
-            {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
-            {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
-            {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
-    };
+      // Unregister handler and restore the old guarantee
+      RemoveVectoredExceptionHandler(exceptionHandlerHandle);
+      SetThreadStackGuarantee(&guaranteeSize);
+      exceptionHandlerHandle = 0;
+      isSet = false;
+    }
+  }
 
-    struct FatalConditionHandler
+  ~FatalConditionHandler() { reset(); }
+
+private:
+  static bool isSet;
+  static ULONG guaranteeSize;
+  static PVOID exceptionHandlerHandle;
+};
+
+bool FatalConditionHandler::isSet = false;
+ULONG FatalConditionHandler::guaranteeSize = 0;
+PVOID FatalConditionHandler::exceptionHandlerHandle = 0;
+
+#      else // DOCTEST_PLATFORM_WINDOWS
+
+struct SignalDefs
+{
+  int id;
+  const char * name;
+};
+SignalDefs signalDefs[] = {
+    {SIGINT, "SIGINT - Terminal interrupt signal"},    {SIGILL, "SIGILL - Illegal instruction signal"},
+    {SIGFPE, "SIGFPE - Floating point error signal"},  {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+    {SIGTERM, "SIGTERM - Termination request signal"}, {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
+
+struct FatalConditionHandler
+{
+  static bool isSet;
+  static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)];
+  static stack_t oldSigStack;
+  static char altStackMem[SIGSTKSZ];
+
+  static void handleSignal(int sig)
+  {
+    std::string name = "<unknown signal>";
+    for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
     {
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
-            for(size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
-                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
-                    reportFatal(signalDefs[i].name);
-                }
-            }
-            // If its not an exception we care about, pass it along.
-            // This stops us from eating debugger breaks etc.
-            return EXCEPTION_CONTINUE_SEARCH;
-        }
+      SignalDefs & def = signalDefs[i];
+      if(sig == def.id)
+      {
+        name = def.name;
+        break;
+      }
+    }
+    reset();
+    reportFatal(name);
+    raise(sig);
+  }
 
-        FatalConditionHandler() {
-            isSet = true;
-            // 32k seems enough for doctest to handle stack overflow,
-            // but the value was found experimentally, so there is no strong guarantee
-            guaranteeSize          = 32 * 1024;
-            exceptionHandlerHandle = 0;
-            // Register as first handler in current chain
-            exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
-            // Pass in guarantee size to be filled
-            SetThreadStackGuarantee(&guaranteeSize);
-        }
+  FatalConditionHandler()
+  {
+    isSet = true;
+    stack_t sigStack;
+    sigStack.ss_sp = altStackMem;
+    sigStack.ss_size = SIGSTKSZ;
+    sigStack.ss_flags = 0;
+    sigaltstack(&sigStack, &oldSigStack);
+    struct sigaction sa = {0};
 
-        static void reset() {
-            if(isSet) {
-                // Unregister handler and restore the old guarantee
-                RemoveVectoredExceptionHandler(exceptionHandlerHandle);
-                SetThreadStackGuarantee(&guaranteeSize);
-                exceptionHandlerHandle = 0;
-                isSet                  = false;
-            }
-        }
-
-        ~FatalConditionHandler() { reset(); }
-
-    private:
-        static bool  isSet;
-        static ULONG guaranteeSize;
-        static PVOID exceptionHandlerHandle;
-    };
-
-    bool  FatalConditionHandler::isSet                  = false;
-    ULONG FatalConditionHandler::guaranteeSize          = 0;
-    PVOID FatalConditionHandler::exceptionHandlerHandle = 0;
-
-#else // DOCTEST_PLATFORM_WINDOWS
-
-    struct SignalDefs
+    sa.sa_handler = handleSignal; // NOLINT
+    sa.sa_flags = SA_ONSTACK;
+    for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
     {
-        int         id;
-        const char* name;
-    };
-    SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
-                               {SIGILL, "SIGILL - Illegal instruction signal"},
-                               {SIGFPE, "SIGFPE - Floating point error signal"},
-                               {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
-                               {SIGTERM, "SIGTERM - Termination request signal"},
-                               {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
+      sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
+    }
+  }
 
-    struct FatalConditionHandler
+  ~FatalConditionHandler() { reset(); }
+  static void reset()
+  {
+    if(isSet)
     {
-        static bool             isSet;
-        static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)];
-        static stack_t          oldSigStack;
-        static char             altStackMem[SIGSTKSZ];
+      // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
+      for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
+      {
+        sigaction(signalDefs[i].id, &oldSigActions[i], 0);
+      } // Return the old stack
+      sigaltstack(&oldSigStack, 0);
+      isSet = false;
+    }
+  }
+};
 
-        static void handleSignal(int sig) {
-            std::string name = "<unknown signal>";
-            for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
-                SignalDefs& def = signalDefs[i];
-                if(sig == def.id) {
-                    name = def.name;
-                    break;
-                }
-            }
-            reset();
-            reportFatal(name);
-            raise(sig);
+bool FatalConditionHandler::isSet = false;
+struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)] = {};
+stack_t FatalConditionHandler::oldSigStack = {};
+char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+
+#      endif // DOCTEST_PLATFORM_WINDOWS
+#    endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+// depending on the current options this will remove the path of filenames
+const char * fileForOutput(const char * file)
+{
+  if(contextState->no_path_in_filenames)
+  {
+    const char * back = std::strrchr(file, '\\');
+    const char * forward = std::strrchr(file, '/');
+    if(back || forward)
+    {
+      if(back > forward)
+        forward = back;
+      return forward + 1;
+    }
+  }
+  return file;
+}
+
+// depending on the current options this will substitute the line numbers with 0
+int lineForOutput(int line)
+{
+  if(contextState->no_line_numbers)
+    return 0;
+  return line;
+}
+
+#    ifdef DOCTEST_PLATFORM_MAC
+#      include <sys/types.h>
+#      include <unistd.h>
+#      include <sys/sysctl.h>
+// The following function is taken directly from the following technical note:
+// http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+bool isDebuggerActive()
+{
+  int mib[4];
+  kinfo_proc info;
+  size_t size;
+  // Initialize the flags so that, if sysctl fails for some bizarre
+  // reason, we get a predictable result.
+  info.kp_proc.p_flag = 0;
+  // Initialize mib, which tells sysctl the info we want, in this case
+  // we're looking for information about a specific process ID.
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PID;
+  mib[3] = getpid();
+  // Call sysctl.
+  size = sizeof(info);
+  if(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, 0, 0) != 0)
+  {
+    fprintf(stderr, "\n** Call to sysctl failed - unable to determine if debugger is "
+                    "active **\n\n");
+    return false;
+  }
+  // We're being debugged if the P_TRACED flag is set.
+  return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
+#    elif DOCTEST_MSVC || defined(__MINGW32__)
+bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
+#    else
+bool isDebuggerActive() { return false; }
+#    endif // Platform
+
+#    ifdef DOCTEST_PLATFORM_WINDOWS
+void myOutputDebugString(const String & text) { ::OutputDebugStringA(text.c_str()); }
+#    else
+// TODO: integration with XCode and other IDEs
+void myOutputDebugString(const String &) {}
+#    endif // Platform
+
+const char * getSeparator()
+{
+  return "===============================================================================\n";
+}
+
+void printToDebugConsole(const String & text)
+{
+  if(isDebuggerActive())
+    myOutputDebugString(text.c_str());
+}
+
+void addFailedAssert(assertType::Enum assert_type)
+{
+  if((assert_type & assertType::is_warn) == 0)
+  { //! OCLINT bitwise operator in conditional
+    contextState->numFailedAssertions++;
+    contextState->numFailedAssertionsForCurrentTestcase++;
+    contextState->hasCurrentTestFailed = true;
+  }
+}
+
+void logTestStart(const TestCase & tc)
+{
+  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)\n", fileForOutput(tc.m_file), lineForOutput(tc.m_line));
+
+  char ts1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(ts1, DOCTEST_COUNTOF(ts1), "TEST SUITE: ");
+  char ts2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(ts2, DOCTEST_COUNTOF(ts2), "%s\n", tc.m_test_suite);
+  char n1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(n1, DOCTEST_COUNTOF(n1), "TEST CASE:  ");
+  char n2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(n2, DOCTEST_COUNTOF(n2), "%s\n", tc.m_name);
+  char d1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(d1, DOCTEST_COUNTOF(d1), "DESCRIPTION: ");
+  char d2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(d2, DOCTEST_COUNTOF(d2), "%s\n", tc.m_description);
+
+  // hack for BDD style of macros - to not print "TEST CASE:"
+  char scenario[] = "  Scenario:";
+  if(std::string(tc.m_name).substr(0, DOCTEST_COUNTOF(scenario) - 1) == scenario)
+    n1[0] = '\0';
+
+  DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+
+  String forDebugConsole;
+  if(tc.m_description)
+  {
+    DOCTEST_PRINTF_COLORED(d1, Color::Yellow);
+    DOCTEST_PRINTF_COLORED(d2, Color::None);
+    forDebugConsole += d1;
+    forDebugConsole += d2;
+  }
+  if(tc.m_test_suite && tc.m_test_suite[0] != '\0')
+  {
+    DOCTEST_PRINTF_COLORED(ts1, Color::Yellow);
+    DOCTEST_PRINTF_COLORED(ts2, Color::None);
+    forDebugConsole += ts1;
+    forDebugConsole += ts2;
+  }
+  DOCTEST_PRINTF_COLORED(n1, Color::Yellow);
+  DOCTEST_PRINTF_COLORED(n2, Color::None);
+
+  String subcaseStuff;
+  std::vector<Subcase> & subcasesStack = contextState->subcasesStack;
+  for(unsigned i = 0; i < subcasesStack.size(); ++i)
+  {
+    if(subcasesStack[i].m_signature.m_name[0] != '\0')
+    {
+      char subcase[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+      DOCTEST_SNPRINTF(subcase, DOCTEST_COUNTOF(loc), "  %s\n", subcasesStack[i].m_signature.m_name);
+      DOCTEST_PRINTF_COLORED(subcase, Color::None);
+      subcaseStuff += subcase;
+    }
+  }
+
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(getSeparator()) + loc + forDebugConsole.c_str() + n1 + n2 + subcaseStuff.c_str() + "\n");
+}
+
+void logTestEnd() {}
+
+void logTestException(const String & what, bool crash)
+{
+  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+
+  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED!\n");
+
+  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  info1[0] = 0;
+  info2[0] = 0;
+  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), crash ? "crashed:\n" : "threw exception:\n");
+  DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "  %s\n", what.c_str());
+
+  std::string contextStr;
+
+  if(!contextState->exceptionalContexts.empty())
+  {
+    contextStr += "with context:\n";
+    for(size_t i = contextState->exceptionalContexts.size(); i > 0; --i)
+    {
+      contextStr += "  ";
+      contextStr += contextState->exceptionalContexts[i - 1];
+      contextStr += "\n";
+    }
+  }
+
+  DOCTEST_PRINTF_COLORED(msg, Color::Red);
+  DOCTEST_PRINTF_COLORED(info1, Color::None);
+  DOCTEST_PRINTF_COLORED(info2, Color::Cyan);
+  DOCTEST_PRINTF_COLORED(contextStr.c_str(), Color::None);
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(msg) + info1 + info2 + contextStr.c_str() + "\n");
+}
+
+String logContext()
+{
+  std::ostringstream stream;
+  std::vector<IContextScope *> & contexts = contextState->contexts;
+  if(!contexts.empty())
+    stream << "with context:\n";
+  for(size_t i = 0; i < contexts.size(); ++i)
+  {
+    stream << "  ";
+    contexts[i]->build(&stream);
+    stream << "\n";
+  }
+  return stream.str().c_str();
+}
+
+const char * getFailString(assertType::Enum assert_type)
+{
+  if(assert_type & assertType::is_warn) //! OCLINT bitwise operator in conditional
+    return "WARNING";
+  if(assert_type & assertType::is_check) //! OCLINT bitwise operator in conditional
+    return "ERROR";
+  if(assert_type & assertType::is_require) //! OCLINT bitwise operator in conditional
+    return "FATAL ERROR";
+  return "";
+}
+
+void logAssert(bool passed,
+               const char * decomposition,
+               bool threw,
+               const String & exception,
+               const char * expr,
+               assertType::Enum assert_type,
+               const char * file,
+               int line)
+{
+  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
+
+  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", passed ? "PASSED" : getFailString(assert_type));
+
+  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n", getAssertString(assert_type), expr);
+
+  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  info2[0] = 0;
+  info3[0] = 0;
+  if(threw)
+  {
+    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
+    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
+  }
+  else
+  {
+    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "with expansion:\n");
+    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s( %s )\n", getAssertString(assert_type), decomposition);
+  }
+
+  const bool isWarn = assert_type & assertType::is_warn;
+  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+  DOCTEST_PRINTF_COLORED(msg, passed ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
+  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+  DOCTEST_PRINTF_COLORED(info2, Color::None);
+  DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
+  String context = logContext();
+  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
+}
+
+void logAssertThrows(bool threw, const char * expr, assertType::Enum assert_type, const char * file, int line)
+{
+  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
+
+  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", threw ? "PASSED" : getFailString(assert_type));
+
+  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n", getAssertString(assert_type), expr);
+
+  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  info2[0] = 0;
+
+  if(!threw)
+    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
+
+  const bool isWarn = assert_type & assertType::is_warn;
+  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+  DOCTEST_PRINTF_COLORED(msg, threw ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
+  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+  DOCTEST_PRINTF_COLORED(info2, Color::None);
+  String context = logContext();
+  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(loc) + msg + info1 + info2 + context.c_str() + "\n");
+}
+
+void logAssertThrowsAs(bool threw,
+                       bool threw_as,
+                       const char * as,
+                       const String & exception,
+                       const char * expr,
+                       assertType::Enum assert_type,
+                       const char * file,
+                       int line)
+{
+  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
+
+  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", threw_as ? "PASSED" : getFailString(assert_type));
+
+  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s, %s )\n", getAssertString(assert_type), expr, as);
+
+  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  info2[0] = 0;
+  info3[0] = 0;
+
+  if(!threw)
+  { //! OCLINT inverted logic
+    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
+  }
+  else if(!threw_as)
+  {
+    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw a different exception:\n");
+    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
+  }
+
+  const bool isWarn = assert_type & assertType::is_warn;
+  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+  DOCTEST_PRINTF_COLORED(msg, threw_as ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
+  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+  DOCTEST_PRINTF_COLORED(info2, Color::None);
+  DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
+  String context = logContext();
+  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
+}
+
+void logAssertNothrow(bool threw,
+                      const String & exception,
+                      const char * expr,
+                      assertType::Enum assert_type,
+                      const char * file,
+                      int line)
+{
+  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
+
+  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", threw ? getFailString(assert_type) : "PASSED");
+
+  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n", getAssertString(assert_type), expr);
+
+  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  info2[0] = 0;
+  info3[0] = 0;
+  if(threw)
+  {
+    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
+    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
+  }
+
+  const bool isWarn = assert_type & assertType::is_warn;
+  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+  DOCTEST_PRINTF_COLORED(msg, threw ? isWarn ? Color::Yellow : Color::Red : Color::BrightGreen);
+  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+  DOCTEST_PRINTF_COLORED(info2, Color::None);
+  DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
+  String context = logContext();
+  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
+}
+
+ResultBuilder::ResultBuilder(assertType::Enum assert_type,
+                             const char * file,
+                             int line,
+                             const char * expr,
+                             const char * exception_type)
+: m_assert_type(assert_type), m_file(file), m_line(line), m_expr(expr), m_exception_type(exception_type),
+  m_threw(false), m_threw_as(false), m_failed(false)
+{
+#    if DOCTEST_MSVC
+  if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+    ++m_expr;
+#    endif // MSVC
+}
+
+ResultBuilder::~ResultBuilder() {}
+
+void ResultBuilder::unexpectedExceptionOccurred()
+{
+  m_threw = true;
+
+  m_exception = translateActiveException();
+}
+
+bool ResultBuilder::log()
+{
+  if((m_assert_type & assertType::is_warn) == 0) //! OCLINT bitwise operator in conditional
+    contextState->numAssertionsForCurrentTestcase++;
+
+  if(m_assert_type & assertType::is_throws)
+  { //! OCLINT bitwise operator in conditional
+    m_failed = !m_threw;
+  }
+  else if(m_assert_type & //! OCLINT bitwise operator in conditional
+          assertType::is_throws_as)
+  {
+    m_failed = !m_threw_as;
+  }
+  else if(m_assert_type & //! OCLINT bitwise operator in conditional
+          assertType::is_nothrow)
+  {
+    m_failed = m_threw;
+  }
+  else
+  {
+    m_failed = m_result;
+  }
+
+  if(m_failed || contextState->success)
+  {
+    DOCTEST_LOG_START();
+
+    if(m_assert_type & assertType::is_throws)
+    { //! OCLINT bitwise operator in conditional
+      logAssertThrows(m_threw, m_expr, m_assert_type, m_file, m_line);
+    }
+    else if(m_assert_type & //! OCLINT bitwise operator in conditional
+            assertType::is_throws_as)
+    {
+      logAssertThrowsAs(m_threw, m_threw_as, m_exception_type, m_exception, m_expr, m_assert_type, m_file, m_line);
+    }
+    else if(m_assert_type & //! OCLINT bitwise operator in conditional
+            assertType::is_nothrow)
+    {
+      logAssertNothrow(m_threw, m_exception, m_expr, m_assert_type, m_file, m_line);
+    }
+    else
+    {
+      logAssert(m_result.m_passed, m_result.m_decomposition.c_str(), m_threw, m_exception, m_expr, m_assert_type,
+                m_file, m_line);
+    }
+  }
+
+  if(m_failed)
+    addFailedAssert(m_assert_type);
+
+  return m_failed && isDebuggerActive() && !contextState->no_breaks; // break into debugger
+}
+
+void ResultBuilder::react() const
+{
+  if(m_failed && checkIfShouldThrow(m_assert_type))
+    throwException();
+}
+
+MessageBuilder::MessageBuilder(const char * file, int line, assertType::Enum severity)
+: m_stream(createStream()), m_file(file), m_line(line), m_severity(severity)
+{
+}
+
+bool MessageBuilder::log()
+{
+  DOCTEST_LOG_START();
+
+  const bool isWarn = m_severity & assertType::is_warn;
+
+  // warn is just a message in this context so we dont treat it as an assert
+  if(!isWarn)
+  {
+    contextState->numAssertionsForCurrentTestcase++;
+    addFailedAssert(m_severity);
+  }
+
+  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(m_file), lineForOutput(m_line));
+  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", isWarn ? "MESSAGE" : getFailString(m_severity));
+
+  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+  DOCTEST_PRINTF_COLORED(msg, isWarn ? Color::Yellow : Color::Red);
+
+  String info = getStreamResult(m_stream);
+  if(info.size())
+  {
+    DOCTEST_PRINTF_COLORED("  ", Color::None);
+    DOCTEST_PRINTF_COLORED(info.c_str(), Color::None);
+    DOCTEST_PRINTF_COLORED("\n", Color::None);
+  }
+  String context = logContext();
+  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+  DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+  printToDebugConsole(String(loc) + msg + "  " + info.c_str() + "\n" + context.c_str() + "\n");
+
+  return isDebuggerActive() && !contextState->no_breaks && !isWarn; // break into debugger
+}
+
+void MessageBuilder::react()
+{
+  if(m_severity & assertType::is_require) //! OCLINT bitwise operator in conditional
+    throwException();
+}
+
+MessageBuilder::~MessageBuilder() { freeStream(m_stream); }
+
+// the implementation of parseFlag()
+bool parseFlagImpl(int argc, const char * const * argv, const char * pattern)
+{
+  for(int i = argc - 1; i >= 0; --i)
+  {
+    const char * temp = std::strstr(argv[i], pattern);
+    if(temp && my_strlen(temp) == my_strlen(pattern))
+    {
+      // eliminate strings in which the chars before the option are not '-'
+      bool noBadCharsFound = true; //! OCLINT prefer early exits and continue
+      while(temp != argv[i])
+      {
+        if(*--temp != '-')
+        {
+          noBadCharsFound = false;
+          break;
         }
-
-        FatalConditionHandler() {
-            isSet = true;
-            stack_t sigStack;
-            sigStack.ss_sp    = altStackMem;
-            sigStack.ss_size  = SIGSTKSZ;
-            sigStack.ss_flags = 0;
-            sigaltstack(&sigStack, &oldSigStack);
-            struct sigaction sa = {0};
-
-            sa.sa_handler = handleSignal; // NOLINT
-            sa.sa_flags   = SA_ONSTACK;
-            for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
-                sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
-            }
-        }
-
-        ~FatalConditionHandler() { reset(); }
-        static void reset() {
-            if(isSet) {
-                // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-                for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
-                    sigaction(signalDefs[i].id, &oldSigActions[i], 0);
-                }
-                // Return the old stack
-                sigaltstack(&oldSigStack, 0);
-                isSet = false;
-            }
-        }
-    };
-
-    bool             FatalConditionHandler::isSet = false;
-    struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)] =
-            {};
-    stack_t FatalConditionHandler::oldSigStack           = {};
-    char    FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
-
-#endif // DOCTEST_PLATFORM_WINDOWS
-#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
-
-    // depending on the current options this will remove the path of filenames
-    const char* fileForOutput(const char* file) {
-        if(contextState->no_path_in_filenames) {
-            const char* back    = std::strrchr(file, '\\');
-            const char* forward = std::strrchr(file, '/');
-            if(back || forward) {
-                if(back > forward)
-                    forward = back;
-                return forward + 1;
-            }
-        }
-        return file;
-    }
-
-    // depending on the current options this will substitute the line numbers with 0
-    int lineForOutput(int line) {
-        if(contextState->no_line_numbers)
-            return 0;
-        return line;
-    }
-
-#ifdef DOCTEST_PLATFORM_MAC
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/sysctl.h>
-    // The following function is taken directly from the following technical note:
-    // http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
-    // Returns true if the current process is being debugged (either
-    // running under the debugger or has a debugger attached post facto).
-    bool isDebuggerActive() {
-        int        mib[4];
-        kinfo_proc info;
-        size_t     size;
-        // Initialize the flags so that, if sysctl fails for some bizarre
-        // reason, we get a predictable result.
-        info.kp_proc.p_flag = 0;
-        // Initialize mib, which tells sysctl the info we want, in this case
-        // we're looking for information about a specific process ID.
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_PROC;
-        mib[2] = KERN_PROC_PID;
-        mib[3] = getpid();
-        // Call sysctl.
-        size = sizeof(info);
-        if(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, 0, 0) != 0) {
-            fprintf(stderr, "\n** Call to sysctl failed - unable to determine if debugger is "
-                            "active **\n\n");
-            return false;
-        }
-        // We're being debugged if the P_TRACED flag is set.
-        return ((info.kp_proc.p_flag & P_TRACED) != 0);
-    }
-#elif DOCTEST_MSVC || defined(__MINGW32__)
-    bool  isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
-#else
-    bool isDebuggerActive() { return false; }
-#endif // Platform
-
-#ifdef DOCTEST_PLATFORM_WINDOWS
-    void myOutputDebugString(const String& text) { ::OutputDebugStringA(text.c_str()); }
-#else
-    // TODO: integration with XCode and other IDEs
-    void myOutputDebugString(const String&) {}
-#endif // Platform
-
-    const char* getSeparator() {
-        return "===============================================================================\n";
-    }
-
-    void printToDebugConsole(const String& text) {
-        if(isDebuggerActive())
-            myOutputDebugString(text.c_str());
-    }
-
-    void addFailedAssert(assertType::Enum assert_type) {
-        if((assert_type & assertType::is_warn) == 0) { //!OCLINT bitwise operator in conditional
-            contextState->numFailedAssertions++;
-            contextState->numFailedAssertionsForCurrentTestcase++;
-            contextState->hasCurrentTestFailed = true;
-        }
-    }
-
-    void logTestStart(const TestCase& tc) {
-        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)\n", fileForOutput(tc.m_file),
-                         lineForOutput(tc.m_line));
-
-        char ts1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(ts1, DOCTEST_COUNTOF(ts1), "TEST SUITE: ");
-        char ts2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(ts2, DOCTEST_COUNTOF(ts2), "%s\n", tc.m_test_suite);
-        char n1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(n1, DOCTEST_COUNTOF(n1), "TEST CASE:  ");
-        char n2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(n2, DOCTEST_COUNTOF(n2), "%s\n", tc.m_name);
-        char d1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(d1, DOCTEST_COUNTOF(d1), "DESCRIPTION: ");
-        char d2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(d2, DOCTEST_COUNTOF(d2), "%s\n", tc.m_description);
-
-        // hack for BDD style of macros - to not print "TEST CASE:"
-        char scenario[] = "  Scenario:";
-        if(std::string(tc.m_name).substr(0, DOCTEST_COUNTOF(scenario) - 1) == scenario)
-            n1[0] = '\0';
-
-        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-
-        String forDebugConsole;
-        if(tc.m_description) {
-            DOCTEST_PRINTF_COLORED(d1, Color::Yellow);
-            DOCTEST_PRINTF_COLORED(d2, Color::None);
-            forDebugConsole += d1;
-            forDebugConsole += d2;
-        }
-        if(tc.m_test_suite && tc.m_test_suite[0] != '\0') {
-            DOCTEST_PRINTF_COLORED(ts1, Color::Yellow);
-            DOCTEST_PRINTF_COLORED(ts2, Color::None);
-            forDebugConsole += ts1;
-            forDebugConsole += ts2;
-        }
-        DOCTEST_PRINTF_COLORED(n1, Color::Yellow);
-        DOCTEST_PRINTF_COLORED(n2, Color::None);
-
-        String                subcaseStuff;
-        std::vector<Subcase>& subcasesStack = contextState->subcasesStack;
-        for(unsigned i = 0; i < subcasesStack.size(); ++i) {
-            if(subcasesStack[i].m_signature.m_name[0] != '\0') {
-                char subcase[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-                DOCTEST_SNPRINTF(subcase, DOCTEST_COUNTOF(loc), "  %s\n",
-                                 subcasesStack[i].m_signature.m_name);
-                DOCTEST_PRINTF_COLORED(subcase, Color::None);
-                subcaseStuff += subcase;
-            }
-        }
-
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(getSeparator()) + loc + forDebugConsole.c_str() + n1 + n2 +
-                            subcaseStuff.c_str() + "\n");
-    }
-
-    void logTestEnd() {}
-
-    void logTestException(const String& what, bool crash) {
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED!\n");
-
-        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        info1[0] = 0;
-        info2[0] = 0;
-        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1),
-                         crash ? "crashed:\n" : "threw exception:\n");
-        DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "  %s\n", what.c_str());
-
-        std::string contextStr;
-
-        if(!contextState->exceptionalContexts.empty()) {
-            contextStr += "with context:\n";
-            for(size_t i = contextState->exceptionalContexts.size(); i > 0; --i) {
-                contextStr += "  ";
-                contextStr += contextState->exceptionalContexts[i - 1];
-                contextStr += "\n";
-            }
-        }
-
-        DOCTEST_PRINTF_COLORED(msg, Color::Red);
-        DOCTEST_PRINTF_COLORED(info1, Color::None);
-        DOCTEST_PRINTF_COLORED(info2, Color::Cyan);
-        DOCTEST_PRINTF_COLORED(contextStr.c_str(), Color::None);
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(msg) + info1 + info2 + contextStr.c_str() + "\n");
-    }
-
-    String logContext() {
-        std::ostringstream           stream;
-        std::vector<IContextScope*>& contexts = contextState->contexts;
-        if(!contexts.empty())
-            stream << "with context:\n";
-        for(size_t i = 0; i < contexts.size(); ++i) {
-            stream << "  ";
-            contexts[i]->build(&stream);
-            stream << "\n";
-        }
-        return stream.str().c_str();
-    }
-
-    const char* getFailString(assertType::Enum assert_type) {
-        if(assert_type & assertType::is_warn) //!OCLINT bitwise operator in conditional
-            return "WARNING";
-        if(assert_type & assertType::is_check) //!OCLINT bitwise operator in conditional
-            return "ERROR";
-        if(assert_type & assertType::is_require) //!OCLINT bitwise operator in conditional
-            return "FATAL ERROR";
-        return "";
-    }
-
-    void logAssert(bool passed, const char* decomposition, bool threw, const String& exception,
-                   const char* expr, assertType::Enum assert_type, const char* file, int line) {
-        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
-                         lineForOutput(line));
-
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
-                         passed ? "PASSED" : getFailString(assert_type));
-
-        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n",
-                         getAssertString(assert_type), expr);
-
-        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        info2[0] = 0;
-        info3[0] = 0;
-        if(threw) {
-            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
-            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
-        } else {
-            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "with expansion:\n");
-            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s( %s )\n",
-                             getAssertString(assert_type), decomposition);
-        }
-
-        const bool isWarn = assert_type & assertType::is_warn;
-        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-        DOCTEST_PRINTF_COLORED(msg,
-                               passed ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
-        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-        DOCTEST_PRINTF_COLORED(info2, Color::None);
-        DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
-        String context = logContext();
-        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
-    }
-
-    void logAssertThrows(bool threw, const char* expr, assertType::Enum assert_type,
-                         const char* file, int line) {
-        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
-                         lineForOutput(line));
-
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
-                         threw ? "PASSED" : getFailString(assert_type));
-
-        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n",
-                         getAssertString(assert_type), expr);
-
-        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        info2[0] = 0;
-
-        if(!threw)
-            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
-
-        const bool isWarn = assert_type & assertType::is_warn;
-        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-        DOCTEST_PRINTF_COLORED(msg,
-                               threw ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
-        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-        DOCTEST_PRINTF_COLORED(info2, Color::None);
-        String context = logContext();
-        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(loc) + msg + info1 + info2 + context.c_str() + "\n");
-    }
-
-    void logAssertThrowsAs(bool threw, bool threw_as, const char* as, const String& exception,
-                           const char* expr, assertType::Enum assert_type, const char* file,
-                           int line) {
-        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
-                         lineForOutput(line));
-
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
-                         threw_as ? "PASSED" : getFailString(assert_type));
-
-        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s, %s )\n",
-                         getAssertString(assert_type), expr, as);
-
-        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        info2[0] = 0;
-        info3[0] = 0;
-
-        if(!threw) { //!OCLINT inverted logic
-            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
-        } else if(!threw_as) {
-            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw a different exception:\n");
-            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
-        }
-
-        const bool isWarn = assert_type & assertType::is_warn;
-        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-        DOCTEST_PRINTF_COLORED(msg,
-                               threw_as ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
-        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-        DOCTEST_PRINTF_COLORED(info2, Color::None);
-        DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
-        String context = logContext();
-        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
-    }
-
-    void logAssertNothrow(bool threw, const String& exception, const char* expr,
-                          assertType::Enum assert_type, const char* file, int line) {
-        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
-                         lineForOutput(line));
-
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
-                         threw ? getFailString(assert_type) : "PASSED");
-
-        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n",
-                         getAssertString(assert_type), expr);
-
-        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        info2[0] = 0;
-        info3[0] = 0;
-        if(threw) {
-            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
-            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
-        }
-
-        const bool isWarn = assert_type & assertType::is_warn;
-        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-        DOCTEST_PRINTF_COLORED(msg,
-                               threw ? isWarn ? Color::Yellow : Color::Red : Color::BrightGreen);
-        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-        DOCTEST_PRINTF_COLORED(info2, Color::None);
-        DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
-        String context = logContext();
-        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
-    }
-
-    ResultBuilder::ResultBuilder(assertType::Enum assert_type, const char* file, int line,
-                                 const char* expr, const char* exception_type)
-            : m_assert_type(assert_type)
-            , m_file(file)
-            , m_line(line)
-            , m_expr(expr)
-            , m_exception_type(exception_type)
-            , m_threw(false)
-            , m_threw_as(false)
-            , m_failed(false) {
-#if DOCTEST_MSVC
-        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-#endif // MSVC
-    }
-
-    ResultBuilder::~ResultBuilder() {}
-
-    void ResultBuilder::unexpectedExceptionOccurred() {
-        m_threw = true;
-
-        m_exception = translateActiveException();
-    }
-
-    bool ResultBuilder::log() {
-        if((m_assert_type & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
-            contextState->numAssertionsForCurrentTestcase++;
-
-        if(m_assert_type & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-            m_failed = !m_threw;
-        } else if(m_assert_type & //!OCLINT bitwise operator in conditional
-                  assertType::is_throws_as) {
-            m_failed = !m_threw_as;
-        } else if(m_assert_type & //!OCLINT bitwise operator in conditional
-                  assertType::is_nothrow) {
-            m_failed = m_threw;
-        } else {
-            m_failed = m_result;
-        }
-
-        if(m_failed || contextState->success) {
-            DOCTEST_LOG_START();
-
-            if(m_assert_type & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-                logAssertThrows(m_threw, m_expr, m_assert_type, m_file, m_line);
-            } else if(m_assert_type & //!OCLINT bitwise operator in conditional
-                      assertType::is_throws_as) {
-                logAssertThrowsAs(m_threw, m_threw_as, m_exception_type, m_exception, m_expr,
-                                  m_assert_type, m_file, m_line);
-            } else if(m_assert_type & //!OCLINT bitwise operator in conditional
-                      assertType::is_nothrow) {
-                logAssertNothrow(m_threw, m_exception, m_expr, m_assert_type, m_file, m_line);
-            } else {
-                logAssert(m_result.m_passed, m_result.m_decomposition.c_str(), m_threw, m_exception,
-                          m_expr, m_assert_type, m_file, m_line);
-            }
-        }
-
-        if(m_failed)
-            addFailedAssert(m_assert_type);
-
-        return m_failed && isDebuggerActive() && !contextState->no_breaks; // break into debugger
-    }
-
-    void ResultBuilder::react() const {
-        if(m_failed && checkIfShouldThrow(m_assert_type))
-            throwException();
-    }
-
-    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity)
-            : m_stream(createStream())
-            , m_file(file)
-            , m_line(line)
-            , m_severity(severity) {}
-
-    bool MessageBuilder::log() {
-        DOCTEST_LOG_START();
-
-        const bool isWarn = m_severity & assertType::is_warn;
-
-        // warn is just a message in this context so we dont treat it as an assert
-        if(!isWarn) {
-            contextState->numAssertionsForCurrentTestcase++;
-            addFailedAssert(m_severity);
-        }
-
-        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(m_file),
-                         lineForOutput(m_line));
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
-                         isWarn ? "MESSAGE" : getFailString(m_severity));
-
-        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-        DOCTEST_PRINTF_COLORED(msg, isWarn ? Color::Yellow : Color::Red);
-
-        String info = getStreamResult(m_stream);
-        if(info.size()) {
-            DOCTEST_PRINTF_COLORED("  ", Color::None);
-            DOCTEST_PRINTF_COLORED(info.c_str(), Color::None);
-            DOCTEST_PRINTF_COLORED("\n", Color::None);
-        }
-        String context = logContext();
-        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-        DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-        printToDebugConsole(String(loc) + msg + "  " + info.c_str() + "\n" + context.c_str() +
-                            "\n");
-
-        return isDebuggerActive() && !contextState->no_breaks && !isWarn; // break into debugger
-    }
-
-    void MessageBuilder::react() {
-        if(m_severity & assertType::is_require) //!OCLINT bitwise operator in conditional
-            throwException();
-    }
-
-    MessageBuilder::~MessageBuilder() { freeStream(m_stream); }
-
-    // the implementation of parseFlag()
-    bool parseFlagImpl(int argc, const char* const* argv, const char* pattern) {
-        for(int i = argc - 1; i >= 0; --i) {
-            const char* temp = std::strstr(argv[i], pattern);
-            if(temp && my_strlen(temp) == my_strlen(pattern)) {
-                // eliminate strings in which the chars before the option are not '-'
-                bool noBadCharsFound = true; //!OCLINT prefer early exits and continue
-                while(temp != argv[i]) {
-                    if(*--temp != '-') {
-                        noBadCharsFound = false;
-                        break;
-                    }
-                }
-                if(noBadCharsFound && argv[i][0] == '-')
-                    return true;
-            }
-        }
-        return false;
-    }
-
-    // locates a flag on the command line
-    bool parseFlag(int argc, const char* const* argv, const char* pattern) {
-#ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        if(!parseFlagImpl(argc, argv, pattern))
-            return parseFlagImpl(argc, argv, pattern + 3); // 3 for "dt-"
+      }
+      if(noBadCharsFound && argv[i][0] == '-')
         return true;
-#else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        return parseFlagImpl(argc, argv, pattern);
-#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
     }
+  }
+  return false;
+}
 
-    // the implementation of parseOption()
-    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String& res) {
-        for(int i = argc - 1; i >= 0; --i) {
-            const char* temp = std::strstr(argv[i], pattern);
-            if(temp) { //!OCLINT prefer early exits and continue
-                // eliminate matches in which the chars before the option are not '-'
-                bool        noBadCharsFound = true;
-                const char* curr            = argv[i];
-                while(curr != temp) {
-                    if(*curr++ != '-') {
-                        noBadCharsFound = false;
-                        break;
-                    }
-                }
-                if(noBadCharsFound && argv[i][0] == '-') {
-                    temp += my_strlen(pattern);
-                    const unsigned len = my_strlen(temp);
-                    if(len) {
-                        res = temp;
-                        return true;
-                    }
-                }
-            }
+// locates a flag on the command line
+bool parseFlag(int argc, const char * const * argv, const char * pattern)
+{
+#    ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+  if(!parseFlagImpl(argc, argv, pattern))
+    return parseFlagImpl(argc, argv, pattern + 3); // 3 for "dt-"
+  return true;
+#    else // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+  return parseFlagImpl(argc, argv, pattern);
+#    endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+}
+
+// the implementation of parseOption()
+bool parseOptionImpl(int argc, const char * const * argv, const char * pattern, String & res)
+{
+  for(int i = argc - 1; i >= 0; --i)
+  {
+    const char * temp = std::strstr(argv[i], pattern);
+    if(temp)
+    { //! OCLINT prefer early exits and continue
+      // eliminate matches in which the chars before the option are not '-'
+      bool noBadCharsFound = true;
+      const char * curr = argv[i];
+      while(curr != temp)
+      {
+        if(*curr++ != '-')
+        {
+          noBadCharsFound = false;
+          break;
         }
-        return false;
-    }
-
-    // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String& res,
-                     const String& defaultVal = String()) {
-        res = defaultVal;
-#ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        if(!parseOptionImpl(argc, argv, pattern, res))
-            return parseOptionImpl(argc, argv, pattern + 3, res); // 3 for "dt-"
-        return true;
-#else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        return parseOptionImpl(argc, argv, pattern, res);
-#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-    }
-
-    // parses a comma separated list of words after a pattern in one of the arguments in argv
-    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
-                           std::vector<String>& res) {
-        String filtersString;
-        if(parseOption(argc, argv, pattern, filtersString)) {
-            // tokenize with "," as a separator
-            // cppcheck-suppress strtokCalled
-            char* pch = std::strtok(filtersString.c_str(), ","); // modifies the string
-            while(pch != 0) {
-                if(my_strlen(pch))
-                    res.push_back(pch);
-                // uses the strtok() internal state to go to the next token
-                // cppcheck-suppress strtokCalled
-                pch = std::strtok(0, ",");
-            }
-            return true;
+      }
+      if(noBadCharsFound && argv[i][0] == '-')
+      {
+        temp += my_strlen(pattern);
+        const unsigned len = my_strlen(temp);
+        if(len)
+        {
+          res = temp;
+          return true;
         }
-        return false;
+      }
     }
+  }
+  return false;
+}
 
-    enum optionType
+// parses an option and returns the string after the '=' character
+bool parseOption(int argc,
+                 const char * const * argv,
+                 const char * pattern,
+                 String & res,
+                 const String & defaultVal = String())
+{
+  res = defaultVal;
+#    ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+  if(!parseOptionImpl(argc, argv, pattern, res))
+    return parseOptionImpl(argc, argv, pattern + 3, res); // 3 for "dt-"
+  return true;
+#    else // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+  return parseOptionImpl(argc, argv, pattern, res);
+#    endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+}
+
+// parses a comma separated list of words after a pattern in one of the arguments in argv
+bool parseCommaSepArgs(int argc, const char * const * argv, const char * pattern, std::vector<String> & res)
+{
+  String filtersString;
+  if(parseOption(argc, argv, pattern, filtersString))
+  {
+    // tokenize with "," as a separator
+    // cppcheck-suppress strtokCalled
+    char * pch = std::strtok(filtersString.c_str(), ","); // modifies the string
+    while(pch != 0)
     {
-        option_bool,
-        option_int
-    };
-
-    // parses an int/bool option from the command line
-    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
-                        int& res) {
-        String parsedValue;
-        if(!parseOption(argc, argv, pattern, parsedValue))
-            return false;
-
-        if(type == 0) {
-            // boolean
-            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
-            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
-
-            // if the value matches any of the positive/negative possibilities
-            for(unsigned i = 0; i < 4; i++) {
-                if(parsedValue.compare(positive[i], true) == 0) {
-                    res = 1; //!OCLINT parameter reassignment
-                    return true;
-                }
-                if(parsedValue.compare(negative[i], true) == 0) {
-                    res = 0; //!OCLINT parameter reassignment
-                    return true;
-                }
-            }
-        } else {
-            // integer
-            int theInt = std::atoi(parsedValue.c_str()); // NOLINT
-            if(theInt != 0) {
-                res = theInt; //!OCLINT parameter reassignment
-                return true;
-            }
-        }
-        return false;
+      if(my_strlen(pch))
+        res.push_back(pch);
+      // uses the strtok() internal state to go to the next token
+      // cppcheck-suppress strtokCalled
+      pch = std::strtok(0, ",");
     }
+    return true;
+  }
+  return false;
+}
 
-    void printVersion() {
-        if(contextState->no_version == false) {
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-            std::printf("doctest version is \"%s\"\n", DOCTEST_VERSION_STR);
-        }
+enum optionType
+{
+  option_bool,
+  option_int
+};
+
+// parses an int/bool option from the command line
+bool parseIntOption(int argc, const char * const * argv, const char * pattern, optionType type, int & res)
+{
+  String parsedValue;
+  if(!parseOption(argc, argv, pattern, parsedValue))
+    return false;
+
+  if(type == 0)
+  {
+    // boolean
+    const char positive[][5] = {"1", "true", "on", "yes"}; // 5 - strlen("true") + 1
+    const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
+
+    // if the value matches any of the positive/negative possibilities
+    for(unsigned i = 0; i < 4; i++)
+    {
+      if(parsedValue.compare(positive[i], true) == 0)
+      {
+        res = 1; //! OCLINT parameter reassignment
+        return true;
+      }
+      if(parsedValue.compare(negative[i], true) == 0)
+      {
+        res = 0; //! OCLINT parameter reassignment
+        return true;
+      }
     }
+  }
+  else
+  {
+    // integer
+    int theInt = std::atoi(parsedValue.c_str()); // NOLINT
+    if(theInt != 0)
+    {
+      res = theInt; //! OCLINT parameter reassignment
+      return true;
+    }
+  }
+  return false;
+}
 
-    void printHelp() {
-        printVersion();
-        // clang-format off
+void printVersion()
+{
+  if(contextState->no_version == false)
+  {
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("doctest version is \"%s\"\n", DOCTEST_VERSION_STR);
+  }
+}
+
+void printHelp()
+{
+  printVersion();
+  // clang-format off
         DOCTEST_PRINTF_COLORED("[doctest]\n", Color::Cyan);
         DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
         std::printf("boolean values: \"1/on/yes/true\" or \"0/off/no/false\"\n");
@@ -5205,104 +5526,100 @@ namespace detail
         std::printf(" -npf, --no-path-filenames=<bool>      only filenames and no paths in output\n");
         std::printf(" -nln, --no-line-numbers=<bool>        0 instead of real line numbers in output\n");
         // ========================================================================================= << 79
-        // clang-format on
+  // clang-format on
 
-        DOCTEST_PRINTF_COLORED("\n[doctest] ", Color::Cyan);
-        std::printf("for more information visit the project documentation\n\n");
+  DOCTEST_PRINTF_COLORED("\n[doctest] ", Color::Cyan);
+  std::printf("for more information visit the project documentation\n\n");
+}
+
+void printSummary()
+{
+  const ContextState * p = contextState;
+
+  DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+  if(p->count || p->list_test_cases)
+  {
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("unskipped test cases passing the current filters: %u\n", p->numTestsPassingFilters);
+  }
+  else if(p->list_test_suites)
+  {
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("unskipped test cases passing the current filters: %u\n", p->numTestsPassingFilters);
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("test suites with unskipped test cases passing the current filters: %u\n",
+                p->numTestSuitesPassingFilters);
+  }
+  else
+  {
+    const bool anythingFailed = p->numFailed > 0 || p->numFailedAssertions > 0;
+
+    char buff[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "test cases: %6u", p->numTestsPassingFilters);
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed", p->numTestsPassingFilters - p->numFailed);
+    DOCTEST_PRINTF_COLORED(buff, (p->numTestsPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6u failed", p->numFailed);
+    DOCTEST_PRINTF_COLORED(buff, p->numFailed > 0 ? Color::Red : Color::None);
+
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    if(p->no_skipped_summary == false)
+    {
+      const int numSkipped = static_cast<unsigned>(getRegisteredTests().size()) - p->numTestsPassingFilters;
+      DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d skipped", numSkipped);
+      DOCTEST_PRINTF_COLORED(buff, numSkipped == 0 ? Color::None : Color::Yellow);
     }
+    DOCTEST_PRINTF_COLORED("\n", Color::None);
 
-    void printSummary() {
-        const ContextState* p = contextState;
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
 
-        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-        if(p->count || p->list_test_cases) {
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-            std::printf("unskipped test cases passing the current filters: %u\n",
-                        p->numTestsPassingFilters);
-        } else if(p->list_test_suites) {
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-            std::printf("unskipped test cases passing the current filters: %u\n",
-                        p->numTestsPassingFilters);
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-            std::printf("test suites with unskipped test cases passing the current filters: %u\n",
-                        p->numTestSuitesPassingFilters);
-        } else {
-            const bool anythingFailed = p->numFailed > 0 || p->numFailedAssertions > 0;
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "assertions: %6d", p->numAssertions);
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed", p->numAssertions - p->numFailedAssertions);
+    DOCTEST_PRINTF_COLORED(buff, (p->numAssertions == 0 || anythingFailed) ? Color::None : Color::Green);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d failed", p->numFailedAssertions);
+    DOCTEST_PRINTF_COLORED(buff, p->numFailedAssertions > 0 ? Color::Red : Color::None);
 
-            char buff[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " |\n");
+    DOCTEST_PRINTF_COLORED(buff, Color::None);
 
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    DOCTEST_PRINTF_COLORED("Status: ", Color::None);
+    const char * result = (p->numFailed > 0) ? "FAILURE!\n" : "SUCCESS!\n";
+    DOCTEST_PRINTF_COLORED(result, p->numFailed > 0 ? Color::Red : Color::Green);
+  }
 
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "test cases: %6u",
-                             p->numTestsPassingFilters);
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed",
-                             p->numTestsPassingFilters - p->numFailed);
-            DOCTEST_PRINTF_COLORED(buff, (p->numTestsPassingFilters == 0 || anythingFailed) ?
-                                                 Color::None :
-                                                 Color::Green);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6u failed", p->numFailed);
-            DOCTEST_PRINTF_COLORED(buff, p->numFailed > 0 ? Color::Red : Color::None);
-
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            if(p->no_skipped_summary == false) {
-                const int numSkipped = static_cast<unsigned>(getRegisteredTests().size()) -
-                                       p->numTestsPassingFilters;
-                DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d skipped", numSkipped);
-                DOCTEST_PRINTF_COLORED(buff, numSkipped == 0 ? Color::None : Color::Yellow);
-            }
-            DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "assertions: %6d", p->numAssertions);
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed",
-                             p->numAssertions - p->numFailedAssertions);
-            DOCTEST_PRINTF_COLORED(buff, (p->numAssertions == 0 || anythingFailed) ? Color::None :
-                                                                                     Color::Green);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d failed", p->numFailedAssertions);
-            DOCTEST_PRINTF_COLORED(buff, p->numFailedAssertions > 0 ? Color::Red : Color::None);
-
-            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " |\n");
-            DOCTEST_PRINTF_COLORED(buff, Color::None);
-
-            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-            DOCTEST_PRINTF_COLORED("Status: ", Color::None);
-            const char* result = (p->numFailed > 0) ? "FAILURE!\n" : "SUCCESS!\n";
-            DOCTEST_PRINTF_COLORED(result, p->numFailed > 0 ? Color::Red : Color::Green);
-        }
-
-        // remove any coloring
-        DOCTEST_PRINTF_COLORED("", Color::None);
-    }
+  // remove any coloring
+  DOCTEST_PRINTF_COLORED("", Color::None);
+}
 } // namespace detail
 
 bool isRunningInTest() { return detail::contextState != 0; }
 
-Context::Context(int argc, const char* const* argv)
-        : p(new detail::ContextState) {
-    parseArgs(argc, argv, true);
-}
+Context::Context(int argc, const char * const * argv) : p(new detail::ContextState) { parseArgs(argc, argv, true); }
 
 Context::~Context() { delete p; }
 
-void Context::applyCommandLine(int argc, const char* const* argv) { parseArgs(argc, argv); }
+void Context::applyCommandLine(int argc, const char * const * argv) { parseArgs(argc, argv); }
 
 // parses args
-void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
-    using namespace detail;
+void Context::parseArgs(int argc, const char * const * argv, bool withDefaults)
+{
+  using namespace detail;
 
-    // clang-format off
+  // clang-format off
     parseCommaSepArgs(argc, argv, "dt-source-file=",        p->filters[0]);
     parseCommaSepArgs(argc, argv, "dt-sf=",                 p->filters[0]);
     parseCommaSepArgs(argc, argv, "dt-source-file-exclude=",p->filters[1]);
@@ -5319,34 +5636,33 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     parseCommaSepArgs(argc, argv, "dt-sc=",                 p->filters[6]);
     parseCommaSepArgs(argc, argv, "dt-subcase-exclude=",    p->filters[7]);
     parseCommaSepArgs(argc, argv, "dt-sce=",                p->filters[7]);
-    // clang-format on
+  // clang-format on
 
-    int    intRes = 0;
-    String strRes;
+  int intRes = 0;
+  String strRes;
 
-#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
-    if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_bool, intRes) ||       \
-       parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_bool, intRes))        \
-        p->var = !!intRes;                                                                         \
-    else if(parseFlag(argc, argv, #name) || parseFlag(argc, argv, #sname))                         \
-        p->var = true;                                                                             \
-    else if(withDefaults)                                                                          \
-    p->var = default
+#    define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                             \
+      if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_bool, intRes)      \
+         || parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_bool, intRes)) \
+        p->var = !!intRes;                                                                       \
+      else if(parseFlag(argc, argv, #name) || parseFlag(argc, argv, #sname))                     \
+        p->var = true;                                                                           \
+      else if(withDefaults)                                                                      \
+      p->var = default
 
-#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
-    if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_int, intRes) ||        \
-       parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_int, intRes))         \
-        p->var = intRes;                                                                           \
-    else if(withDefaults)                                                                          \
-    p->var = default
+#    define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                 \
+      if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_int, intRes)      \
+         || parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_int, intRes)) \
+        p->var = intRes;                                                                        \
+      else if(withDefaults)                                                                     \
+      p->var = default
 
-#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
-    if(parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), strRes, default) ||              \
-       parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), strRes, default) ||             \
-       withDefaults)                                                                               \
-    p->var = strRes
+#    define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                           \
+      if(parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), strRes, default)                      \
+         || parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), strRes, default) || withDefaults) \
+      p->var = strRes
 
-    // clang-format off
+  // clang-format off
     DOCTEST_PARSE_STR_OPTION(dt-order-by, dt-ob, order_by, "file");
     DOCTEST_PARSE_INT_OPTION(dt-rand-seed, dt-rs, rand_seed, 0);
 
@@ -5371,327 +5687,361 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG(dt-no-path-filenames, dt-npf, no_path_in_filenames, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG(dt-no-line-numbers, dt-nln, no_line_numbers, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG(dt-no-skipped-summary, dt-nss, no_skipped_summary, false);
-    // clang-format on
+  // clang-format on
 
-#undef DOCTEST_PARSE_STR_OPTION
-#undef DOCTEST_PARSE_INT_OPTION
-#undef DOCTEST_PARSE_AS_BOOL_OR_FLAG
+#    undef DOCTEST_PARSE_STR_OPTION
+#    undef DOCTEST_PARSE_INT_OPTION
+#    undef DOCTEST_PARSE_AS_BOOL_OR_FLAG
 
-    if(withDefaults) {
-        p->help             = false;
-        p->version          = false;
-        p->count            = false;
-        p->list_test_cases  = false;
-        p->list_test_suites = false;
-    }
-    if(parseFlag(argc, argv, "dt-help") || parseFlag(argc, argv, "dt-h") ||
-       parseFlag(argc, argv, "dt-?")) {
-        p->help = true;
-        p->exit = true;
-    }
-    if(parseFlag(argc, argv, "dt-version") || parseFlag(argc, argv, "dt-v")) {
-        p->version = true;
-        p->exit    = true;
-    }
-    if(parseFlag(argc, argv, "dt-count") || parseFlag(argc, argv, "dt-c")) {
-        p->count = true;
-        p->exit  = true;
-    }
-    if(parseFlag(argc, argv, "dt-list-test-cases") || parseFlag(argc, argv, "dt-ltc")) {
-        p->list_test_cases = true;
-        p->exit            = true;
-    }
-    if(parseFlag(argc, argv, "dt-list-test-suites") || parseFlag(argc, argv, "dt-lts")) {
-        p->list_test_suites = true;
-        p->exit             = true;
-    }
+  if(withDefaults)
+  {
+    p->help = false;
+    p->version = false;
+    p->count = false;
+    p->list_test_cases = false;
+    p->list_test_suites = false;
+  }
+  if(parseFlag(argc, argv, "dt-help") || parseFlag(argc, argv, "dt-h") || parseFlag(argc, argv, "dt-?"))
+  {
+    p->help = true;
+    p->exit = true;
+  }
+  if(parseFlag(argc, argv, "dt-version") || parseFlag(argc, argv, "dt-v"))
+  {
+    p->version = true;
+    p->exit = true;
+  }
+  if(parseFlag(argc, argv, "dt-count") || parseFlag(argc, argv, "dt-c"))
+  {
+    p->count = true;
+    p->exit = true;
+  }
+  if(parseFlag(argc, argv, "dt-list-test-cases") || parseFlag(argc, argv, "dt-ltc"))
+  {
+    p->list_test_cases = true;
+    p->exit = true;
+  }
+  if(parseFlag(argc, argv, "dt-list-test-suites") || parseFlag(argc, argv, "dt-lts"))
+  {
+    p->list_test_suites = true;
+    p->exit = true;
+  }
 }
 
 // allows the user to add procedurally to the filters from the command line
-void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
+void Context::addFilter(const char * filter, const char * value) { setOption(filter, value); }
 
 // allows the user to clear all filters from the command line
-void Context::clearFilters() {
-    for(unsigned i = 0; i < p->filters.size(); ++i)
-        p->filters[i].clear();
+void Context::clearFilters()
+{
+  for(unsigned i = 0; i < p->filters.size(); ++i)
+    p->filters[i].clear();
 }
 
 // allows the user to override procedurally the int/bool options from the command line
-void Context::setOption(const char* option, int value) {
-    setOption(option, toString(value).c_str());
-}
+void Context::setOption(const char * option, int value) { setOption(option, toString(value).c_str()); }
 
 // allows the user to override procedurally the string options from the command line
-void Context::setOption(const char* option, const char* value) {
-    String      argv   = String("-") + option + "=" + value;
-    const char* lvalue = argv.c_str();
-    parseArgs(1, &lvalue);
+void Context::setOption(const char * option, const char * value)
+{
+  String argv = String("-") + option + "=" + value;
+  const char * lvalue = argv.c_str();
+  parseArgs(1, &lvalue);
 }
 
 // users should query this in their main() and exit the program if true
 bool Context::shouldExit() { return p->exit; }
 
 // the main function that does all the filtering and test running
-int Context::run() {
-    using namespace detail;
+int Context::run()
+{
+  using namespace detail;
 
-    Color::init();
+  Color::init();
 
-    contextState = p;
-    p->resetRunData();
+  contextState = p;
+  p->resetRunData();
 
-    // handle version, help and no_run
-    if(p->no_run || p->version || p->help) {
-        if(p->version)
-            printVersion();
-        if(p->help)
-            printHelp();
-
-        contextState = 0;
-
-        return EXIT_SUCCESS;
-    }
-
-    printVersion();
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("run with \"--help\" for options\n");
-
-    unsigned i = 0; // counter used for loops - here for VC6
-
-    std::set<TestCase>& registeredTests = getRegisteredTests();
-
-    std::vector<const TestCase*> testArray;
-    for(std::set<TestCase>::iterator it = registeredTests.begin(); it != registeredTests.end();
-        ++it)
-        testArray.push_back(&(*it));
-
-    // sort the collected records
-    if(!testArray.empty()) {
-        if(p->order_by.compare("file", true) == 0) {
-            std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), fileOrderComparator);
-        } else if(p->order_by.compare("suite", true) == 0) {
-            std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), suiteOrderComparator);
-        } else if(p->order_by.compare("name", true) == 0) {
-            std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), nameOrderComparator);
-        } else if(p->order_by.compare("rand", true) == 0) {
-            std::srand(p->rand_seed);
-
-            // random_shuffle implementation
-            const TestCase** first = &testArray[0];
-            for(i = testArray.size() - 1; i > 0; --i) {
-                int idxToSwap = std::rand() % (i + 1); // NOLINT
-
-                const TestCase* temp = first[i];
-
-                first[i]         = first[idxToSwap];
-                first[idxToSwap] = temp;
-            }
-        }
-    }
-
-    if(p->list_test_cases) {
-        DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-        std::printf("listing all test case names\n");
-        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-    }
-
-    std::set<String> testSuitesPassingFilters;
-    if(p->list_test_suites) {
-        DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-        std::printf("listing all test suites\n");
-        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-    }
-
-    // invoke the registered functions if they match the filter criteria (or just count them)
-    for(i = 0; i < testArray.size(); i++) {
-        const TestCase& data = *testArray[i];
-
-        if(data.m_skip && !p->no_skip)
-            continue;
-
-        if(!matchesAny(data.m_file, p->filters[0], 1, p->case_sensitive))
-            continue;
-        if(matchesAny(data.m_file, p->filters[1], 0, p->case_sensitive))
-            continue;
-        if(!matchesAny(data.m_test_suite, p->filters[2], 1, p->case_sensitive))
-            continue;
-        if(matchesAny(data.m_test_suite, p->filters[3], 0, p->case_sensitive))
-            continue;
-        if(!matchesAny(data.m_name, p->filters[4], 1, p->case_sensitive))
-            continue;
-        if(matchesAny(data.m_name, p->filters[5], 0, p->case_sensitive))
-            continue;
-
-        p->numTestsPassingFilters++;
-
-        // do not execute the test if we are to only count the number of filter passing tests
-        if(p->count)
-            continue;
-
-        // print the name of the test and don't execute it
-        if(p->list_test_cases) {
-            std::printf("%s\n", data.m_name);
-            continue;
-        }
-
-        // print the name of the test suite if not done already and don't execute it
-        if(p->list_test_suites) {
-            if((testSuitesPassingFilters.count(data.m_test_suite) == 0) &&
-               data.m_test_suite[0] != '\0') {
-                std::printf("%s\n", data.m_test_suite);
-                testSuitesPassingFilters.insert(data.m_test_suite);
-                p->numTestSuitesPassingFilters++;
-            }
-            continue;
-        }
-
-        // skip the test if it is not in the execution range
-        if((p->last < p->numTestsPassingFilters && p->first <= p->last) ||
-           (p->first > p->numTestsPassingFilters))
-            continue;
-
-        // execute the test if it passes all the filtering
-        {
-            p->currentTest = &data;
-
-            bool failed                              = false;
-            p->hasLoggedCurrentTestStart             = false;
-            p->numFailedAssertionsForCurrentTestcase = 0;
-            p->subcasesPassed.clear();
-            double duration = 0;
-            Timer  timer;
-            timer.start();
-            do {
-                // if the start has been logged from a previous iteration of this loop
-                if(p->hasLoggedCurrentTestStart)
-                    logTestEnd();
-                p->hasLoggedCurrentTestStart = false;
-
-                // if logging successful tests - force the start log
-                if(p->success)
-                    DOCTEST_LOG_START();
-
-                // reset the assertion state
-                p->numAssertionsForCurrentTestcase = 0;
-                p->hasCurrentTestFailed            = false;
-
-                // reset some of the fields for subcases (except for the set of fully passed ones)
-                p->subcasesHasSkipped   = false;
-                p->subcasesCurrentLevel = 0;
-                p->subcasesEnteredLevels.clear();
-
-                // reset stuff for logging with INFO()
-                p->exceptionalContexts.clear();
-
-// execute the test
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                try {
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-                    FatalConditionHandler fatalConditionHandler; // Handle signals
-                    data.m_test();
-                    fatalConditionHandler.reset();
-                    if(contextState->hasCurrentTestFailed)
-                        failed = true;
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                } catch(const TestFailureException&) { failed = true; } catch(...) {
-                    DOCTEST_LOG_START();
-                    logTestException(translateActiveException());
-                    failed = true;
-                }
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-                p->numAssertions += p->numAssertionsForCurrentTestcase;
-
-                // exit this loop if enough assertions have failed
-                if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after) {
-                    p->subcasesHasSkipped = false;
-                    DOCTEST_PRINTF_COLORED("Aborting - too many failed asserts!\n", Color::Red);
-                }
-
-            } while(p->subcasesHasSkipped == true);
-
-            duration = timer.getElapsedSeconds();
-
-            if(Approx(p->currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
-               Approx(duration).epsilon(DBL_EPSILON) > p->currentTest->m_timeout) {
-                failed = true;
-                DOCTEST_LOG_START();
-                char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-                DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg),
-                                 "Test case exceeded time limit of %.6f!\n",
-                                 p->currentTest->m_timeout);
-                DOCTEST_PRINTF_COLORED(msg, Color::Red);
-            }
-
-            if(p->duration) {
-                char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-                DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "%.6f s: %s\n", duration,
-                                 p->currentTest->m_name);
-                DOCTEST_PRINTF_COLORED(msg, Color::None);
-            }
-
-            if(data.m_should_fail) {
-                DOCTEST_LOG_START();
-                if(failed) {
-                    failed = false;
-                    DOCTEST_PRINTF_COLORED("Failed as expected so marking it as not failed\n",
-                                           Color::Yellow);
-                } else {
-                    failed = true;
-                    DOCTEST_PRINTF_COLORED("Should have failed but didn't! Marking it as failed!\n",
-                                           Color::Red);
-                }
-            } else if(failed && data.m_may_fail) {
-                DOCTEST_LOG_START();
-                failed = false;
-                DOCTEST_PRINTF_COLORED("Allowed to fail so marking it as not failed\n",
-                                       Color::Yellow);
-            } else if(data.m_expected_failures > 0) {
-                DOCTEST_LOG_START();
-                char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-                if(p->numFailedAssertionsForCurrentTestcase == data.m_expected_failures) {
-                    failed = false;
-                    DOCTEST_SNPRINTF(
-                            msg, DOCTEST_COUNTOF(msg),
-                            "Failed exactly %d times as expected so marking it as not failed!\n",
-                            data.m_expected_failures);
-                    DOCTEST_PRINTF_COLORED(msg, Color::Yellow);
-                } else {
-                    failed = true;
-                    DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg),
-                                     "Didn't fail exactly %d times so marking it as failed!\n",
-                                     data.m_expected_failures);
-                    DOCTEST_PRINTF_COLORED(msg, Color::Red);
-                }
-            }
-
-            if(p->hasLoggedCurrentTestStart)
-                logTestEnd();
-
-            if(failed) // if any subcase has failed - the whole test case has failed
-                p->numFailed++;
-
-            // stop executing tests if enough assertions have failed
-            if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after)
-                break;
-        }
-    }
-
-    printSummary();
+  // handle version, help and no_run
+  if(p->no_run || p->version || p->help)
+  {
+    if(p->version)
+      printVersion();
+    if(p->help)
+      printHelp();
 
     contextState = 0;
 
-    if(p->numFailed && !p->no_exitcode)
-        return EXIT_FAILURE;
     return EXIT_SUCCESS;
+  }
+
+  printVersion();
+  DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+  std::printf("run with \"--help\" for options\n");
+
+  unsigned i = 0; // counter used for loops - here for VC6
+
+  std::set<TestCase> & registeredTests = getRegisteredTests();
+
+  std::vector<const TestCase *> testArray;
+  for(std::set<TestCase>::iterator it = registeredTests.begin(); it != registeredTests.end(); ++it)
+    testArray.push_back(&(*it));
+
+  // sort the collected records
+  if(!testArray.empty())
+  {
+    if(p->order_by.compare("file", true) == 0)
+    {
+      std::qsort(&testArray[0], testArray.size(), sizeof(TestCase *), fileOrderComparator);
+    }
+    else if(p->order_by.compare("suite", true) == 0)
+    {
+      std::qsort(&testArray[0], testArray.size(), sizeof(TestCase *), suiteOrderComparator);
+    }
+    else if(p->order_by.compare("name", true) == 0)
+    {
+      std::qsort(&testArray[0], testArray.size(), sizeof(TestCase *), nameOrderComparator);
+    }
+    else if(p->order_by.compare("rand", true) == 0)
+    {
+      std::srand(p->rand_seed);
+
+      // random_shuffle implementation
+      const TestCase ** first = &testArray[0];
+      for(i = testArray.size() - 1; i > 0; --i)
+      {
+        int idxToSwap = std::rand() % (i + 1); // NOLINT
+
+        const TestCase * temp = first[i];
+
+        first[i] = first[idxToSwap];
+        first[idxToSwap] = temp;
+      }
+    }
+  }
+
+  if(p->list_test_cases)
+  {
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("listing all test case names\n");
+    DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+  }
+
+  std::set<String> testSuitesPassingFilters;
+  if(p->list_test_suites)
+  {
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("listing all test suites\n");
+    DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+  }
+
+  // invoke the registered functions if they match the filter criteria (or just count them)
+  for(i = 0; i < testArray.size(); i++)
+  {
+    const TestCase & data = *testArray[i];
+
+    if(data.m_skip && !p->no_skip)
+      continue;
+
+    if(!matchesAny(data.m_file, p->filters[0], 1, p->case_sensitive))
+      continue;
+    if(matchesAny(data.m_file, p->filters[1], 0, p->case_sensitive))
+      continue;
+    if(!matchesAny(data.m_test_suite, p->filters[2], 1, p->case_sensitive))
+      continue;
+    if(matchesAny(data.m_test_suite, p->filters[3], 0, p->case_sensitive))
+      continue;
+    if(!matchesAny(data.m_name, p->filters[4], 1, p->case_sensitive))
+      continue;
+    if(matchesAny(data.m_name, p->filters[5], 0, p->case_sensitive))
+      continue;
+
+    p->numTestsPassingFilters++;
+
+    // do not execute the test if we are to only count the number of filter passing tests
+    if(p->count)
+      continue;
+
+    // print the name of the test and don't execute it
+    if(p->list_test_cases)
+    {
+      std::printf("%s\n", data.m_name);
+      continue;
+    }
+
+    // print the name of the test suite if not done already and don't execute it
+    if(p->list_test_suites)
+    {
+      if((testSuitesPassingFilters.count(data.m_test_suite) == 0) && data.m_test_suite[0] != '\0')
+      {
+        std::printf("%s\n", data.m_test_suite);
+        testSuitesPassingFilters.insert(data.m_test_suite);
+        p->numTestSuitesPassingFilters++;
+      }
+      continue;
+    }
+
+    // skip the test if it is not in the execution range
+    if((p->last < p->numTestsPassingFilters && p->first <= p->last) || (p->first > p->numTestsPassingFilters))
+      continue;
+
+    // execute the test if it passes all the filtering
+    {
+      p->currentTest = &data;
+
+      bool failed = false;
+      p->hasLoggedCurrentTestStart = false;
+      p->numFailedAssertionsForCurrentTestcase = 0;
+      p->subcasesPassed.clear();
+      double duration = 0;
+      Timer timer;
+      timer.start();
+      do
+      {
+        // if the start has been logged from a previous iteration of this loop
+        if(p->hasLoggedCurrentTestStart)
+          logTestEnd();
+        p->hasLoggedCurrentTestStart = false;
+
+        // if logging successful tests - force the start log
+        if(p->success)
+          DOCTEST_LOG_START();
+
+        // reset the assertion state
+        p->numAssertionsForCurrentTestcase = 0;
+        p->hasCurrentTestFailed = false;
+
+        // reset some of the fields for subcases (except for the set of fully passed ones)
+        p->subcasesHasSkipped = false;
+        p->subcasesCurrentLevel = 0;
+        p->subcasesEnteredLevels.clear();
+
+        // reset stuff for logging with INFO()
+        p->exceptionalContexts.clear();
+
+// execute the test
+#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        try
+        {
+#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+          FatalConditionHandler fatalConditionHandler; // Handle signals
+          data.m_test();
+          fatalConditionHandler.reset();
+          if(contextState->hasCurrentTestFailed)
+            failed = true;
+#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        }
+        catch(const TestFailureException &)
+        {
+          failed = true;
+        }
+        catch(...)
+        {
+          DOCTEST_LOG_START();
+          logTestException(translateActiveException());
+          failed = true;
+        }
+#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+        p->numAssertions += p->numAssertionsForCurrentTestcase;
+
+        // exit this loop if enough assertions have failed
+        if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after)
+        {
+          p->subcasesHasSkipped = false;
+          DOCTEST_PRINTF_COLORED("Aborting - too many failed asserts!\n", Color::Red);
+        }
+
+      } while(p->subcasesHasSkipped == true);
+
+      duration = timer.getElapsedSeconds();
+
+      if(Approx(p->currentTest->m_timeout).epsilon(DBL_EPSILON) != 0
+         && Approx(duration).epsilon(DBL_EPSILON) > p->currentTest->m_timeout)
+      {
+        failed = true;
+        DOCTEST_LOG_START();
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "Test case exceeded time limit of %.6f!\n",
+                         p->currentTest->m_timeout);
+        DOCTEST_PRINTF_COLORED(msg, Color::Red);
+      }
+
+      if(p->duration)
+      {
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "%.6f s: %s\n", duration, p->currentTest->m_name);
+        DOCTEST_PRINTF_COLORED(msg, Color::None);
+      }
+
+      if(data.m_should_fail)
+      {
+        DOCTEST_LOG_START();
+        if(failed)
+        {
+          failed = false;
+          DOCTEST_PRINTF_COLORED("Failed as expected so marking it as not failed\n", Color::Yellow);
+        }
+        else
+        {
+          failed = true;
+          DOCTEST_PRINTF_COLORED("Should have failed but didn't! Marking it as failed!\n", Color::Red);
+        }
+      }
+      else if(failed && data.m_may_fail)
+      {
+        DOCTEST_LOG_START();
+        failed = false;
+        DOCTEST_PRINTF_COLORED("Allowed to fail so marking it as not failed\n", Color::Yellow);
+      }
+      else if(data.m_expected_failures > 0)
+      {
+        DOCTEST_LOG_START();
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        if(p->numFailedAssertionsForCurrentTestcase == data.m_expected_failures)
+        {
+          failed = false;
+          DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg),
+                           "Failed exactly %d times as expected so marking it as not failed!\n",
+                           data.m_expected_failures);
+          DOCTEST_PRINTF_COLORED(msg, Color::Yellow);
+        }
+        else
+        {
+          failed = true;
+          DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "Didn't fail exactly %d times so marking it as failed!\n",
+                           data.m_expected_failures);
+          DOCTEST_PRINTF_COLORED(msg, Color::Red);
+        }
+      }
+
+      if(p->hasLoggedCurrentTestStart)
+        logTestEnd();
+
+      if(failed) // if any subcase has failed - the whole test case has failed
+        p->numFailed++;
+
+      // stop executing tests if enough assertions have failed
+      if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after)
+        break;
+    }
+  }
+
+  printSummary();
+
+  contextState = 0;
+
+  if(p->numFailed && !p->no_exitcode)
+    return EXIT_FAILURE;
+  return EXIT_SUCCESS;
 }
 } // namespace doctest
 
-#endif // DOCTEST_CONFIG_DISABLE
+#  endif // DOCTEST_CONFIG_DISABLE
 
-#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
-#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#  ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+int main(int argc, char ** argv) { return doctest::Context(argc, argv).run(); }
+#  endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP

--- a/tests/doctest/doctest.h
+++ b/tests/doctest/doctest.h
@@ -56,7 +56,8 @@
 #define DOCTEST_VERSION_PATCH 6
 #define DOCTEST_VERSION_STR "1.2.6"
 
-#define DOCTEST_VERSION (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
+#define DOCTEST_VERSION                                                                            \
+    (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
 
 // =================================================================================================
 // == COMPILER VERSION =============================================================================
@@ -67,25 +68,26 @@
 #define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
 
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)
-#  if _MSC_VER == _MSC_FULL_VER / 10000
-#    define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
-#  else
-#    define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
-#  endif
+#if _MSC_VER == _MSC_FULL_VER / 10000
+#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
+#else
+#define DOCTEST_MSVC                                                                               \
+    DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
+#endif
 #elif defined(__clang__) && defined(__clang_minor__)
-#  define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#  define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #endif
 
 #ifndef DOCTEST_MSVC
-#  define DOCTEST_MSVC 0
+#define DOCTEST_MSVC 0
 #endif // DOCTEST_MSVC
 #ifndef DOCTEST_CLANG
-#  define DOCTEST_CLANG 0
+#define DOCTEST_CLANG 0
 #endif // DOCTEST_CLANG
 #ifndef DOCTEST_GCC
-#  define DOCTEST_GCC 0
+#define DOCTEST_GCC 0
 #endif // DOCTEST_GCC
 
 // =================================================================================================
@@ -93,70 +95,72 @@
 // =================================================================================================
 
 #if DOCTEST_CLANG
-#  ifdef __has_warning
-#    define DOCTEST_CLANG_HAS_WARNING(x) __has_warning(x)
-#  endif // __has_warning
-#  ifdef __has_feature
-#    define DOCTEST_CLANG_HAS_FEATURE(x) __has_feature(x)
-#  endif // __has_feature
-#  define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#  x)
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-#  define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-#  define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
-#  define DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#  define DOCTEST_GCC_SUPPRESS_WARNING(w)
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#  define DOCTEST_GCC_SUPPRESS_WARNING_POP
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w) \
+#ifdef __has_warning
+#define DOCTEST_CLANG_HAS_WARNING(x) __has_warning(x)
+#endif // __has_warning
+#ifdef __has_feature
+#define DOCTEST_CLANG_HAS_FEATURE(x) __has_feature(x)
+#endif // __has_feature
+#define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
+#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING(w)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
+#define DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
-#  define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
 #elif DOCTEST_GCC
-#  define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#  x)
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
-#    define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
-#  else // GCC 4.7+
-#    define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-#  endif // GCC 4.7+
-#  define DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#  define DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#  define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_POP
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
-#    define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
-#  else // GCC 4.7+
-#    define DOCTEST_GCC_SUPPRESS_WARNING_POP
-#  endif // GCC 4.7+
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
-#  define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
+#define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
+#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
+#else // GCC 4.7+
+#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#endif // GCC 4.7+
+#define DOCTEST_CLANG_SUPPRESS_WARNING(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
+#define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
+#else // GCC 4.7+
+#define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#endif // GCC 4.7+
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
 #elif DOCTEST_MSVC
-#  define DOCTEST_PRAGMA_TO_STR(x)
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
-#  define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-#  define DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#  define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
-#  define DOCTEST_GCC_SUPPRESS_WARNING(w)
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_POP
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
-#  define DOCTEST_GCC_SUPPRESS_WARNING_POP
-#  define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
-#  define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#  define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
+#define DOCTEST_PRAGMA_TO_STR(x)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+#define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
+#define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+#define DOCTEST_CLANG_SUPPRESS_WARNING(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
+#define DOCTEST_GCC_SUPPRESS_WARNING(w)
+#define DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
+#define DOCTEST_GCC_SUPPRESS_WARNING_POP
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
 #endif // different compilers - warning suppression macros
 
 #ifndef DOCTEST_CLANG_HAS_WARNING
-#  define DOCTEST_CLANG_HAS_WARNING(x) 1
+#define DOCTEST_CLANG_HAS_WARNING(x) 1
 #endif // DOCTEST_CLANG_HAS_WARNING
 
 #ifndef DOCTEST_CLANG_HAS_FEATURE
-#  define DOCTEST_CLANG_HAS_FEATURE(x) 0
+#define DOCTEST_CLANG_HAS_FEATURE(x) 0
 #endif // DOCTEST_CLANG_HAS_FEATURE
 
 // =================================================================================================
@@ -225,20 +229,20 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 // - C4710 # function not inlined
 // - C4711 # function 'x' selected for automatic inline expansion
 
-#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN \
-  DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                               \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4548)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4986)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4350)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4668)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4365)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4774)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4820)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4625)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4626)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(5027)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(5026)                              \
-  DOCTEST_MSVC_SUPPRESS_WARNING(4623)
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026)                                                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623)
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -247,25 +251,25 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 // =================================================================================================
 
 #if __cplusplus >= 201103L
-#  ifndef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#  endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#  ifndef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#  endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#  ifndef DOCTEST_CONFIG_WITH_NULLPTR
-#    define DOCTEST_CONFIG_WITH_NULLPTR
-#  endif // DOCTEST_CONFIG_WITH_NULLPTR
-#  ifndef DOCTEST_CONFIG_WITH_LONG_LONG
-#    define DOCTEST_CONFIG_WITH_LONG_LONG
-#  endif // DOCTEST_CONFIG_WITH_LONG_LONG
-#  ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#endif   // __cplusplus >= 201103L
+#ifndef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#ifndef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#ifndef DOCTEST_CONFIG_WITH_NULLPTR
+#define DOCTEST_CONFIG_WITH_NULLPTR
+#endif // DOCTEST_CONFIG_WITH_NULLPTR
+#ifndef DOCTEST_CONFIG_WITH_LONG_LONG
+#define DOCTEST_CONFIG_WITH_LONG_LONG
+#endif // DOCTEST_CONFIG_WITH_LONG_LONG
+#ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif // __cplusplus >= 201103L
 
 // MSVC C++11 feature support table: https://msdn.microsoft.com/en-us/library/hh567368.aspx
 // GCC C++11 feature support table: https://gcc.gnu.org/projects/cxx-status.html
@@ -281,111 +285,113 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 // deleted functions
 
 #ifndef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#  if DOCTEST_MSVC >= DOCTEST_COMPILER(18, 0, 0)
-#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#  endif // MSVC
-#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_deleted_functions)
-#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#  endif // clang
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
-#  endif // GCC
-#endif   // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(18, 0, 0)
+#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#endif // MSVC
+#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_deleted_functions)
+#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#endif // clang
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#endif // GCC
+#endif // DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
 
 #if defined(DOCTEST_CONFIG_NO_DELETED_FUNCTIONS) && defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS)
-#  undef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
+#undef DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS
 #endif // DOCTEST_CONFIG_NO_DELETED_FUNCTIONS
 
 // rvalue references
 
 #ifndef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
-#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#  endif // MSVC
-#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_rvalue_references)
-#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#  endif // clang
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-#  endif // GCC
-#endif   // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
+#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#endif // MSVC
+#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_rvalue_references)
+#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#endif // clang
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#endif // GCC
+#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 
 #if defined(DOCTEST_CONFIG_NO_RVALUE_REFERENCES) && defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES)
-#  undef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+#undef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 #endif // DOCTEST_CONFIG_NO_RVALUE_REFERENCES
 
 // nullptr
 
 #ifndef DOCTEST_CONFIG_WITH_NULLPTR
-#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_nullptr)
-#    define DOCTEST_CONFIG_WITH_NULLPTR
-#  endif // clang
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define DOCTEST_CONFIG_WITH_NULLPTR
-#  endif // GCC
-#  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
-#    define DOCTEST_CONFIG_WITH_NULLPTR
-#  endif // MSVC
-#endif   // DOCTEST_CONFIG_WITH_NULLPTR
+#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_nullptr)
+#define DOCTEST_CONFIG_WITH_NULLPTR
+#endif // clang
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define DOCTEST_CONFIG_WITH_NULLPTR
+#endif // GCC
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
+#define DOCTEST_CONFIG_WITH_NULLPTR
+#endif // MSVC
+#endif // DOCTEST_CONFIG_WITH_NULLPTR
 
 #if defined(DOCTEST_CONFIG_NO_NULLPTR) && defined(DOCTEST_CONFIG_WITH_NULLPTR)
-#  undef DOCTEST_CONFIG_WITH_NULLPTR
+#undef DOCTEST_CONFIG_WITH_NULLPTR
 #endif // DOCTEST_CONFIG_NO_NULLPTR
 
 // variadic macros
 
 #ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0) && !defined(__EDGE__)
-#    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  endif // MSVC
-#  if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 1, 0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  endif // GCC and clang
-#endif   // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0) && !defined(__EDGE__)
+#define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif // MSVC
+#if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 1, 0)) &&                                  \
+        defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif // GCC and clang
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 #if defined(DOCTEST_CONFIG_NO_VARIADIC_MACROS) && defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS)
-#  undef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#undef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #endif // DOCTEST_CONFIG_NO_VARIADIC_MACROS
 
 // long long
 
 #ifndef DOCTEST_CONFIG_WITH_LONG_LONG
-#  if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0)
-#    define DOCTEST_CONFIG_WITH_LONG_LONG
-#  endif // MSVC
-#  if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define DOCTEST_CONFIG_WITH_LONG_LONG
-#  endif // GCC and clang
-#endif   // DOCTEST_CONFIG_WITH_LONG_LONG
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(14, 0, 0)
+#define DOCTEST_CONFIG_WITH_LONG_LONG
+#endif // MSVC
+#if(DOCTEST_CLANG || DOCTEST_GCC >= DOCTEST_COMPILER(4, 5, 0)) &&                                  \
+        defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define DOCTEST_CONFIG_WITH_LONG_LONG
+#endif // GCC and clang
+#endif // DOCTEST_CONFIG_WITH_LONG_LONG
 
 #if defined(DOCTEST_CONFIG_NO_LONG_LONG) && defined(DOCTEST_CONFIG_WITH_LONG_LONG)
-#  undef DOCTEST_CONFIG_WITH_LONG_LONG
+#undef DOCTEST_CONFIG_WITH_LONG_LONG
 #endif // DOCTEST_CONFIG_NO_LONG_LONG
 
 // static_assert
 
 #ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_static_assert)
-#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  endif // clang
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  endif // GCC
-#  if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
-#    define DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  endif // MSVC
-#endif   // DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_FEATURE(cxx_static_assert)
+#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#endif // clang
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 3, 0) && defined(__GXX_EXPERIMENTAL_CXX0X__)
+#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#endif // GCC
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(16, 0, 0)
+#define DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#endif // MSVC
+#endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
 #if defined(DOCTEST_CONFIG_NO_STATIC_ASSERT) && defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
-#  undef DOCTEST_CONFIG_WITH_STATIC_ASSERT
+#undef DOCTEST_CONFIG_WITH_STATIC_ASSERT
 #endif // DOCTEST_CONFIG_NO_STATIC_ASSERT
 
 // other stuff...
 
-#if defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES) || defined(DOCTEST_CONFIG_WITH_LONG_LONG)  \
-    || defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS) || defined(DOCTEST_CONFIG_WITH_NULLPTR) \
-    || defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS) || defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
-#  define DOCTEST_NO_CPP11_COMPAT
+#if defined(DOCTEST_CONFIG_WITH_RVALUE_REFERENCES) || defined(DOCTEST_CONFIG_WITH_LONG_LONG) ||    \
+        defined(DOCTEST_CONFIG_WITH_DELETED_FUNCTIONS) || defined(DOCTEST_CONFIG_WITH_NULLPTR) ||  \
+        defined(DOCTEST_CONFIG_WITH_VARIADIC_MACROS) || defined(DOCTEST_CONFIG_WITH_STATIC_ASSERT)
+#define DOCTEST_NO_CPP11_COMPAT
 #endif // c++11 stuff
 
 #if defined(DOCTEST_NO_CPP11_COMPAT)
@@ -394,74 +400,74 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #endif // DOCTEST_NO_CPP11_COMPAT
 
 #if DOCTEST_MSVC && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-#  define DOCTEST_CONFIG_WINDOWS_SEH
+#define DOCTEST_CONFIG_WINDOWS_SEH
 #endif // MSVC
 #if defined(DOCTEST_CONFIG_NO_WINDOWS_SEH) && defined(DOCTEST_CONFIG_WINDOWS_SEH)
-#  undef DOCTEST_CONFIG_WINDOWS_SEH
+#undef DOCTEST_CONFIG_WINDOWS_SEH
 #endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
 #if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS)
-#  define DOCTEST_CONFIG_POSIX_SIGNALS
+#define DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
-#  undef DOCTEST_CONFIG_POSIX_SIGNALS
+#undef DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#  if(DOCTEST_GCC || DOCTEST_CLANG) && !defined(__EXCEPTIONS)
-#    define DOCTEST_CONFIG_NO_EXCEPTIONS
-#  endif // clang and gcc
+#if(DOCTEST_GCC || DOCTEST_CLANG) && !defined(__EXCEPTIONS)
+#define DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // clang and gcc
 // in MSVC _HAS_EXCEPTIONS is defined in a header instead of as a project define
 // so we can't do the automatic detection for MSVC without including some header
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#  ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#    define DOCTEST_CONFIG_NO_EXCEPTIONS
-#  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif   // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+#define DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
 #if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
-#  define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
-#  define DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_CONFIG_IMPLEMENT
 #endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #if defined _WIN32 || defined __CYGWIN__
-#  if DOCTEST_MSVC
-#    define DOCTEST_SYMBOL_EXPORT __declspec(dllexport)
-#    define DOCTEST_SYMBOL_IMPORT __declspec(dllimport)
-#  else // MSVC
-#    define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
-#    define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
-#  endif // MSVC
-#else    // _WIN32
-#  define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
-#  define DOCTEST_SYMBOL_IMPORT
+#if DOCTEST_MSVC
+#define DOCTEST_SYMBOL_EXPORT __declspec(dllexport)
+#define DOCTEST_SYMBOL_IMPORT __declspec(dllimport)
+#else // MSVC
+#define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
+#define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
+#endif // MSVC
+#else  // _WIN32
+#define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
+#define DOCTEST_SYMBOL_IMPORT
 #endif // _WIN32
 
 #ifdef DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
-#  ifdef DOCTEST_CONFIG_IMPLEMENT
-#    define DOCTEST_INTERFACE DOCTEST_SYMBOL_EXPORT
-#  else // DOCTEST_CONFIG_IMPLEMENT
-#    define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
-#  endif // DOCTEST_CONFIG_IMPLEMENT
-#else    // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
-#  define DOCTEST_INTERFACE
+#ifdef DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_INTERFACE DOCTEST_SYMBOL_EXPORT
+#else // DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
+#endif // DOCTEST_CONFIG_IMPLEMENT
+#else  // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#define DOCTEST_INTERFACE
 #endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 
 #if DOCTEST_MSVC
-#  define DOCTEST_NOINLINE __declspec(noinline)
-#  define DOCTEST_UNUSED
+#define DOCTEST_NOINLINE __declspec(noinline)
+#define DOCTEST_UNUSED
 #else // MSVC
-#  define DOCTEST_NOINLINE __attribute__((noinline))
-#  define DOCTEST_UNUSED __attribute__((unused))
+#define DOCTEST_NOINLINE __attribute__((noinline))
+#define DOCTEST_UNUSED __attribute__((unused))
 #endif // MSVC
 
 #ifndef DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
-#  define DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK 5
+#define DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK 5
 #endif // DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
 
 // =================================================================================================
@@ -472,18 +478,18 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
 #define DOCTEST_CAT(s1, s2) DOCTEST_CAT_IMPL(s1, s2)
 #ifdef __COUNTER__ // not standard and may be missing for some compilers
-#  define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __COUNTER__)
+#define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __COUNTER__)
 #else // __COUNTER__
-#  define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
+#define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
 #endif // __COUNTER__
 
 // macro for making a string out of an identifier
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  define DOCTEST_TOSTR_IMPL(...) #  __VA_ARGS__
-#  define DOCTEST_TOSTR(...) DOCTEST_TOSTR_IMPL(__VA_ARGS__)
+#define DOCTEST_TOSTR_IMPL(...) #__VA_ARGS__
+#define DOCTEST_TOSTR(...) DOCTEST_TOSTR_IMPL(__VA_ARGS__)
 #else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  define DOCTEST_TOSTR_IMPL(x) #  x
-#  define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
+#define DOCTEST_TOSTR_IMPL(x) #x
+#define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for concatenating literals and making the result a string
@@ -493,133 +499,132 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 #define DOCTEST_COUNTOF(x) (sizeof(x) / sizeof(x[0]))
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
-#  define DOCTEST_REF_WRAP(x) x &
+#define DOCTEST_REF_WRAP(x) x&
 #else // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
-#  define DOCTEST_REF_WRAP(x) x
+#define DOCTEST_REF_WRAP(x) x
 #endif // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 
 // not using __APPLE__ because... this is how Catch does it
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-#  define DOCTEST_PLATFORM_MAC
+#define DOCTEST_PLATFORM_MAC
 #elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-#  define DOCTEST_PLATFORM_IPHONE
+#define DOCTEST_PLATFORM_IPHONE
 #elif defined(_WIN32)
-#  define DOCTEST_PLATFORM_WINDOWS
+#define DOCTEST_PLATFORM_WINDOWS
 #else
-#  define DOCTEST_PLATFORM_LINUX
+#define DOCTEST_PLATFORM_LINUX
 #endif
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var) \
-  DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors") static int var DOCTEST_UNUSED
+#define DOCTEST_GLOBAL_NO_WARNINGS(var)                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors") static int var DOCTEST_UNUSED
 #define DOCTEST_GLOBAL_NO_WARNINGS_END() DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 // should probably take a look at https://github.com/scottt/debugbreak
 #ifdef DOCTEST_PLATFORM_MAC
-#  define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
 #elif DOCTEST_MSVC
-#  define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
+#define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
 #elif defined(__MINGW32__)
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();
-#  define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
+#define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
 #else // linux
-#  define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
+#define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
 #endif // linux
 
 #if DOCTEST_CLANG
 // to detect if libc++ is being used with clang (the _LIBCPP_VERSION identifier)
-#  include <ciso646>
+#include <ciso646>
 #endif // clang
 
 #ifdef _LIBCPP_VERSION
 // not forward declaring ostream for libc++ because I had some problems (inline namespaces vs c++98)
 // so the <iosfwd> header is used - also it is very light and doesn't drag a ton of stuff
-#  include <iosfwd>
+#include <iosfwd>
 #else // _LIBCPP_VERSION
-#  ifndef DOCTEST_CONFIG_USE_IOSFWD
+#ifndef DOCTEST_CONFIG_USE_IOSFWD
 namespace std
 {
-template<class charT>
+template <class charT>
 struct char_traits;
-template<>
+template <>
 struct char_traits<char>;
-template<class charT, class traits>
+template <class charT, class traits>
 class basic_ostream;
-typedef basic_ostream<char, char_traits<char>> ostream;
+typedef basic_ostream<char, char_traits<char> > ostream;
 } // namespace std
-#  else // DOCTEST_CONFIG_USE_IOSFWD
-#    include <iosfwd>
-#  endif // DOCTEST_CONFIG_USE_IOSFWD
-#endif   // _LIBCPP_VERSION
+#else // DOCTEST_CONFIG_USE_IOSFWD
+#include <iosfwd>
+#endif // DOCTEST_CONFIG_USE_IOSFWD
+#endif // _LIBCPP_VERSION
 
 // static assert macro - because of the c++98 support requires that the message is an
 // identifier (no spaces and not a C string) - example without quotes: I_am_a_message
 // taken from here: http://stackoverflow.com/a/1980156/3162383
 #ifdef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  define DOCTEST_STATIC_ASSERT(expression, message) static_assert(expression, #  message)
+#define DOCTEST_STATIC_ASSERT(expression, message) static_assert(expression, #message)
 #else // DOCTEST_CONFIG_WITH_STATIC_ASSERT
-#  define DOCTEST_STATIC_ASSERT(expression, message)                                                     \
-    struct DOCTEST_CAT(__static_assertion_at_line_, __LINE__)                                            \
-    {                                                                                                    \
-      doctest::detail::static_assert_impl::StaticAssertion<static_cast<bool>((expression))> DOCTEST_CAT( \
-          DOCTEST_CAT(DOCTEST_CAT(STATIC_ASSERTION_FAILED_AT_LINE_, __LINE__), _),                       \
-          message);                                                                                      \
-    };                                                                                                   \
-    typedef doctest::detail::static_assert_impl::StaticAssertionTest<static_cast<int>(                   \
-        sizeof(DOCTEST_CAT(__static_assertion_at_line_, __LINE__)))>                                     \
-        DOCTEST_CAT(__static_assertion_test_at_line_, __LINE__)
+#define DOCTEST_STATIC_ASSERT(expression, message)                                                 \
+    struct DOCTEST_CAT(__static_assertion_at_line_, __LINE__)                                      \
+    {                                                                                              \
+        doctest::detail::static_assert_impl::StaticAssertion<static_cast<bool>((expression))>      \
+                DOCTEST_CAT(DOCTEST_CAT(DOCTEST_CAT(STATIC_ASSERTION_FAILED_AT_LINE_, __LINE__),   \
+                                        _),                                                        \
+                            message);                                                              \
+    };                                                                                             \
+    typedef doctest::detail::static_assert_impl::StaticAssertionTest<static_cast<int>(             \
+            sizeof(DOCTEST_CAT(__static_assertion_at_line_, __LINE__)))>                           \
+            DOCTEST_CAT(__static_assertion_test_at_line_, __LINE__)
 #endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
 #ifdef DOCTEST_CONFIG_WITH_NULLPTR
-#  ifdef _LIBCPP_VERSION
-#    include <cstddef>
-#  else  // _LIBCPP_VERSION
+#ifdef _LIBCPP_VERSION
+#include <cstddef>
+#else  // _LIBCPP_VERSION
 namespace std
 {
 typedef decltype(nullptr) nullptr_t;
 }
-#  endif // _LIBCPP_VERSION
-#endif   // DOCTEST_CONFIG_WITH_NULLPTR
+#endif // _LIBCPP_VERSION
+#endif // DOCTEST_CONFIG_WITH_NULLPTR
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-#  ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-#    include <type_traits>
-#  endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#include <type_traits>
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
 namespace doctest
 {
 namespace detail
 {
-struct TestSuite
-{
-  const char * m_test_suite;
-  const char * m_description;
-  bool m_skip;
-  bool m_may_fail;
-  bool m_should_fail;
-  int m_expected_failures;
-  double m_timeout;
+    struct TestSuite
+    {
+        const char* m_test_suite;
+        const char* m_description;
+        bool        m_skip;
+        bool        m_may_fail;
+        bool        m_should_fail;
+        int         m_expected_failures;
+        double      m_timeout;
 
-  TestSuite & operator*(const char * in)
-  {
-    m_test_suite = in;
-    // clear state
-    m_description = 0;
-    m_skip = false;
-    m_may_fail = false;
-    m_should_fail = false;
-    m_expected_failures = 0;
-    m_timeout = 0;
-    return *this;
-  }
+        TestSuite& operator*(const char* in) {
+            m_test_suite = in;
+            // clear state
+            m_description       = 0;
+            m_skip              = false;
+            m_may_fail          = false;
+            m_should_fail       = false;
+            m_expected_failures = 0;
+            m_timeout           = 0;
+            return *this;
+        }
 
-  template<typename T>
-  TestSuite & operator*(const T & in)
-  {
-    in.fill(*this);
-    return *this;
-  }
-};
+        template <typename T>
+        TestSuite& operator*(const T& in) {
+            in.fill(*this);
+            return *this;
+        }
+    };
 } // namespace detail
 } // namespace doctest
 
@@ -627,7 +632,7 @@ struct TestSuite
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden
 namespace doctest_detail_test_suite_ns
 {
-DOCTEST_INTERFACE doctest::detail::TestSuite & getCurrentTestSuite();
+DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
 } // namespace doctest_detail_test_suite_ns
 
 #endif // DOCTEST_CONFIG_DISABLE
@@ -656,100 +661,93 @@ namespace doctest
 // - relational operators as free functions - taking const char* as one of the params
 class DOCTEST_INTERFACE String
 {
-  static const unsigned len = 24;       //! OCLINT avoid private static members
-  static const unsigned last = len - 1; //! OCLINT avoid private static members
+    static const unsigned len  = 24;      //!OCLINT avoid private static members
+    static const unsigned last = len - 1; //!OCLINT avoid private static members
 
-  struct view // len should be more than sizeof(view) - because of the final byte for flags
-  {
-    char * ptr;
-    unsigned size;
-    unsigned capacity;
-  };
+    struct view // len should be more than sizeof(view) - because of the final byte for flags
+    {
+        char*    ptr;
+        unsigned size;
+        unsigned capacity;
+    };
 
-  union {
-    char buf[len];
-    view data;
-  };
+    union
+    {
+        char buf[len];
+        view data;
+    };
 
-  void copy(const String & other);
+    void copy(const String& other);
 
-  void setOnHeap() { *reinterpret_cast<unsigned char *>(&buf[last]) = 128; }
-  void setLast(unsigned in = last) { buf[last] = char(in); }
+    void setOnHeap() { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
+    void setLast(unsigned in = last) { buf[last] = char(in); }
 
 public:
-  String()
-  {
-    buf[0] = '\0';
-    setLast();
-  }
-
-  String(const char * in);
-
-  String(const String & other) { copy(other); }
-
-  ~String()
-  {
-    if(!isOnStack())
-      delete[] data.ptr;
-  }
-
-  // GCC 4.9/5/6 report Wstrict-overflow when optimizations are ON and it got inlined in the vector class somewhere...
-  // see commit 574ef95f0cd379118be5011704664e4b5351f1e0 and build https://travis-ci.org/onqtam/doctest/builds/230671611
-  DOCTEST_NOINLINE String & operator=(const String & other)
-  {
-    if(this != &other)
-    {
-      if(!isOnStack())
-        delete[] data.ptr;
-
-      copy(other);
+    String() {
+        buf[0] = '\0';
+        setLast();
     }
 
-    return *this;
-  }
-  String & operator+=(const String & other);
+    String(const char* in);
 
-  String operator+(const String & other) const { return String(*this) += other; }
+    String(const String& other) { copy(other); }
+
+    ~String() {
+        if(!isOnStack())
+            delete[] data.ptr;
+    }
+
+    // GCC 4.9/5/6 report Wstrict-overflow when optimizations are ON and it got inlined in the vector class somewhere...
+    // see commit 574ef95f0cd379118be5011704664e4b5351f1e0 and build https://travis-ci.org/onqtam/doctest/builds/230671611
+    DOCTEST_NOINLINE String& operator=(const String& other) {
+        if(this != &other) {
+            if(!isOnStack())
+                delete[] data.ptr;
+
+            copy(other);
+        }
+
+        return *this;
+    }
+    String& operator+=(const String& other);
+
+    String operator+(const String& other) const { return String(*this) += other; }
 
 #ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-  String(String && other);
-  String & operator=(String && other);
+    String(String&& other);
+    String& operator=(String&& other);
 #endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 
-  bool isOnStack() const { return (buf[last] & 128) == 0; }
+    bool isOnStack() const { return (buf[last] & 128) == 0; }
 
-  char operator[](unsigned i) const { return const_cast<String *>(this)->operator[](i); } // NOLINT
-  char & operator[](unsigned i)
-  {
-    if(isOnStack())
-      return reinterpret_cast<char *>(buf)[i];
-    return data.ptr[i];
-  }
+    char operator[](unsigned i) const { return const_cast<String*>(this)->operator[](i); } // NOLINT
+    char& operator[](unsigned i) {
+        if(isOnStack())
+            return reinterpret_cast<char*>(buf)[i];
+        return data.ptr[i];
+    }
 
-  const char * c_str() const { return const_cast<String *>(this)->c_str(); } // NOLINT
-  char * c_str()
-  {
-    if(isOnStack())
-      return reinterpret_cast<char *>(buf);
-    return data.ptr;
-  }
+    const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
+    char*       c_str() {
+        if(isOnStack())
+            return reinterpret_cast<char*>(buf);
+        return data.ptr;
+    }
 
-  unsigned size() const
-  {
-    if(isOnStack())
-      return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
-    return data.size;
-  }
+    unsigned size() const {
+        if(isOnStack())
+            return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
+        return data.size;
+    }
 
-  unsigned capacity() const
-  {
-    if(isOnStack())
-      return len;
-    return data.capacity;
-  }
+    unsigned capacity() const {
+        if(isOnStack())
+            return len;
+        return data.capacity;
+    }
 
-  int compare(const char * other, bool no_case = false) const;
-  int compare(const String & other, bool no_case = false) const;
+    int compare(const char* other, bool no_case = false) const;
+    int compare(const String& other, bool no_case = false) const;
 };
 
 // clang-format off
@@ -761,351 +759,247 @@ inline bool operator<=(const String& lhs, const String& rhs) { return (lhs != rh
 inline bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
 // clang-format on
 
-DOCTEST_INTERFACE std::ostream & operator<<(std::ostream & stream, const String & in);
+DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& stream, const String& in);
 
 namespace detail
 {
 #ifndef DOCTEST_CONFIG_WITH_STATIC_ASSERT
-namespace static_assert_impl
-{
-template<bool>
-struct StaticAssertion;
+    namespace static_assert_impl
+    {
+        template <bool>
+        struct StaticAssertion;
 
-template<>
-struct StaticAssertion<true>
-{
-};
+        template <>
+        struct StaticAssertion<true>
+        {};
 
-template<int i>
-struct StaticAssertionTest
-{
-};
-} // namespace static_assert_impl
+        template <int i>
+        struct StaticAssertionTest
+        {};
+    }  // namespace static_assert_impl
 #endif // DOCTEST_CONFIG_WITH_STATIC_ASSERT
 
-template<bool CONDITION, typename TYPE = void>
-struct enable_if
-{
-};
+    template <bool CONDITION, typename TYPE = void>
+    struct enable_if
+    {};
 
-template<typename TYPE>
-struct enable_if<true, TYPE>
-{
-  typedef TYPE type;
-};
+    template <typename TYPE>
+    struct enable_if<true, TYPE>
+    { typedef TYPE type; };
 
-template<typename T>
-struct deferred_false
-// cppcheck-suppress unusedStructMember
-{
-  static const bool value = false;
-};
+    template <typename T>
+    struct deferred_false
+    // cppcheck-suppress unusedStructMember
+    { static const bool value = false; };
 
-// to silence the warning "-Wzero-as-null-pointer-constant" only for gcc 5 for the Approx template ctor - pragmas don't
-// work for it...
-inline void * getNull() { return 0; }
+    // to silence the warning "-Wzero-as-null-pointer-constant" only for gcc 5 for the Approx template ctor - pragmas don't work for it...
+    inline void* getNull() { return 0; }
 
-namespace has_insertion_operator_impl
-{
-typedef char no;
-typedef char yes[2];
+    namespace has_insertion_operator_impl
+    {
+        typedef char no;
+        typedef char yes[2];
 
-struct any_t
-{
-  template<typename T>
-  // cppcheck-suppress noExplicitConstructor
-  any_t(const DOCTEST_REF_WRAP(T));
-};
+        struct any_t
+        {
+            template <typename T>
+            // cppcheck-suppress noExplicitConstructor
+            any_t(const DOCTEST_REF_WRAP(T));
+        };
 
-yes & testStreamable(std::ostream &);
-no testStreamable(no);
+        yes& testStreamable(std::ostream&);
+        no   testStreamable(no);
 
-no operator<<(const std::ostream &, const any_t &);
+        no operator<<(const std::ostream&, const any_t&);
 
-template<typename T>
-struct has_insertion_operator
-{
-  static std::ostream & s;
-  static const DOCTEST_REF_WRAP(T) t;
-  static const bool value = sizeof(testStreamable(s << t)) == sizeof(yes);
-};
-} // namespace has_insertion_operator_impl
+        template <typename T>
+        struct has_insertion_operator
+        {
+            static std::ostream& s;
+            static const DOCTEST_REF_WRAP(T) t;
+            static const bool value = sizeof(testStreamable(s << t)) == sizeof(yes);
+        };
+    } // namespace has_insertion_operator_impl
 
-template<typename T>
-struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
-{
-};
+    template <typename T>
+    struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
+    {};
 
-DOCTEST_INTERFACE void my_memcpy(void * dest, const void * src, unsigned num);
-DOCTEST_INTERFACE unsigned my_strlen(const char * in);
+    DOCTEST_INTERFACE void     my_memcpy(void* dest, const void* src, unsigned num);
+    DOCTEST_INTERFACE unsigned my_strlen(const char* in);
 
-DOCTEST_INTERFACE std::ostream * createStream();
-DOCTEST_INTERFACE String getStreamResult(std::ostream *);
-DOCTEST_INTERFACE void freeStream(std::ostream *);
+    DOCTEST_INTERFACE std::ostream* createStream();
+    DOCTEST_INTERFACE String getStreamResult(std::ostream*);
+    DOCTEST_INTERFACE void   freeStream(std::ostream*);
 
-template<bool C>
-struct StringMakerBase
-{
-  template<typename T>
-  static String convert(const DOCTEST_REF_WRAP(T))
-  {
-    return "{?}";
-  }
-};
+    template <bool C>
+    struct StringMakerBase
+    {
+        template <typename T>
+        static String convert(const DOCTEST_REF_WRAP(T)) {
+            return "{?}";
+        }
+    };
 
-template<>
-struct StringMakerBase<true>
-{
-  template<typename T>
-  static String convert(const DOCTEST_REF_WRAP(T) in)
-  {
-    std::ostream * stream = createStream();
-    *stream << in;
-    String result = getStreamResult(stream);
-    freeStream(stream);
-    return result;
-  }
-};
+    template <>
+    struct StringMakerBase<true>
+    {
+        template <typename T>
+        static String convert(const DOCTEST_REF_WRAP(T) in) {
+            std::ostream* stream = createStream();
+            *stream << in;
+            String result = getStreamResult(stream);
+            freeStream(stream);
+            return result;
+        }
+    };
 
-DOCTEST_INTERFACE String rawMemoryToString(const void * object, unsigned size);
+    DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
 
-template<typename T>
-String rawMemoryToString(const DOCTEST_REF_WRAP(T) object)
-{
-  return rawMemoryToString(&object, sizeof(object));
-}
+    template <typename T>
+    String rawMemoryToString(const DOCTEST_REF_WRAP(T) object) {
+        return rawMemoryToString(&object, sizeof(object));
+    }
 
-class NullType
-{
-};
+    class NullType
+    {
+    };
 
-template<class T, class U>
-struct Typelist
-{
-  typedef T Head;
-  typedef U Tail;
-};
+    template <class T, class U>
+    struct Typelist
+    {
+        typedef T Head;
+        typedef U Tail;
+    };
 
-// type of recursive function
-template<class TList, class Callable>
-struct ForEachType;
+    // type of recursive function
+    template <class TList, class Callable>
+    struct ForEachType;
 
-// Recursion rule
-template<class Head, class Tail, class Callable>
-struct ForEachType<Typelist<Head, Tail>, Callable> : public ForEachType<Tail, Callable>
-{
-  enum
-  {
-    value = 1 + ForEachType<Tail, Callable>::value
-  };
+    // Recursion rule
+    template <class Head, class Tail, class Callable>
+    struct ForEachType<Typelist<Head, Tail>, Callable> : public ForEachType<Tail, Callable>
+    {
+        enum
+        {
+            value = 1 + ForEachType<Tail, Callable>::value
+        };
 
-  explicit ForEachType(Callable & callable) : ForEachType<Tail, Callable>(callable)
-  {
+        explicit ForEachType(Callable& callable)
+                : ForEachType<Tail, Callable>(callable) {
 #if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 10, 0)
-    callable.operator()<value, Head>();
+            callable.operator()<value, Head>();
 #else  // MSVC
-    callable.template operator()<value, Head>();
+            callable.template operator()<value, Head>();
 #endif // MSVC
-  }
-};
+        }
+    };
 
-// Recursion end
-template<class Head, class Callable>
-struct ForEachType<Typelist<Head, NullType>, Callable>
-{
-public:
-  enum
-  {
-    value = 0
-  };
+    // Recursion end
+    template <class Head, class Callable>
+    struct ForEachType<Typelist<Head, NullType>, Callable>
+    {
+    public:
+        enum
+        {
+            value = 0
+        };
 
-  explicit ForEachType(Callable & callable)
-  {
+        explicit ForEachType(Callable& callable) {
 #if DOCTEST_MSVC && DOCTEST_MSVC < DOCTEST_COMPILER(19, 10, 0)
-    callable.operator()<value, Head>();
+            callable.operator()<value, Head>();
 #else  // MSVC
-    callable.template operator()<value, Head>();
+            callable.template operator()<value, Head>();
 #endif // MSVC
-  }
-};
+        }
+    };
 
-template<typename T>
-const char * type_to_string()
-{
-  return "<>";
-}
+    template <typename T>
+    const char* type_to_string() {
+        return "<>";
+    }
 } // namespace detail
 
-template<typename T1 = detail::NullType,
-         typename T2 = detail::NullType,
-         typename T3 = detail::NullType,
-         typename T4 = detail::NullType,
-         typename T5 = detail::NullType,
-         typename T6 = detail::NullType,
-         typename T7 = detail::NullType,
-         typename T8 = detail::NullType,
-         typename T9 = detail::NullType,
-         typename T10 = detail::NullType,
-         typename T11 = detail::NullType,
-         typename T12 = detail::NullType,
-         typename T13 = detail::NullType,
-         typename T14 = detail::NullType,
-         typename T15 = detail::NullType,
-         typename T16 = detail::NullType,
-         typename T17 = detail::NullType,
-         typename T18 = detail::NullType,
-         typename T19 = detail::NullType,
-         typename T20 = detail::NullType,
-         typename T21 = detail::NullType,
-         typename T22 = detail::NullType,
-         typename T23 = detail::NullType,
-         typename T24 = detail::NullType,
-         typename T25 = detail::NullType,
-         typename T26 = detail::NullType,
-         typename T27 = detail::NullType,
-         typename T28 = detail::NullType,
-         typename T29 = detail::NullType,
-         typename T30 = detail::NullType,
-         typename T31 = detail::NullType,
-         typename T32 = detail::NullType,
-         typename T33 = detail::NullType,
-         typename T34 = detail::NullType,
-         typename T35 = detail::NullType,
-         typename T36 = detail::NullType,
-         typename T37 = detail::NullType,
-         typename T38 = detail::NullType,
-         typename T39 = detail::NullType,
-         typename T40 = detail::NullType,
-         typename T41 = detail::NullType,
-         typename T42 = detail::NullType,
-         typename T43 = detail::NullType,
-         typename T44 = detail::NullType,
-         typename T45 = detail::NullType,
-         typename T46 = detail::NullType,
-         typename T47 = detail::NullType,
-         typename T48 = detail::NullType,
-         typename T49 = detail::NullType,
-         typename T50 = detail::NullType,
-         typename T51 = detail::NullType,
-         typename T52 = detail::NullType,
-         typename T53 = detail::NullType,
-         typename T54 = detail::NullType,
-         typename T55 = detail::NullType,
-         typename T56 = detail::NullType,
-         typename T57 = detail::NullType,
-         typename T58 = detail::NullType,
-         typename T59 = detail::NullType,
-         typename T60 = detail::NullType>
+template <typename T1 = detail::NullType, typename T2 = detail::NullType,
+          typename T3 = detail::NullType, typename T4 = detail::NullType,
+          typename T5 = detail::NullType, typename T6 = detail::NullType,
+          typename T7 = detail::NullType, typename T8 = detail::NullType,
+          typename T9 = detail::NullType, typename T10 = detail::NullType,
+          typename T11 = detail::NullType, typename T12 = detail::NullType,
+          typename T13 = detail::NullType, typename T14 = detail::NullType,
+          typename T15 = detail::NullType, typename T16 = detail::NullType,
+          typename T17 = detail::NullType, typename T18 = detail::NullType,
+          typename T19 = detail::NullType, typename T20 = detail::NullType,
+          typename T21 = detail::NullType, typename T22 = detail::NullType,
+          typename T23 = detail::NullType, typename T24 = detail::NullType,
+          typename T25 = detail::NullType, typename T26 = detail::NullType,
+          typename T27 = detail::NullType, typename T28 = detail::NullType,
+          typename T29 = detail::NullType, typename T30 = detail::NullType,
+          typename T31 = detail::NullType, typename T32 = detail::NullType,
+          typename T33 = detail::NullType, typename T34 = detail::NullType,
+          typename T35 = detail::NullType, typename T36 = detail::NullType,
+          typename T37 = detail::NullType, typename T38 = detail::NullType,
+          typename T39 = detail::NullType, typename T40 = detail::NullType,
+          typename T41 = detail::NullType, typename T42 = detail::NullType,
+          typename T43 = detail::NullType, typename T44 = detail::NullType,
+          typename T45 = detail::NullType, typename T46 = detail::NullType,
+          typename T47 = detail::NullType, typename T48 = detail::NullType,
+          typename T49 = detail::NullType, typename T50 = detail::NullType,
+          typename T51 = detail::NullType, typename T52 = detail::NullType,
+          typename T53 = detail::NullType, typename T54 = detail::NullType,
+          typename T55 = detail::NullType, typename T56 = detail::NullType,
+          typename T57 = detail::NullType, typename T58 = detail::NullType,
+          typename T59 = detail::NullType, typename T60 = detail::NullType>
 struct Types
 {
 private:
-  typedef typename Types<T2,
-                         T3,
-                         T4,
-                         T5,
-                         T6,
-                         T7,
-                         T8,
-                         T9,
-                         T10,
-                         T11,
-                         T12,
-                         T13,
-                         T14,
-                         T15,
-                         T16,
-                         T17,
-                         T18,
-                         T19,
-                         T20,
-                         T21,
-                         T22,
-                         T23,
-                         T24,
-                         T25,
-                         T26,
-                         T27,
-                         T28,
-                         T29,
-                         T30,
-                         T31,
-                         T32,
-                         T33,
-                         T34,
-                         T35,
-                         T36,
-                         T37,
-                         T38,
-                         T39,
-                         T40,
-                         T41,
-                         T42,
-                         T43,
-                         T44,
-                         T45,
-                         T46,
-                         T47,
-                         T48,
-                         T49,
-                         T50,
-                         T51,
-                         T52,
-                         T53,
-                         T54,
-                         T55,
-                         T56,
-                         T57,
-                         T58,
-                         T59,
-                         T60>::Result TailResult;
+    typedef typename Types<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17,
+                           T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31,
+                           T32, T33, T34, T35, T36, T37, T38, T39, T40, T41, T42, T43, T44, T45,
+                           T46, T47, T48, T49, T50, T51, T52, T53, T54, T55, T56, T57, T58, T59,
+                           T60>::Result TailResult;
 
 public:
-  typedef detail::Typelist<T1, TailResult> Result;
+    typedef detail::Typelist<T1, TailResult> Result;
 };
 
-template<>
+template <>
 struct Types<>
-{
-  typedef detail::NullType Result;
-};
+{ typedef detail::NullType Result; };
 
-template<typename T>
+template <typename T>
 struct StringMaker : detail::StringMakerBase<detail::has_insertion_operator<T>::value>
+{};
+
+template <typename T>
+struct StringMaker<T*>
 {
+    template <typename U>
+    static String convert(U* p) {
+        if(p)
+            return detail::rawMemoryToString(p);
+        return "NULL";
+    }
 };
 
-template<typename T>
-struct StringMaker<T *>
-{
-  template<typename U>
-  static String convert(U * p)
-  {
-    if(p)
-      return detail::rawMemoryToString(p);
-    return "NULL";
-  }
-};
-
-template<typename R, typename C>
+template <typename R, typename C>
 struct StringMaker<R C::*>
 {
-  static String convert(R C::*p)
-  {
-    if(p)
-      return detail::rawMemoryToString(p);
-    return "NULL";
-  }
+    static String convert(R C::*p) {
+        if(p)
+            return detail::rawMemoryToString(p);
+        return "NULL";
+    }
 };
 
-template<typename T>
-String toString(const DOCTEST_REF_WRAP(T) value)
-{
-  return StringMaker<T>::convert(value);
+template <typename T>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    return StringMaker<T>::convert(value);
 }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-DOCTEST_INTERFACE String toString(char * in);
-DOCTEST_INTERFACE String toString(const char * in);
+DOCTEST_INTERFACE String toString(char* in);
+DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 DOCTEST_INTERFACE String toString(bool in);
 DOCTEST_INTERFACE String toString(float in);
@@ -1134,27 +1028,25 @@ DOCTEST_INTERFACE String toString(std::nullptr_t in);
 class DOCTEST_INTERFACE Approx
 {
 public:
-  explicit Approx(double value);
+    explicit Approx(double value);
 
-  Approx operator()(double value) const
-  {
-    Approx approx(value);
-    approx.epsilon(m_epsilon);
-    approx.scale(m_scale);
-    return approx;
-  }
+    Approx operator()(double value) const {
+        Approx approx(value);
+        approx.epsilon(m_epsilon);
+        approx.scale(m_scale);
+        return approx;
+    }
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  template<typename T>
-  explicit Approx(
-      const T & value,
-      typename detail::enable_if<std::is_constructible<double, T>::value>::type * = static_cast<T *>(detail::getNull()))
-  {
-    *this = Approx(static_cast<double>(value));
-  }
+    template <typename T>
+    explicit Approx(const T& value,
+                    typename detail::enable_if<std::is_constructible<double, T>::value>::type* =
+                            static_cast<T*>(detail::getNull())) {
+        *this = Approx(static_cast<double>(value));
+    }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-  // clang-format off
+    // clang-format off
     // overloads for double - the first one is necessary as it is in the implementation part of doctest
     // as for the others - keeping them for potentially faster compile times
     DOCTEST_INTERFACE friend bool operator==(double lhs, Approx const& rhs);
@@ -1189,177 +1081,174 @@ public:
 #undef DOCTEST_APPROX_PREFIX
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-  // clang-format on
+    // clang-format on
 
-  Approx & epsilon(double newEpsilon)
-  {
-    m_epsilon = newEpsilon;
-    return *this;
-  }
+    Approx& epsilon(double newEpsilon) {
+        m_epsilon = newEpsilon;
+        return *this;
+    }
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  template<typename T>
-  typename detail::enable_if<std::is_constructible<double, T>::value, Approx &>::type epsilon(const T & newEpsilon)
-  {
-    m_epsilon = static_cast<double>(newEpsilon);
-    return *this;
-  }
+    template <typename T>
+    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
+            const T& newEpsilon) {
+        m_epsilon = static_cast<double>(newEpsilon);
+        return *this;
+    }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-  Approx & scale(double newScale)
-  {
-    m_scale = newScale;
-    return *this;
-  }
+    Approx& scale(double newScale) {
+        m_scale = newScale;
+        return *this;
+    }
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  template<typename T>
-  typename detail::enable_if<std::is_constructible<double, T>::value, Approx &>::type scale(const T & newScale)
-  {
-    m_scale = static_cast<double>(newScale);
-    return *this;
-  }
+    template <typename T>
+    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
+            const T& newScale) {
+        m_scale = static_cast<double>(newScale);
+        return *this;
+    }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-  String toString() const;
+    String toString() const;
 
 private:
-  double m_epsilon;
-  double m_scale;
-  double m_value;
+    double m_epsilon;
+    double m_scale;
+    double m_value;
 };
 
-template<>
-inline String toString<Approx>(const DOCTEST_REF_WRAP(Approx) value)
-{
-  return value.toString();
+template <>
+inline String toString<Approx>(const DOCTEST_REF_WRAP(Approx) value) {
+    return value.toString();
 }
 
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
 namespace detail
 {
-// the function type this library works with
-typedef void (*funcType)();
+    // the function type this library works with
+    typedef void (*funcType)();
 
-namespace assertType
-{
-enum Enum
-{
-  // macro traits
+    namespace assertType
+    {
+        enum Enum
+        {
+            // macro traits
 
-  is_warn = 1,
-  is_check = 2,
-  is_require = 4,
+            is_warn    = 1,
+            is_check   = 2,
+            is_require = 4,
 
-  is_throws = 8,
-  is_throws_as = 16,
-  is_nothrow = 32,
+            is_throws    = 8,
+            is_throws_as = 16,
+            is_nothrow   = 32,
 
-  is_fast = 64, // not checked anywhere - used just to distinguish the types
-  is_false = 128,
-  is_unary = 256,
+            is_fast  = 64, // not checked anywhere - used just to distinguish the types
+            is_false = 128,
+            is_unary = 256,
 
-  is_eq = 512,
-  is_ne = 1024,
+            is_eq = 512,
+            is_ne = 1024,
 
-  is_lt = 2048,
-  is_gt = 4096,
+            is_lt = 2048,
+            is_gt = 4096,
 
-  is_ge = 8192,
-  is_le = 16384,
+            is_ge = 8192,
+            is_le = 16384,
 
-  // macro types
+            // macro types
 
-  DT_WARN = is_warn,
-  DT_CHECK = is_check,
-  DT_REQUIRE = is_require,
+            DT_WARN    = is_warn,
+            DT_CHECK   = is_check,
+            DT_REQUIRE = is_require,
 
-  DT_WARN_FALSE = is_false | is_warn,
-  DT_CHECK_FALSE = is_false | is_check,
-  DT_REQUIRE_FALSE = is_false | is_require,
+            DT_WARN_FALSE    = is_false | is_warn,
+            DT_CHECK_FALSE   = is_false | is_check,
+            DT_REQUIRE_FALSE = is_false | is_require,
 
-  DT_WARN_THROWS = is_throws | is_warn,
-  DT_CHECK_THROWS = is_throws | is_check,
-  DT_REQUIRE_THROWS = is_throws | is_require,
+            DT_WARN_THROWS    = is_throws | is_warn,
+            DT_CHECK_THROWS   = is_throws | is_check,
+            DT_REQUIRE_THROWS = is_throws | is_require,
 
-  DT_WARN_THROWS_AS = is_throws_as | is_warn,
-  DT_CHECK_THROWS_AS = is_throws_as | is_check,
-  DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
+            DT_WARN_THROWS_AS    = is_throws_as | is_warn,
+            DT_CHECK_THROWS_AS   = is_throws_as | is_check,
+            DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
 
-  DT_WARN_NOTHROW = is_nothrow | is_warn,
-  DT_CHECK_NOTHROW = is_nothrow | is_check,
-  DT_REQUIRE_NOTHROW = is_nothrow | is_require,
+            DT_WARN_NOTHROW    = is_nothrow | is_warn,
+            DT_CHECK_NOTHROW   = is_nothrow | is_check,
+            DT_REQUIRE_NOTHROW = is_nothrow | is_require,
 
-  DT_WARN_EQ = is_eq | is_warn,
-  DT_CHECK_EQ = is_eq | is_check,
-  DT_REQUIRE_EQ = is_eq | is_require,
+            DT_WARN_EQ    = is_eq | is_warn,
+            DT_CHECK_EQ   = is_eq | is_check,
+            DT_REQUIRE_EQ = is_eq | is_require,
 
-  DT_WARN_NE = is_ne | is_warn,
-  DT_CHECK_NE = is_ne | is_check,
-  DT_REQUIRE_NE = is_ne | is_require,
+            DT_WARN_NE    = is_ne | is_warn,
+            DT_CHECK_NE   = is_ne | is_check,
+            DT_REQUIRE_NE = is_ne | is_require,
 
-  DT_WARN_GT = is_gt | is_warn,
-  DT_CHECK_GT = is_gt | is_check,
-  DT_REQUIRE_GT = is_gt | is_require,
+            DT_WARN_GT    = is_gt | is_warn,
+            DT_CHECK_GT   = is_gt | is_check,
+            DT_REQUIRE_GT = is_gt | is_require,
 
-  DT_WARN_LT = is_lt | is_warn,
-  DT_CHECK_LT = is_lt | is_check,
-  DT_REQUIRE_LT = is_lt | is_require,
+            DT_WARN_LT    = is_lt | is_warn,
+            DT_CHECK_LT   = is_lt | is_check,
+            DT_REQUIRE_LT = is_lt | is_require,
 
-  DT_WARN_GE = is_ge | is_warn,
-  DT_CHECK_GE = is_ge | is_check,
-  DT_REQUIRE_GE = is_ge | is_require,
+            DT_WARN_GE    = is_ge | is_warn,
+            DT_CHECK_GE   = is_ge | is_check,
+            DT_REQUIRE_GE = is_ge | is_require,
 
-  DT_WARN_LE = is_le | is_warn,
-  DT_CHECK_LE = is_le | is_check,
-  DT_REQUIRE_LE = is_le | is_require,
+            DT_WARN_LE    = is_le | is_warn,
+            DT_CHECK_LE   = is_le | is_check,
+            DT_REQUIRE_LE = is_le | is_require,
 
-  DT_WARN_UNARY = is_unary | is_warn,
-  DT_CHECK_UNARY = is_unary | is_check,
-  DT_REQUIRE_UNARY = is_unary | is_require,
+            DT_WARN_UNARY    = is_unary | is_warn,
+            DT_CHECK_UNARY   = is_unary | is_check,
+            DT_REQUIRE_UNARY = is_unary | is_require,
 
-  DT_WARN_UNARY_FALSE = is_false | is_unary | is_warn,
-  DT_CHECK_UNARY_FALSE = is_false | is_unary | is_check,
-  DT_REQUIRE_UNARY_FALSE = is_false | is_unary | is_require,
+            DT_WARN_UNARY_FALSE    = is_false | is_unary | is_warn,
+            DT_CHECK_UNARY_FALSE   = is_false | is_unary | is_check,
+            DT_REQUIRE_UNARY_FALSE = is_false | is_unary | is_require,
 
-  DT_FAST_WARN_EQ = is_fast | is_eq | is_warn,
-  DT_FAST_CHECK_EQ = is_fast | is_eq | is_check,
-  DT_FAST_REQUIRE_EQ = is_fast | is_eq | is_require,
+            DT_FAST_WARN_EQ    = is_fast | is_eq | is_warn,
+            DT_FAST_CHECK_EQ   = is_fast | is_eq | is_check,
+            DT_FAST_REQUIRE_EQ = is_fast | is_eq | is_require,
 
-  DT_FAST_WARN_NE = is_fast | is_ne | is_warn,
-  DT_FAST_CHECK_NE = is_fast | is_ne | is_check,
-  DT_FAST_REQUIRE_NE = is_fast | is_ne | is_require,
+            DT_FAST_WARN_NE    = is_fast | is_ne | is_warn,
+            DT_FAST_CHECK_NE   = is_fast | is_ne | is_check,
+            DT_FAST_REQUIRE_NE = is_fast | is_ne | is_require,
 
-  DT_FAST_WARN_GT = is_fast | is_gt | is_warn,
-  DT_FAST_CHECK_GT = is_fast | is_gt | is_check,
-  DT_FAST_REQUIRE_GT = is_fast | is_gt | is_require,
+            DT_FAST_WARN_GT    = is_fast | is_gt | is_warn,
+            DT_FAST_CHECK_GT   = is_fast | is_gt | is_check,
+            DT_FAST_REQUIRE_GT = is_fast | is_gt | is_require,
 
-  DT_FAST_WARN_LT = is_fast | is_lt | is_warn,
-  DT_FAST_CHECK_LT = is_fast | is_lt | is_check,
-  DT_FAST_REQUIRE_LT = is_fast | is_lt | is_require,
+            DT_FAST_WARN_LT    = is_fast | is_lt | is_warn,
+            DT_FAST_CHECK_LT   = is_fast | is_lt | is_check,
+            DT_FAST_REQUIRE_LT = is_fast | is_lt | is_require,
 
-  DT_FAST_WARN_GE = is_fast | is_ge | is_warn,
-  DT_FAST_CHECK_GE = is_fast | is_ge | is_check,
-  DT_FAST_REQUIRE_GE = is_fast | is_ge | is_require,
+            DT_FAST_WARN_GE    = is_fast | is_ge | is_warn,
+            DT_FAST_CHECK_GE   = is_fast | is_ge | is_check,
+            DT_FAST_REQUIRE_GE = is_fast | is_ge | is_require,
 
-  DT_FAST_WARN_LE = is_fast | is_le | is_warn,
-  DT_FAST_CHECK_LE = is_fast | is_le | is_check,
-  DT_FAST_REQUIRE_LE = is_fast | is_le | is_require,
+            DT_FAST_WARN_LE    = is_fast | is_le | is_warn,
+            DT_FAST_CHECK_LE   = is_fast | is_le | is_check,
+            DT_FAST_REQUIRE_LE = is_fast | is_le | is_require,
 
-  DT_FAST_WARN_UNARY = is_fast | is_unary | is_warn,
-  DT_FAST_CHECK_UNARY = is_fast | is_unary | is_check,
-  DT_FAST_REQUIRE_UNARY = is_fast | is_unary | is_require,
+            DT_FAST_WARN_UNARY    = is_fast | is_unary | is_warn,
+            DT_FAST_CHECK_UNARY   = is_fast | is_unary | is_check,
+            DT_FAST_REQUIRE_UNARY = is_fast | is_unary | is_require,
 
-  DT_FAST_WARN_UNARY_FALSE = is_fast | is_false | is_unary | is_warn,
-  DT_FAST_CHECK_UNARY_FALSE = is_fast | is_false | is_unary | is_check,
-  DT_FAST_REQUIRE_UNARY_FALSE = is_fast | is_false | is_unary | is_require
-};
-} // namespace assertType
+            DT_FAST_WARN_UNARY_FALSE    = is_fast | is_false | is_unary | is_warn,
+            DT_FAST_CHECK_UNARY_FALSE   = is_fast | is_false | is_unary | is_check,
+            DT_FAST_REQUIRE_UNARY_FALSE = is_fast | is_false | is_unary | is_require
+        };
+    } // namespace assertType
 
-DOCTEST_INTERFACE const char * getAssertString(assertType::Enum val);
+    DOCTEST_INTERFACE const char* getAssertString(assertType::Enum val);
 
-// clang-format off
+    // clang-format off
     template<class T>               struct decay_array       { typedef T type; };
     template<class T, unsigned N>   struct decay_array<T[N]> { typedef T* type; };
     template<class T>               struct decay_array<T[]>  { typedef T* type; };
@@ -1369,75 +1258,79 @@ DOCTEST_INTERFACE const char * getAssertString(assertType::Enum val);
     template<>          struct not_char_pointer<const char*> { enum { value = 0 }; };
 
     template<class T> struct can_use_op : not_char_pointer<typename decay_array<T>::type> {};
-// clang-format on
+    // clang-format on
 
-struct TestFailureException
-{
-};
+    struct TestFailureException
+    {
+    };
 
-DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum assert_type);
-DOCTEST_INTERFACE void fastAssertThrowIfFlagSet(int flags);
-DOCTEST_INTERFACE void throwException();
+    DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum assert_type);
+    DOCTEST_INTERFACE void fastAssertThrowIfFlagSet(int flags);
+    DOCTEST_INTERFACE void throwException();
 
-struct TestAccessibleContextState
-{
-  bool no_throw; // to skip exceptions-related assertion macros
-  bool success;  // include successful assertions in output
-};
+    struct TestAccessibleContextState
+    {
+        bool no_throw; // to skip exceptions-related assertion macros
+        bool success;  // include successful assertions in output
+    };
 
-struct ContextState;
+    struct ContextState;
 
-DOCTEST_INTERFACE TestAccessibleContextState * getTestsContextState();
+    DOCTEST_INTERFACE TestAccessibleContextState* getTestsContextState();
 
-struct DOCTEST_INTERFACE SubcaseSignature
-{
-  const char * m_name;
-  const char * m_file;
-  int m_line;
+    struct DOCTEST_INTERFACE SubcaseSignature
+    {
+        const char* m_name;
+        const char* m_file;
+        int         m_line;
 
-  SubcaseSignature(const char * name, const char * file, int line) : m_name(name), m_file(file), m_line(line) {}
+        SubcaseSignature(const char* name, const char* file, int line)
+                : m_name(name)
+                , m_file(file)
+                , m_line(line) {}
 
-  bool operator<(const SubcaseSignature & other) const;
-};
+        bool operator<(const SubcaseSignature& other) const;
+    };
 
-// cppcheck-suppress copyCtorAndEqOperator
-struct DOCTEST_INTERFACE Subcase
-{
-  SubcaseSignature m_signature;
-  bool m_entered;
+    // cppcheck-suppress copyCtorAndEqOperator
+    struct DOCTEST_INTERFACE Subcase
+    {
+        SubcaseSignature m_signature;
+        bool             m_entered;
 
-  Subcase(const char * name, const char * file, int line);
-  Subcase(const Subcase & other);
-  ~Subcase();
+        Subcase(const char* name, const char* file, int line);
+        Subcase(const Subcase& other);
+        ~Subcase();
 
-  operator bool() const { return m_entered; }
-};
+        operator bool() const { return m_entered; }
+    };
 
-template<typename L, typename R>
-String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char * op, const DOCTEST_REF_WRAP(R) rhs)
-{
-  return toString(lhs) + op + toString(rhs);
-}
+    template <typename L, typename R>
+    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
+                               const DOCTEST_REF_WRAP(R) rhs) {
+        return toString(lhs) + op + toString(rhs);
+    }
 
-struct DOCTEST_INTERFACE Result
-{
-  bool m_passed;
-  String m_decomposition;
+    struct DOCTEST_INTERFACE Result
+    {
+        bool   m_passed;
+        String m_decomposition;
 
-  ~Result();
+        ~Result();
 
-  DOCTEST_NOINLINE Result(bool passed = false, const String & decomposition = String())
-  : m_passed(passed), m_decomposition(decomposition)
-  {
-  }
+        DOCTEST_NOINLINE Result(bool passed = false, const String& decomposition = String())
+                : m_passed(passed)
+                , m_decomposition(decomposition) {}
 
-  DOCTEST_NOINLINE Result(const Result & other) : m_passed(other.m_passed), m_decomposition(other.m_decomposition) {}
+        DOCTEST_NOINLINE Result(const Result& other)
+                : m_passed(other.m_passed)
+                , m_decomposition(other.m_decomposition) {}
 
-  Result & operator=(const Result & other);
+        Result& operator=(const Result& other);
 
-  operator bool() { return !m_passed; }
+        operator bool() { return !m_passed; }
 
-  // clang-format off
+        // clang-format off
         // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
         template <typename R> Result& operator&  (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
         template <typename R> Result& operator^  (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
@@ -1461,35 +1354,35 @@ struct DOCTEST_INTERFACE Result
         template <typename R> Result& operator&= (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
         template <typename R> Result& operator^= (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
         template <typename R> Result& operator|= (const R&) { DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); return *this; }
-  // clang-format on
-};
+        // clang-format on
+    };
 
-#  ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
-// DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
-// DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
-// DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
+    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
+    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
+    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
 
-DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
-//#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0)
-// DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
-//#endif // GCC
-// DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-// DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
+    //#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 6, 0)
+    //DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
+    //#endif // GCC
+    //DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
+    //DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
-DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-// http://stackoverflow.com/questions/39479163 what's the difference between C4018 and C4389
-DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
-// DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+    // http://stackoverflow.com/questions/39479163 what's the difference between C4018 and C4389
+    DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
+    DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
+    DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+    //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
 
-#  endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
 // clang-format off
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1510,225 +1403,207 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
     template <typename L, typename R> DOCTEST_COMPARISON_RETURN_TYPE gt(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs >  rhs; }
     template <typename L, typename R> DOCTEST_COMPARISON_RETURN_TYPE le(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs <= rhs; }
     template <typename L, typename R> DOCTEST_COMPARISON_RETURN_TYPE ge(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs >= rhs; }
-// clang-format on
+    // clang-format on
 
-#  ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-#    define DOCTEST_CMP_EQ(l, r) l == r
-#    define DOCTEST_CMP_NE(l, r) l != r
-#    define DOCTEST_CMP_GT(l, r) l > r
-#    define DOCTEST_CMP_LT(l, r) l < r
-#    define DOCTEST_CMP_GE(l, r) l >= r
-#    define DOCTEST_CMP_LE(l, r) l <= r
-#  else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-#    define DOCTEST_CMP_EQ(l, r) eq(l, r)
-#    define DOCTEST_CMP_NE(l, r) ne(l, r)
-#    define DOCTEST_CMP_GT(l, r) gt(l, r)
-#    define DOCTEST_CMP_LT(l, r) lt(l, r)
-#    define DOCTEST_CMP_GE(l, r) ge(l, r)
-#    define DOCTEST_CMP_LE(l, r) le(l, r)
-#  endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#define DOCTEST_CMP_EQ(l, r) l == r
+#define DOCTEST_CMP_NE(l, r) l != r
+#define DOCTEST_CMP_GT(l, r) l > r
+#define DOCTEST_CMP_LT(l, r) l < r
+#define DOCTEST_CMP_GE(l, r) l >= r
+#define DOCTEST_CMP_LE(l, r) l <= r
+#else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#define DOCTEST_CMP_EQ(l, r) eq(l, r)
+#define DOCTEST_CMP_NE(l, r) ne(l, r)
+#define DOCTEST_CMP_GT(l, r) gt(l, r)
+#define DOCTEST_CMP_LT(l, r) lt(l, r)
+#define DOCTEST_CMP_GE(l, r) ge(l, r)
+#define DOCTEST_CMP_LE(l, r) le(l, r)
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
-#  define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro) \
-    template<typename R>                                                \
-    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs)  \
-    {                                                                   \
-      bool res = op_macro(lhs, rhs);                                    \
-      if(m_assert_type & assertType::is_false)                          \
-        res = !res;                                                     \
-      if(!res || doctest::detail::getTestsContextState()->success)      \
-        return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));      \
-      return Result(res);                                               \
+#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
+    template <typename R>                                                                          \
+    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs) {                           \
+        bool res = op_macro(lhs, rhs);                                                             \
+        if(m_assert_type & assertType::is_false)                                                   \
+            res = !res;                                                                            \
+        if(!res || doctest::detail::getTestsContextState()->success)                               \
+            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                             \
+        return Result(res);                                                                        \
     }
 
-#  define DOCTEST_FORBIT_EXPRESSION(op)                                                                            \
-    template<typename R>                                                                                           \
-    Expression_lhs & operator op(const R &)                                                                        \
-    {                                                                                                              \
-      DOCTEST_STATIC_ASSERT(deferred_false<R>::value, Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison); \
-      return *this;                                                                                                \
+#define DOCTEST_FORBIT_EXPRESSION(op)                                                              \
+    template <typename R>                                                                          \
+    Expression_lhs& operator op(const R&) {                                                        \
+        DOCTEST_STATIC_ASSERT(deferred_false<R>::value,                                            \
+                              Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison);         \
+        return *this;                                                                              \
     }
 
-template<typename L>
-// cppcheck-suppress copyCtorAndEqOperator
-struct Expression_lhs
-{
-  L lhs;
-  assertType::Enum m_assert_type;
+    template <typename L>
+    // cppcheck-suppress copyCtorAndEqOperator
+    struct Expression_lhs
+    {
+        L                lhs;
+        assertType::Enum m_assert_type;
 
-  explicit Expression_lhs(L in, assertType::Enum assert_type) : lhs(in), m_assert_type(assert_type) {}
+        explicit Expression_lhs(L in, assertType::Enum assert_type)
+                : lhs(in)
+                , m_assert_type(assert_type) {}
 
-  DOCTEST_NOINLINE operator Result()
-  {
-    bool res = !!lhs;
-    if(m_assert_type & assertType::is_false) //! OCLINT bitwise operator in conditional
-      res = !res;
+        DOCTEST_NOINLINE operator Result() {
+            bool res = !!lhs;
+            if(m_assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
+                res = !res;
 
-    if(!res || getTestsContextState()->success)
-      return Result(res, toString(lhs));
-    return Result(res);
-  }
+            if(!res || getTestsContextState()->success)
+                return Result(res, toString(lhs));
+            return Result(res);
+        }
 
-  // clang-format off
+        // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>, " >  ", DOCTEST_CMP_GT) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<, " <  ", DOCTEST_CMP_LT) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>=, " >= ", DOCTEST_CMP_GE) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE) //!OCLINT bitwise operator in conditional
-  // clang-format on
+        // clang-format on
 
-  // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
-  DOCTEST_FORBIT_EXPRESSION(&)
-  DOCTEST_FORBIT_EXPRESSION (^)
-  DOCTEST_FORBIT_EXPRESSION(|)
-  DOCTEST_FORBIT_EXPRESSION(&&)
-  DOCTEST_FORBIT_EXPRESSION(||)
-  DOCTEST_FORBIT_EXPRESSION(=)
-  DOCTEST_FORBIT_EXPRESSION(+=)
-  DOCTEST_FORBIT_EXPRESSION(-=)
-  DOCTEST_FORBIT_EXPRESSION(*=)
-  DOCTEST_FORBIT_EXPRESSION(/=)
-  DOCTEST_FORBIT_EXPRESSION(%=)
-  DOCTEST_FORBIT_EXPRESSION(<<=)
-  DOCTEST_FORBIT_EXPRESSION(>>=)
-  DOCTEST_FORBIT_EXPRESSION(&=)
-  DOCTEST_FORBIT_EXPRESSION(^=)
-  DOCTEST_FORBIT_EXPRESSION(|=)
-  // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-  // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
-  DOCTEST_FORBIT_EXPRESSION(<<)
-  DOCTEST_FORBIT_EXPRESSION(>>)
-};
+        // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
+        DOCTEST_FORBIT_EXPRESSION(&)
+        DOCTEST_FORBIT_EXPRESSION (^)
+        DOCTEST_FORBIT_EXPRESSION(|)
+        DOCTEST_FORBIT_EXPRESSION(&&)
+        DOCTEST_FORBIT_EXPRESSION(||)
+        DOCTEST_FORBIT_EXPRESSION(=)
+        DOCTEST_FORBIT_EXPRESSION(+=)
+        DOCTEST_FORBIT_EXPRESSION(-=)
+        DOCTEST_FORBIT_EXPRESSION(*=)
+        DOCTEST_FORBIT_EXPRESSION(/=)
+        DOCTEST_FORBIT_EXPRESSION(%=)
+        DOCTEST_FORBIT_EXPRESSION(<<=)
+        DOCTEST_FORBIT_EXPRESSION(>>=)
+        DOCTEST_FORBIT_EXPRESSION(&=)
+        DOCTEST_FORBIT_EXPRESSION(^=)
+        DOCTEST_FORBIT_EXPRESSION(|=)
+        // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
+        // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+        DOCTEST_FORBIT_EXPRESSION(<<)
+        DOCTEST_FORBIT_EXPRESSION(>>)
+    };
 
-#  ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-#  endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-struct ExpressionDecomposer
-{
-  assertType::Enum m_assert_type;
+    struct ExpressionDecomposer
+    {
+        assertType::Enum m_assert_type;
 
-  ExpressionDecomposer(assertType::Enum assert_type) : m_assert_type(assert_type) {}
+        ExpressionDecomposer(assertType::Enum assert_type)
+                : m_assert_type(assert_type) {}
 
-  // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-  // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay
-  // for now... https://github.com/philsquared/Catch/issues/870 https://github.com/philsquared/Catch/issues/565
-  template<typename L>
-  Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand)
-  {
-    return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_assert_type);
-  }
-};
+        // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
+        // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
+        // https://github.com/philsquared/Catch/issues/870
+        // https://github.com/philsquared/Catch/issues/565
+        template <typename L>
+        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand) {
+            return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_assert_type);
+        }
+    };
 
-struct DOCTEST_INTERFACE TestCase
-{
-  // not used for determining uniqueness
-  funcType m_test;           // a function pointer to the test case
-  String m_full_name;        // contains the name (only for templated test cases!) + the template type
-  const char * m_name;       // name of the test case
-  const char * m_type;       // for templated test cases - gets appended to the real name
-  const char * m_test_suite; // the test suite in which the test was added
-  const char * m_description;
-  bool m_skip;
-  bool m_may_fail;
-  bool m_should_fail;
-  int m_expected_failures;
-  double m_timeout;
+    struct DOCTEST_INTERFACE TestCase
+    {
+        // not used for determining uniqueness
+        funcType m_test;    // a function pointer to the test case
+        String m_full_name; // contains the name (only for templated test cases!) + the template type
+        const char* m_name;       // name of the test case
+        const char* m_type;       // for templated test cases - gets appended to the real name
+        const char* m_test_suite; // the test suite in which the test was added
+        const char* m_description;
+        bool        m_skip;
+        bool        m_may_fail;
+        bool        m_should_fail;
+        int         m_expected_failures;
+        double      m_timeout;
 
-  // fields by which uniqueness of test cases shall be determined
-  const char * m_file; // the file in which the test was registered
-  unsigned m_line;     // the line where the test was registered
-  int m_template_id;   // an ID used to distinguish between the different versions of a templated test case
+        // fields by which uniqueness of test cases shall be determined
+        const char* m_file; // the file in which the test was registered
+        unsigned    m_line; // the line where the test was registered
+        int m_template_id; // an ID used to distinguish between the different versions of a templated test case
 
-  TestCase(funcType test,
-           const char * file,
-           unsigned line,
-           const TestSuite & test_suite,
-           const char * type = "",
-           int template_id = -1);
+        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
+                 const char* type = "", int template_id = -1);
 
-  // for gcc 4.7
-  DOCTEST_NOINLINE ~TestCase() {}
+        // for gcc 4.7
+        DOCTEST_NOINLINE ~TestCase() {}
 
-  TestCase & operator*(const char * in);
+        TestCase& operator*(const char* in);
 
-  template<typename T>
-  TestCase & operator*(const T & in)
-  {
-    in.fill(*this);
-    return *this;
-  }
+        template <typename T>
+        TestCase& operator*(const T& in) {
+            in.fill(*this);
+            return *this;
+        }
 
-  TestCase(const TestCase & other) { *this = other; }
+        TestCase(const TestCase& other) { *this = other; }
 
-  TestCase & operator=(const TestCase & other);
+        TestCase& operator=(const TestCase& other);
 
-  bool operator<(const TestCase & other) const;
-};
+        bool operator<(const TestCase& other) const;
+    };
 
-// forward declarations of functions used by the macros
-DOCTEST_INTERFACE int regTest(const TestCase & tc);
-DOCTEST_INTERFACE int setTestSuite(const TestSuite & ts);
+    // forward declarations of functions used by the macros
+    DOCTEST_INTERFACE int regTest(const TestCase& tc);
+    DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
 
-DOCTEST_INTERFACE void addFailedAssert(assertType::Enum assert_type);
+    DOCTEST_INTERFACE void addFailedAssert(assertType::Enum assert_type);
 
-DOCTEST_INTERFACE void logTestStart(const TestCase & tc);
-DOCTEST_INTERFACE void logTestEnd();
+    DOCTEST_INTERFACE void logTestStart(const TestCase& tc);
+    DOCTEST_INTERFACE void logTestEnd();
 
-DOCTEST_INTERFACE void logTestException(const String & what, bool crash = false);
+    DOCTEST_INTERFACE void logTestException(const String& what, bool crash = false);
 
-DOCTEST_INTERFACE void logAssert(bool passed,
-                                 const char * decomposition,
-                                 bool threw,
-                                 const String & exception,
-                                 const char * expr,
-                                 assertType::Enum assert_type,
-                                 const char * file,
-                                 int line);
+    DOCTEST_INTERFACE void logAssert(bool passed, const char* decomposition, bool threw,
+                                     const String& exception, const char* expr,
+                                     assertType::Enum assert_type, const char* file, int line);
 
-DOCTEST_INTERFACE void logAssertThrows(bool threw,
-                                       const char * expr,
-                                       assertType::Enum assert_type,
-                                       const char * file,
-                                       int line);
+    DOCTEST_INTERFACE void logAssertThrows(bool threw, const char* expr,
+                                           assertType::Enum assert_type, const char* file,
+                                           int line);
 
-DOCTEST_INTERFACE void logAssertThrowsAs(bool threw,
-                                         bool threw_as,
-                                         const char * as,
-                                         const String & exception,
-                                         const char * expr,
-                                         assertType::Enum assert_type,
-                                         const char * file,
-                                         int line);
+    DOCTEST_INTERFACE void logAssertThrowsAs(bool threw, bool threw_as, const char* as,
+                                             const String& exception, const char* expr,
+                                             assertType::Enum assert_type, const char* file,
+                                             int line);
 
-DOCTEST_INTERFACE void logAssertNothrow(bool threw,
-                                        const String & exception,
-                                        const char * expr,
-                                        assertType::Enum assert_type,
-                                        const char * file,
-                                        int line);
+    DOCTEST_INTERFACE void logAssertNothrow(bool threw, const String& exception, const char* expr,
+                                            assertType::Enum assert_type, const char* file,
+                                            int line);
 
-DOCTEST_INTERFACE bool isDebuggerActive();
-DOCTEST_INTERFACE void writeToDebugConsole(const String &);
+    DOCTEST_INTERFACE bool isDebuggerActive();
+    DOCTEST_INTERFACE void writeToDebugConsole(const String&);
 
-namespace binaryAssertComparison
-{
-enum Enum
-{
-  eq = 0,
-  ne,
-  gt,
-  lt,
-  ge,
-  le
-};
-} // namespace binaryAssertComparison
+    namespace binaryAssertComparison
+    {
+        enum Enum
+        {
+            eq = 0,
+            ne,
+            gt,
+            lt,
+            ge,
+            le
+        };
+    } // namespace binaryAssertComparison
 
-// clang-format off
+    // clang-format off
     template <int, class L, class R> struct RelationalComparator     { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
     template <class L, class R> struct RelationalComparator<0, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return eq(lhs, rhs); } };
     template <class L, class R> struct RelationalComparator<1, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return ne(lhs, rhs); } };
@@ -1736,506 +1611,481 @@ enum Enum
     template <class L, class R> struct RelationalComparator<3, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return lt(lhs, rhs); } };
     template <class L, class R> struct RelationalComparator<4, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return ge(lhs, rhs); } };
     template <class L, class R> struct RelationalComparator<5, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return le(lhs, rhs); } };
-// clang-format on
+    // clang-format on
 
-struct DOCTEST_INTERFACE ResultBuilder
-{
-  assertType::Enum m_assert_type;
-  const char * m_file;
-  int m_line;
-  const char * m_expr;
-  const char * m_exception_type;
-
-  Result m_result;
-  bool m_threw;
-  bool m_threw_as;
-  bool m_failed;
-  String m_exception;
-
-  ResultBuilder(assertType::Enum assert_type,
-                const char * file,
-                int line,
-                const char * expr,
-                const char * exception_type = "");
-
-  ~ResultBuilder();
-
-  void setResult(const Result & res) { m_result = res; }
-
-  template<int comparison, typename L, typename R>
-  DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs)
-  {
-    m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
-    if(!m_result.m_passed || getTestsContextState()->success)
-      m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
-  }
-
-  template<typename L>
-  DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val)
-  {
-    m_result.m_passed = !!val;
-
-    if(m_assert_type & assertType::is_false) //! OCLINT bitwise operator in conditional
-      m_result.m_passed = !m_result.m_passed;
-
-    if(!m_result.m_passed || getTestsContextState()->success)
-      m_result.m_decomposition = toString(val);
-  }
-
-  void unexpectedExceptionOccurred();
-
-  bool log();
-  void react() const;
-};
-
-namespace assertAction
-{
-enum Enum
-{
-  nothing = 0,
-  dbgbreak = 1,
-  shouldthrow = 2
-};
-} // namespace assertAction
-
-template<int comparison, typename L, typename R>
-DOCTEST_NOINLINE int fast_binary_assert(assertType::Enum assert_type,
-                                        const char * file,
-                                        int line,
-                                        const char * expr,
-                                        const DOCTEST_REF_WRAP(L) lhs,
-                                        const DOCTEST_REF_WRAP(R) rhs)
-{
-  ResultBuilder rb(assert_type, file, line, expr);
-
-  rb.m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
-
-  if(!rb.m_result.m_passed || getTestsContextState()->success)
-    rb.m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
-
-  int res = 0;
-
-  if(rb.log())
-    res |= assertAction::dbgbreak;
-
-  if(rb.m_failed && checkIfShouldThrow(assert_type))
-    res |= assertAction::shouldthrow;
-
-#  ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-  // #########################################################################################
-  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
-  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-  // #########################################################################################
-  if(res & assertAction::dbgbreak)
-    DOCTEST_BREAK_INTO_DEBUGGER();
-  fastAssertThrowIfFlagSet(res);
-#  endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-  return res;
-}
-
-template<typename L>
-DOCTEST_NOINLINE int fast_unary_assert(assertType::Enum assert_type,
-                                       const char * file,
-                                       int line,
-                                       const char * val_str,
-                                       const DOCTEST_REF_WRAP(L) val)
-{
-  ResultBuilder rb(assert_type, file, line, val_str);
-
-  rb.m_result.m_passed = !!val;
-
-  if(assert_type & assertType::is_false) //! OCLINT bitwise operator in conditional
-    rb.m_result.m_passed = !rb.m_result.m_passed;
-
-  if(!rb.m_result.m_passed || getTestsContextState()->success)
-    rb.m_result.m_decomposition = toString(val);
-
-  int res = 0;
-
-  if(rb.log())
-    res |= assertAction::dbgbreak;
-
-  if(rb.m_failed && checkIfShouldThrow(assert_type))
-    res |= assertAction::shouldthrow;
-
-#  ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-  // #########################################################################################
-  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
-  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-  // #########################################################################################
-  if(res & assertAction::dbgbreak)
-    DOCTEST_BREAK_INTO_DEBUGGER();
-  fastAssertThrowIfFlagSet(res);
-#  endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-  return res;
-}
-
-struct DOCTEST_INTERFACE IExceptionTranslator
-{
-  virtual ~IExceptionTranslator() {}
-  virtual bool translate(String &) const = 0;
-};
-
-template<typename T>
-class ExceptionTranslator : public IExceptionTranslator //! OCLINT destructor of virtual class
-{
-public:
-  explicit ExceptionTranslator(String (*translateFunction)(T)) : m_translateFunction(translateFunction) {}
-
-  bool translate(String & res) const
-  {
-#  ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    try
+    struct DOCTEST_INTERFACE ResultBuilder
     {
-      throw;
-      // cppcheck-suppress catchExceptionByValue
-    }
-    catch(T ex)
-    {                                // NOLINT
-      res = m_translateFunction(ex); //! OCLINT parameter reassignment
-      return true;
-    }
-    catch(...)
+        assertType::Enum m_assert_type;
+        const char*      m_file;
+        int              m_line;
+        const char*      m_expr;
+        const char*      m_exception_type;
+
+        Result m_result;
+        bool   m_threw;
+        bool   m_threw_as;
+        bool   m_failed;
+        String m_exception;
+
+        ResultBuilder(assertType::Enum assert_type, const char* file, int line, const char* expr,
+                      const char* exception_type = "");
+
+        ~ResultBuilder();
+
+        void setResult(const Result& res) { m_result = res; }
+
+        template <int comparison, typename L, typename R>
+        DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
+                                            const DOCTEST_REF_WRAP(R) rhs) {
+            m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
+            if(!m_result.m_passed || getTestsContextState()->success)
+                m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
+        }
+
+        template <typename L>
+        DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val) {
+            m_result.m_passed = !!val;
+
+            if(m_assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
+                m_result.m_passed = !m_result.m_passed;
+
+            if(!m_result.m_passed || getTestsContextState()->success)
+                m_result.m_decomposition = toString(val);
+        }
+
+        void unexpectedExceptionOccurred();
+
+        bool log();
+        void react() const;
+    };
+
+    namespace assertAction
     {
-    }            //! OCLINT -  empty catch statement
-#  endif         // DOCTEST_CONFIG_NO_EXCEPTIONS
-    ((void)res); // to silence -Wunused-parameter
-    return false;
-  }
+        enum Enum
+        {
+            nothing     = 0,
+            dbgbreak    = 1,
+            shouldthrow = 2
+        };
+    } // namespace assertAction
 
-protected:
-  String (*m_translateFunction)(T);
-};
+    template <int comparison, typename L, typename R>
+    DOCTEST_NOINLINE int fast_binary_assert(assertType::Enum assert_type, const char* file,
+                                            int line, const char* expr,
+                                            const DOCTEST_REF_WRAP(L) lhs,
+                                            const DOCTEST_REF_WRAP(R) rhs) {
+        ResultBuilder rb(assert_type, file, line, expr);
 
-DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator * translateFunction);
+        rb.m_result.m_passed = RelationalComparator<comparison, L, R>()(lhs, rhs);
 
-// FIX FOR VISUAL STUDIO VERSIONS PRIOR TO 2015 - they failed to compile the call to operator<< with
-// std::ostream passed as a reference noting that there is a use of an undefined type (which there isn't)
-DOCTEST_INTERFACE void writeStringToStream(std::ostream * stream, const String & str);
+        if(!rb.m_result.m_passed || getTestsContextState()->success)
+            rb.m_result.m_decomposition = stringifyBinaryExpr(lhs, ", ", rhs);
 
-template<bool C>
-struct StringStreamBase
-{
-  template<typename T>
-  static void convert(std::ostream * stream, const T & in)
-  {
-    writeStringToStream(stream, toString(in));
-  }
+        int res = 0;
 
-  // always treat char* as a string in this context - no matter
-  // if DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING is defined
-  static void convert(std::ostream * stream, const char * in) { writeStringToStream(stream, String(in)); }
-};
+        if(rb.log())
+            res |= assertAction::dbgbreak;
 
-template<>
-struct StringStreamBase<true>
-{
-  template<typename T>
-  static void convert(std::ostream * stream, const T & in)
-  {
-    *stream << in;
-  }
-};
+        if(rb.m_failed && checkIfShouldThrow(assert_type))
+            res |= assertAction::shouldthrow;
 
-template<typename T>
-struct StringStream : StringStreamBase<has_insertion_operator<T>::value>
-{
-};
+#ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+        // #########################################################################################
+        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
+        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+        // #########################################################################################
+        if(res & assertAction::dbgbreak)
+            DOCTEST_BREAK_INTO_DEBUGGER();
+        fastAssertThrowIfFlagSet(res);
+#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-template<typename T>
-void toStream(std::ostream * stream, const T & value)
-{
-  StringStream<T>::convert(stream, value);
-}
-
-#  ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-DOCTEST_INTERFACE void toStream(std::ostream * stream, char * in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, const char * in);
-#  endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-DOCTEST_INTERFACE void toStream(std::ostream * stream, bool in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, float in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, double in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, double long in);
-
-DOCTEST_INTERFACE void toStream(std::ostream * stream, char in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, char signed in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, char unsigned in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int short in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int short unsigned in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int unsigned in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int long in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int long unsigned in);
-
-#  ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int long long in);
-DOCTEST_INTERFACE void toStream(std::ostream * stream, int long long unsigned in);
-#  endif // DOCTEST_CONFIG_WITH_LONG_LONG
-
-struct IContextScope
-{
-  virtual ~IContextScope() {}
-  virtual void build(std::ostream *) = 0;
-};
-
-DOCTEST_INTERFACE void addToContexts(IContextScope * ptr);
-DOCTEST_INTERFACE void popFromContexts();
-DOCTEST_INTERFACE void useContextIfExceptionOccurred(IContextScope * ptr);
-
-// cppcheck-suppress copyCtorAndEqOperator
-class ContextBuilder
-{
-  friend class ContextScope;
-
-  struct ICapture
-  {
-    virtual ~ICapture() {}
-    virtual void toStream(std::ostream *) const = 0;
-  };
-
-  template<typename T>
-  struct Capture : ICapture //! OCLINT destructor of virtual class
-  {
-    const T * capture;
-
-    explicit Capture(const T * in) : capture(in) {}
-    virtual void toStream(std::ostream * stream) const
-    { // override
-      detail::toStream(stream, *capture);
+        return res;
     }
-  };
 
-  struct Chunk
-  {
-    char buf[sizeof(Capture<char>)]; // place to construct a Capture<T>
-  };
+    template <typename L>
+    DOCTEST_NOINLINE int fast_unary_assert(assertType::Enum assert_type, const char* file, int line,
+                                           const char* val_str, const DOCTEST_REF_WRAP(L) val) {
+        ResultBuilder rb(assert_type, file, line, val_str);
 
-  struct Node
-  {
-    Chunk chunk;
-    Node * next;
-  };
+        rb.m_result.m_passed = !!val;
 
-  Chunk stackChunks[DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK];
-  int numCaptures;
-  Node * head;
-  Node * tail;
+        if(assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
+            rb.m_result.m_passed = !rb.m_result.m_passed;
 
-  void build(std::ostream * stream) const
-  {
-    int curr = 0;
-    // iterate over small buffer
-    while(curr < numCaptures && curr < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
-      reinterpret_cast<const ICapture *>(stackChunks[curr++].buf)->toStream(stream);
-    // iterate over list
-    Node * curr_elem = head;
-    while(curr < numCaptures)
+        if(!rb.m_result.m_passed || getTestsContextState()->success)
+            rb.m_result.m_decomposition = toString(val);
+
+        int res = 0;
+
+        if(rb.log())
+            res |= assertAction::dbgbreak;
+
+        if(rb.m_failed && checkIfShouldThrow(assert_type))
+            res |= assertAction::shouldthrow;
+
+#ifdef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+        // #########################################################################################
+        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK TO SEE THE FAILING ASSERTION
+        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+        // #########################################################################################
+        if(res & assertAction::dbgbreak)
+            DOCTEST_BREAK_INTO_DEBUGGER();
+        fastAssertThrowIfFlagSet(res);
+#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+        return res;
+    }
+
+    struct DOCTEST_INTERFACE IExceptionTranslator
     {
-      reinterpret_cast<const ICapture *>(curr_elem->chunk.buf)->toStream(stream);
-      curr_elem = curr_elem->next;
-      ++curr;
-    }
-  }
+        virtual ~IExceptionTranslator() {}
+        virtual bool translate(String&) const = 0;
+    };
 
-  // steal the contents of the other - acting as a move constructor...
-  DOCTEST_NOINLINE ContextBuilder(ContextBuilder & other)
-  : numCaptures(other.numCaptures), head(other.head), tail(other.tail)
-  {
-    other.numCaptures = 0;
-    other.head = 0;
-    other.tail = 0;
-    my_memcpy(stackChunks, other.stackChunks, unsigned(int(sizeof(Chunk)) * DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK));
-  }
-
-  ContextBuilder & operator=(const ContextBuilder &); // NOLINT
-
-public:
-  // cppcheck-suppress uninitMemberVar
-  DOCTEST_NOINLINE ContextBuilder() // NOLINT
-  : numCaptures(0), head(0), tail(0)
-  {
-  }
-
-  template<typename T>
-  DOCTEST_NOINLINE ContextBuilder & operator<<(T & in)
-  {
-    Capture<T> temp(&in);
-
-    // construct either on stack or on heap
-    // copy the bytes for the whole object - including the vtable because we cant construct
-    // the object directly in the buffer using placement new - need the <new> header...
-    if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
+    template <typename T>
+    class ExceptionTranslator : public IExceptionTranslator //!OCLINT destructor of virtual class
     {
-      my_memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
-    }
-    else
+    public:
+        explicit ExceptionTranslator(String (*translateFunction)(T))
+                : m_translateFunction(translateFunction) {}
+
+        bool translate(String& res) const {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+            try {
+                throw;
+                // cppcheck-suppress catchExceptionByValue
+            } catch(T ex) {                    // NOLINT
+                res = m_translateFunction(ex); //!OCLINT parameter reassignment
+                return true;
+            } catch(...) {} //!OCLINT -  empty catch statement
+#endif                      // DOCTEST_CONFIG_NO_EXCEPTIONS
+            ((void)res);    // to silence -Wunused-parameter
+            return false;
+        }
+
+    protected:
+        String (*m_translateFunction)(T);
+    };
+
+    DOCTEST_INTERFACE void registerExceptionTranslatorImpl(
+            const IExceptionTranslator* translateFunction);
+
+    // FIX FOR VISUAL STUDIO VERSIONS PRIOR TO 2015 - they failed to compile the call to operator<< with
+    // std::ostream passed as a reference noting that there is a use of an undefined type (which there isn't)
+    DOCTEST_INTERFACE void writeStringToStream(std::ostream* stream, const String& str);
+
+    template <bool C>
+    struct StringStreamBase
     {
-      Node * curr = new Node;
-      curr->next = 0;
-      if(tail)
-      {
-        tail->next = curr;
-        tail = curr;
-      }
-      else
-      {
-        head = tail = curr;
-      }
+        template <typename T>
+        static void convert(std::ostream* stream, const T& in) {
+            writeStringToStream(stream, toString(in));
+        }
 
-      my_memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
-    }
-    ++numCaptures;
-    return *this;
-  }
+        // always treat char* as a string in this context - no matter
+        // if DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING is defined
+        static void convert(std::ostream* stream, const char* in) {
+            writeStringToStream(stream, String(in));
+        }
+    };
 
-  DOCTEST_NOINLINE ~ContextBuilder()
-  {
-    // free the linked list - the ones on the stack are left as-is
-    // no destructors are called at all - there is no need
-    while(head)
+    template <>
+    struct StringStreamBase<true>
     {
-      Node * next = head->next;
-      delete head;
-      head = next;
+        template <typename T>
+        static void convert(std::ostream* stream, const T& in) {
+            *stream << in;
+        }
+    };
+
+    template <typename T>
+    struct StringStream : StringStreamBase<has_insertion_operator<T>::value>
+    {};
+
+    template <typename T>
+    void toStream(std::ostream* stream, const T& value) {
+        StringStream<T>::convert(stream, value);
     }
-  }
 
-#  ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-  template<typename T>
-  ContextBuilder & operator<<(const T &&)
-  {
-    DOCTEST_STATIC_ASSERT(
-        deferred_false<T>::value,
-        Cannot_pass_temporaries_or_rvalues_to_the_streaming_operator_because_it_caches_pointers_to_the_passed_objects_for_lazy_evaluation);
-    return *this;
-  }
-#  endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-};
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, char* in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, const char* in);
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, bool in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, float in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, double in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, double long in);
 
-class ContextScope : public IContextScope
-{
-  ContextBuilder contextBuilder;
-  bool built;
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, char in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, char signed in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, char unsigned in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int short in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int short unsigned in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int unsigned in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long unsigned in);
 
-public:
-  DOCTEST_NOINLINE explicit ContextScope(ContextBuilder & temp) : contextBuilder(temp), built(false)
-  {
-    addToContexts(this);
-  }
+#ifdef DOCTEST_CONFIG_WITH_LONG_LONG
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long long in);
+    DOCTEST_INTERFACE void toStream(std::ostream* stream, int long long unsigned in);
+#endif // DOCTEST_CONFIG_WITH_LONG_LONG
 
-  DOCTEST_NOINLINE ~ContextScope()
-  {
-    if(!built)
-      useContextIfExceptionOccurred(this);
-    popFromContexts();
-  }
+    struct IContextScope
+    {
+        virtual ~IContextScope() {}
+        virtual void build(std::ostream*) = 0;
+    };
 
-  void build(std::ostream * stream)
-  {
-    built = true;
-    contextBuilder.build(stream);
-  }
-};
+    DOCTEST_INTERFACE void addToContexts(IContextScope* ptr);
+    DOCTEST_INTERFACE void popFromContexts();
+    DOCTEST_INTERFACE void useContextIfExceptionOccurred(IContextScope* ptr);
 
-class DOCTEST_INTERFACE MessageBuilder
-{
-  std::ostream * m_stream;
-  const char * m_file;
-  int m_line;
-  assertType::Enum m_severity;
+    // cppcheck-suppress copyCtorAndEqOperator
+    class ContextBuilder
+    {
+        friend class ContextScope;
 
-public:
-  MessageBuilder(const char * file, int line, assertType::Enum severity);
-  ~MessageBuilder();
+        struct ICapture
+        {
+            virtual ~ICapture() {}
+            virtual void toStream(std::ostream*) const = 0;
+        };
 
-  template<typename T>
-  MessageBuilder & operator<<(const T & in)
-  {
-    toStream(m_stream, in);
-    return *this;
-  }
+        template <typename T>
+        struct Capture : ICapture //!OCLINT destructor of virtual class
+        {
+            const T* capture;
 
-  bool log();
-  void react();
-};
+            explicit Capture(const T* in)
+                    : capture(in) {}
+            virtual void toStream(std::ostream* stream) const { // override
+                detail::toStream(stream, *capture);
+            }
+        };
+
+        struct Chunk
+        {
+            char buf[sizeof(Capture<char>)]; // place to construct a Capture<T>
+        };
+
+        struct Node
+        {
+            Chunk chunk;
+            Node* next;
+        };
+
+        Chunk stackChunks[DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK];
+        int   numCaptures;
+        Node* head;
+        Node* tail;
+
+        void build(std::ostream* stream) const {
+            int curr = 0;
+            // iterate over small buffer
+            while(curr < numCaptures && curr < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
+                reinterpret_cast<const ICapture*>(stackChunks[curr++].buf)->toStream(stream);
+            // iterate over list
+            Node* curr_elem = head;
+            while(curr < numCaptures) {
+                reinterpret_cast<const ICapture*>(curr_elem->chunk.buf)->toStream(stream);
+                curr_elem = curr_elem->next;
+                ++curr;
+            }
+        }
+
+        // steal the contents of the other - acting as a move constructor...
+        DOCTEST_NOINLINE ContextBuilder(ContextBuilder& other)
+                : numCaptures(other.numCaptures)
+                , head(other.head)
+                , tail(other.tail) {
+            other.numCaptures = 0;
+            other.head        = 0;
+            other.tail        = 0;
+            my_memcpy(stackChunks, other.stackChunks,
+                      unsigned(int(sizeof(Chunk)) * DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK));
+        }
+
+        ContextBuilder& operator=(const ContextBuilder&); // NOLINT
+
+    public:
+        // cppcheck-suppress uninitMemberVar
+        DOCTEST_NOINLINE ContextBuilder() // NOLINT
+                : numCaptures(0)
+                , head(0)
+                , tail(0) {}
+
+        template <typename T>
+        DOCTEST_NOINLINE ContextBuilder& operator<<(T& in) {
+            Capture<T> temp(&in);
+
+            // construct either on stack or on heap
+            // copy the bytes for the whole object - including the vtable because we cant construct
+            // the object directly in the buffer using placement new - need the <new> header...
+            if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK) {
+                my_memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
+            } else {
+                Node* curr = new Node;
+                curr->next = 0;
+                if(tail) {
+                    tail->next = curr;
+                    tail       = curr;
+                } else {
+                    head = tail = curr;
+                }
+
+                my_memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
+            }
+            ++numCaptures;
+            return *this;
+        }
+
+        DOCTEST_NOINLINE ~ContextBuilder() {
+            // free the linked list - the ones on the stack are left as-is
+            // no destructors are called at all - there is no need
+            while(head) {
+                Node* next = head->next;
+                delete head;
+                head = next;
+            }
+        }
+
+#ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+        template <typename T>
+        ContextBuilder& operator<<(const T&&) {
+            DOCTEST_STATIC_ASSERT(
+                    deferred_false<T>::value,
+                    Cannot_pass_temporaries_or_rvalues_to_the_streaming_operator_because_it_caches_pointers_to_the_passed_objects_for_lazy_evaluation);
+            return *this;
+        }
+#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+    };
+
+    class ContextScope : public IContextScope
+    {
+        ContextBuilder contextBuilder;
+        bool           built;
+
+    public:
+        DOCTEST_NOINLINE explicit ContextScope(ContextBuilder& temp)
+                : contextBuilder(temp)
+                , built(false) {
+            addToContexts(this);
+        }
+
+        DOCTEST_NOINLINE ~ContextScope() {
+            if(!built)
+                useContextIfExceptionOccurred(this);
+            popFromContexts();
+        }
+
+        void build(std::ostream* stream) {
+            built = true;
+            contextBuilder.build(stream);
+        }
+    };
+
+    class DOCTEST_INTERFACE MessageBuilder
+    {
+        std::ostream*    m_stream;
+        const char*      m_file;
+        int              m_line;
+        assertType::Enum m_severity;
+
+    public:
+        MessageBuilder(const char* file, int line, assertType::Enum severity);
+        ~MessageBuilder();
+
+        template <typename T>
+        MessageBuilder& operator<<(const T& in) {
+            toStream(m_stream, in);
+            return *this;
+        }
+
+        bool log();
+        void react();
+    };
 } // namespace detail
 
 struct test_suite
 {
-  const char * data;
-  test_suite(const char * in) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_test_suite = data; }
-  void fill(detail::TestSuite & state) const { state.m_test_suite = data; }
+    const char* data;
+    test_suite(const char* in)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_test_suite = data; }
+    void fill(detail::TestSuite& state) const { state.m_test_suite = data; }
 };
 
 struct description
 {
-  const char * data;
-  description(const char * in) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_description = data; }
-  void fill(detail::TestSuite & state) const { state.m_description = data; }
+    const char* data;
+    description(const char* in)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_description = data; }
+    void fill(detail::TestSuite& state) const { state.m_description = data; }
 };
 
 struct skip
 {
-  bool data;
-  skip(bool in = true) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_skip = data; }
-  void fill(detail::TestSuite & state) const { state.m_skip = data; }
+    bool data;
+    skip(bool in = true)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_skip = data; }
+    void fill(detail::TestSuite& state) const { state.m_skip = data; }
 };
 
 struct timeout
 {
-  double data;
-  timeout(double in) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_timeout = data; }
-  void fill(detail::TestSuite & state) const { state.m_timeout = data; }
+    double data;
+    timeout(double in)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_timeout = data; }
+    void fill(detail::TestSuite& state) const { state.m_timeout = data; }
 };
 
 struct may_fail
 {
-  bool data;
-  may_fail(bool in = true) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_may_fail = data; }
-  void fill(detail::TestSuite & state) const { state.m_may_fail = data; }
+    bool data;
+    may_fail(bool in = true)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_may_fail = data; }
+    void fill(detail::TestSuite& state) const { state.m_may_fail = data; }
 };
 
 struct should_fail
 {
-  bool data;
-  should_fail(bool in = true) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_should_fail = data; }
-  void fill(detail::TestSuite & state) const { state.m_should_fail = data; }
+    bool data;
+    should_fail(bool in = true)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_should_fail = data; }
+    void fill(detail::TestSuite& state) const { state.m_should_fail = data; }
 };
 
 struct expected_failures
 {
-  int data;
-  expected_failures(int in) : data(in) {}
-  void fill(detail::TestCase & state) const { state.m_expected_failures = data; }
-  void fill(detail::TestSuite & state) const { state.m_expected_failures = data; }
+    int data;
+    expected_failures(int in)
+            : data(in) {}
+    void fill(detail::TestCase& state) const { state.m_expected_failures = data; }
+    void fill(detail::TestSuite& state) const { state.m_expected_failures = data; }
 };
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
-template<typename T>
-int registerExceptionTranslator(String (*translateFunction)(T))
-{
-  DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
-  static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
-  DOCTEST_CLANG_SUPPRESS_WARNING_POP
-  detail::registerExceptionTranslatorImpl(&exceptionTranslator);
-  return 0;
+template <typename T>
+int registerExceptionTranslator(String (*translateFunction)(T)) {
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
+    static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    detail::registerExceptionTranslatorImpl(&exceptionTranslator);
+    return 0;
 }
 
 #else  // DOCTEST_CONFIG_DISABLE
-template<typename T>
-int registerExceptionTranslator(String (*)(T))
-{
-  return 0;
+template <typename T>
+int registerExceptionTranslator(String (*)(T)) {
+    return 0;
 }
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -2245,27 +2095,27 @@ DOCTEST_INTERFACE bool isRunningInTest();
 class DOCTEST_INTERFACE Context
 {
 #if !defined(DOCTEST_CONFIG_DISABLE)
-  detail::ContextState * p;
+    detail::ContextState* p;
 
-  void parseArgs(int argc, const char * const * argv, bool withDefaults = false);
+    void parseArgs(int argc, const char* const* argv, bool withDefaults = false);
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 public:
-  explicit Context(int argc = 0, const char * const * argv = 0);
+    explicit Context(int argc = 0, const char* const* argv = 0);
 
-  ~Context();
+    ~Context();
 
-  void applyCommandLine(int argc, const char * const * argv);
+    void applyCommandLine(int argc, const char* const* argv);
 
-  void addFilter(const char * filter, const char * value);
-  void clearFilters();
-  void setOption(const char * option, int value);
-  void setOption(const char * option, const char * value);
+    void addFilter(const char* filter, const char* value);
+    void clearFilters();
+    void setOption(const char* option, int value);
+    void setOption(const char* option, const char* value);
 
-  bool shouldExit();
+    bool shouldExit();
 
-  int run();
+    int run();
 };
 
 } // namespace doctest
@@ -2273,231 +2123,232 @@ public:
 // if registering is not disabled
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_EXPAND_VA_ARGS(...) __VA_ARGS__
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_EXPAND_VA_ARGS
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_EXPAND_VA_ARGS(...) __VA_ARGS__
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_EXPAND_VA_ARGS
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#  define DOCTEST_STRIP_PARENS(x) x
-#  define DOCTEST_HANDLE_BRACED_VA_ARGS(expr) DOCTEST_STRIP_PARENS(DOCTEST_EXPAND_VA_ARGS expr)
+#define DOCTEST_STRIP_PARENS(x) x
+#define DOCTEST_HANDLE_BRACED_VA_ARGS(expr) DOCTEST_STRIP_PARENS(DOCTEST_EXPAND_VA_ARGS expr)
 
 // registers the test by initializing a dummy var with a function
-#  define DOCTEST_REGISTER_FUNCTION(f, decorators)                                                            \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) = doctest::detail::regTest(             \
-        doctest::detail::TestCase(f, __FILE__, __LINE__, doctest_detail_test_suite_ns::getCurrentTestSuite()) \
-        * decorators);                                                                                        \
+#define DOCTEST_REGISTER_FUNCTION(f, decorators)                                                   \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) = doctest::detail::regTest(  \
+            doctest::detail::TestCase(f, __FILE__, __LINE__,                                       \
+                                      doctest_detail_test_suite_ns::getCurrentTestSuite()) *       \
+            decorators);                                                                           \
     DOCTEST_GLOBAL_NO_WARNINGS_END()
 
-#  define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators) \
-    namespace                                                    \
-    {                                                            \
-    struct der : base                                            \
-    {                                                            \
-      void f();                                                  \
-    };                                                           \
-    static void func()                                           \
-    {                                                            \
-      der v;                                                     \
-      v.f();                                                     \
-    }                                                            \
-    DOCTEST_REGISTER_FUNCTION(func, decorators)                  \
-    }                                                            \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
+    namespace                                                                                      \
+    {                                                                                              \
+        struct der : base                                                                          \
+        {                                                                                          \
+            void f();                                                                              \
+        };                                                                                         \
+        static void func() {                                                                       \
+            der v;                                                                                 \
+            v.f();                                                                                 \
+        }                                                                                          \
+        DOCTEST_REGISTER_FUNCTION(func, decorators)                                                \
+    }                                                                                              \
     inline DOCTEST_NOINLINE void der::f()
 
-#  define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators) \
-    static void f();                                          \
-    DOCTEST_REGISTER_FUNCTION(f, decorators)                  \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
+    static void f();                                                                               \
+    DOCTEST_REGISTER_FUNCTION(f, decorators)                                                       \
     static void f()
 
 // for registering tests
-#  define DOCTEST_TEST_CASE(decorators) \
+#define DOCTEST_TEST_CASE(decorators)                                                              \
     DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests with a fixture
-#  define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                                \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c, DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), \
-                              decorators)
+#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c,                          \
+                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TYPE_TO_STRING_IMPL(...)            \
-      template<>                                        \
-      inline const char * type_to_string<__VA_ARGS__>() \
-      {                                                 \
-        return "<" #__VA_ARGS__ ">";                    \
-      }
-#    define DOCTEST_TYPE_TO_STRING(...)        \
-      namespace doctest                        \
-      {                                        \
-      namespace detail                         \
-      {                                        \
-      DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__) \
-      }                                        \
-      }                                        \
-      typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TYPE_TO_STRING_IMPL(x)    \
-      template<>                              \
-      inline const char * type_to_string<x>() \
-      {                                       \
-        return "<" #x ">";                    \
-      }
-#    define DOCTEST_TYPE_TO_STRING(x) \
-      namespace doctest               \
-      {                               \
-      namespace detail                \
-      {                               \
-      DOCTEST_TYPE_TO_STRING_IMPL(x)  \
-      }                               \
-      }                               \
-      typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TYPE_TO_STRING_IMPL(...)                                                           \
+    template <>                                                                                    \
+    inline const char* type_to_string<__VA_ARGS__>() {                                             \
+        return "<" #__VA_ARGS__ ">";                                                               \
+    }
+#define DOCTEST_TYPE_TO_STRING(...)                                                                \
+    namespace doctest                                                                              \
+    {                                                                                              \
+        namespace detail                                                                           \
+        {                                                                                          \
+            DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__)                                               \
+        }                                                                                          \
+    }                                                                                              \
+    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TYPE_TO_STRING_IMPL(x)                                                             \
+    template <>                                                                                    \
+    inline const char* type_to_string<x>() {                                                       \
+        return "<" #x ">";                                                                         \
+    }
+#define DOCTEST_TYPE_TO_STRING(x)                                                                  \
+    namespace doctest                                                                              \
+    {                                                                                              \
+        namespace detail                                                                           \
+        {                                                                                          \
+            DOCTEST_TYPE_TO_STRING_IMPL(x)                                                         \
+        }                                                                                          \
+    }                                                                                              \
+    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for typed tests
-#  define DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, anon)                                              \
-    template<typename T>                                                                                           \
-    inline void anon();                                                                                            \
-    struct DOCTEST_CAT(anon, FUNCTOR)                                                                              \
-    {                                                                                                              \
-      template<int Index, typename Type>                                                                           \
-      void operator()()                                                                                            \
-      {                                                                                                            \
-        doctest::detail::regTest(doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                         \
-                                                           doctest_detail_test_suite_ns::getCurrentTestSuite(),    \
-                                                           doctest::detail::type_to_string<Type>(), Index)         \
-                                 * decorators);                                                                    \
-      }                                                                                                            \
-    };                                                                                                             \
-    inline int DOCTEST_CAT(anon, REG_FUNC)()                                                                       \
-    {                                                                                                              \
-      DOCTEST_CAT(anon, FUNCTOR) registrar;                                                                        \
-      doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result, DOCTEST_CAT(anon, FUNCTOR)> doIt( \
-          registrar);                                                                                              \
-      return 0;                                                                                                    \
-    }                                                                                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();                          \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                                               \
-    template<typename T>                                                                                           \
+#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, anon)                                \
+    template <typename T>                                                                          \
+    inline void anon();                                                                            \
+    struct DOCTEST_CAT(anon, FUNCTOR)                                                              \
+    {                                                                                              \
+        template <int Index, typename Type>                                                        \
+        void operator()() {                                                                        \
+            doctest::detail::regTest(                                                              \
+                    doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                      \
+                                              doctest_detail_test_suite_ns::getCurrentTestSuite(), \
+                                              doctest::detail::type_to_string<Type>(), Index) *    \
+                    decorators);                                                                   \
+        }                                                                                          \
+    };                                                                                             \
+    inline int DOCTEST_CAT(anon, REG_FUNC)() {                                                     \
+        DOCTEST_CAT(anon, FUNCTOR) registrar;                                                      \
+        doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result,                 \
+                                     DOCTEST_CAT(anon, FUNCTOR)>                                   \
+                doIt(registrar);                                                                   \
+        return 0;                                                                                  \
+    }                                                                                              \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();          \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+    template <typename T>                                                                          \
     inline void anon()
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, ...) \
-      DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, (__VA_ARGS__), DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, types) \
-      DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, ...)                                             \
+    DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, (__VA_ARGS__),                                  \
+                                    DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TEST_CASE_TEMPLATE(decorators, T, types)                                           \
+    DOCTEST_TEST_CASE_TEMPLATE_IMPL(decorators, T, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#  define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(decorators, T, id, anon)                                       \
-    template<typename T>                                                                                        \
-    inline void anon();                                                                                         \
-    struct DOCTEST_CAT(id, _FUNCTOR)                                                                            \
-    {                                                                                                           \
-      int m_line;                                                                                               \
-      DOCTEST_CAT(id, _FUNCTOR)                                                                                 \
-      (int line) : m_line(line) {}                                                                              \
-      template<int Index, typename Type>                                                                        \
-      void operator()()                                                                                         \
-      {                                                                                                         \
-        doctest::detail::regTest(doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                      \
-                                                           doctest_detail_test_suite_ns::getCurrentTestSuite(), \
-                                                           doctest::detail::type_to_string<Type>(),             \
-                                                           m_line * 1000 + Index)                               \
-                                 * decorators);                                                                 \
-      }                                                                                                         \
-    };                                                                                                          \
-    template<typename T>                                                                                        \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(decorators, T, id, anon)                            \
+    template <typename T>                                                                          \
+    inline void anon();                                                                            \
+    struct DOCTEST_CAT(id, _FUNCTOR)                                                               \
+    {                                                                                              \
+        int m_line;                                                                                \
+        DOCTEST_CAT(id, _FUNCTOR)                                                                  \
+        (int line)                                                                                 \
+                : m_line(line) {}                                                                  \
+        template <int Index, typename Type>                                                        \
+        void operator()() {                                                                        \
+            doctest::detail::regTest(                                                              \
+                    doctest::detail::TestCase(anon<Type>, __FILE__, __LINE__,                      \
+                                              doctest_detail_test_suite_ns::getCurrentTestSuite(), \
+                                              doctest::detail::type_to_string<Type>(),             \
+                                              m_line * 1000 + Index) *                             \
+                    decorators);                                                                   \
+        }                                                                                          \
+    };                                                                                             \
+    template <typename T>                                                                          \
     inline void anon()
 
-#  define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(decorators, T, id) \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(decorators, T, id)                                       \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(decorators, T, id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
 
-#  define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, anon)                                            \
-    static int DOCTEST_CAT(anon, REG_FUNC)()                                                                      \
-    {                                                                                                             \
-      DOCTEST_CAT(id, _FUNCTOR) registrar(__LINE__);                                                              \
-      doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result, DOCTEST_CAT(id, _FUNCTOR)> doIt( \
-          registrar);                                                                                             \
-      return 0;                                                                                                   \
-    }                                                                                                             \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();                         \
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, anon)                               \
+    static int DOCTEST_CAT(anon, REG_FUNC)() {                                                     \
+        DOCTEST_CAT(id, _FUNCTOR) registrar(__LINE__);                                             \
+        doctest::detail::ForEachType<DOCTEST_HANDLE_BRACED_VA_ARGS(types)::Result,                 \
+                                     DOCTEST_CAT(id, _FUNCTOR)>                                    \
+                doIt(registrar);                                                                   \
+        return 0;                                                                                  \
+    }                                                                                              \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = DOCTEST_CAT(anon, REG_FUNC)();          \
     DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) \
-      DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, (__VA_ARGS__), DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types) \
-      DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                            \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, (__VA_ARGS__),                                 \
+                                                DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types)                                          \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, types, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for subcases
-#  define DOCTEST_SUBCASE(name)                                                                    \
+#define DOCTEST_SUBCASE(name)                                                                      \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
-           doctest::detail::Subcase(name, __FILE__, __LINE__))
+               doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
-#  define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                         \
-    namespace ns_name                                                          \
-    {                                                                          \
-    namespace doctest_detail_test_suite_ns                                     \
-    {                                                                          \
-    static DOCTEST_NOINLINE doctest::detail::TestSuite & getCurrentTestSuite() \
-    {                                                                          \
-      static doctest::detail::TestSuite data;                                  \
-      static bool inited = false;                                              \
-      if(!inited)                                                              \
-      {                                                                        \
-        data * decorators;                                                     \
-        inited = true;                                                         \
-      }                                                                        \
-      return data;                                                             \
-    }                                                                          \
-    }                                                                          \
-    }                                                                          \
+#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
+    namespace ns_name                                                                              \
+    {                                                                                              \
+        namespace doctest_detail_test_suite_ns                                                     \
+        {                                                                                          \
+            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() {            \
+                static doctest::detail::TestSuite data;                                            \
+                static bool                       inited = false;                                  \
+                if(!inited) {                                                                      \
+                    data* decorators;                                                              \
+                    inited = true;                                                                 \
+                }                                                                                  \
+                return data;                                                                       \
+            }                                                                                      \
+        }                                                                                          \
+    }                                                                                              \
     namespace ns_name
 
-#  define DOCTEST_TEST_SUITE(decorators) DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
+#define DOCTEST_TEST_SUITE(decorators)                                                             \
+    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
-#  define DOCTEST_TEST_SUITE_BEGIN(decorators)                                    \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =           \
-        doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators); \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                              \
+#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
+            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators);              \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for ending a testsuite block
-#  define DOCTEST_TEST_SUITE_END                                          \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =   \
-        doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""); \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                      \
+#define DOCTEST_TEST_SUITE_END                                                                     \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
+            doctest::detail::setTestSuite(doctest::detail::TestSuite() * "");                      \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for registering exception translators
-#  define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature) \
-    inline doctest::String translatorName(signature);                           \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =  \
-        doctest::registerExceptionTranslator(translatorName);                   \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                            \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
+    inline doctest::String translatorName(signature);                                              \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =                     \
+            doctest::registerExceptionTranslator(translatorName);                                  \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
     doctest::String translatorName(signature)
 
-#  define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature) \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_), signature)
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_),       \
+                                               signature)
 
 // for logging
-#  define DOCTEST_INFO(x) \
-    doctest::detail::ContextScope DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_)(doctest::detail::ContextBuilder() << x)
-#  define DOCTEST_CAPTURE(x) DOCTEST_INFO(#  x " := " << x)
+#define DOCTEST_INFO(x)                                                                            \
+    doctest::detail::ContextScope DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_)(                            \
+            doctest::detail::ContextBuilder() << x)
+#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := " << x)
 
-#  define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                   \
-    do                                                                                   \
-    {                                                                                    \
-      doctest::detail::MessageBuilder mb(file, line, doctest::detail::assertType::type); \
-      mb << x;                                                                           \
-      if(mb.log())                                                                       \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                   \
-      mb.react();                                                                        \
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                               \
+    do {                                                                                           \
+        doctest::detail::MessageBuilder mb(file, line, doctest::detail::assertType::type);         \
+        mb << x;                                                                                   \
+        if(mb.log())                                                                               \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
+        mb.react();                                                                                \
     } while((void)0, 0)
 
 // clang-format off
@@ -2506,73 +2357,68 @@ public:
 #define DOCTEST_ADD_FAIL_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
 // clang-format on
 
-#  define DOCTEST_MESSAGE(x) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, x)
-#  define DOCTEST_FAIL_CHECK(x) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, x)
-#  define DOCTEST_FAIL(x) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, x)
+#define DOCTEST_MESSAGE(x) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, x)
+#define DOCTEST_FAIL_CHECK(x) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, x)
+#define DOCTEST_FAIL(x) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, x)
 
-#  if __cplusplus >= 201402L || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 10, 0))
-template<class T, T x>
+#if __cplusplus >= 201402L || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 10, 0))
+template <class T, T x>
 constexpr T to_lvalue = x;
-#    define DOCTEST_TO_LVALUE(...) to_lvalue<decltype(__VA_ARGS__), __VA_ARGS__>
-#  else
-#    ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_TO_LVALUE(...) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
-#    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_TO_LVALUE(x) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
-#    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  endif   // TO_LVALUE hack for logging macros like INFO()
+#define DOCTEST_TO_LVALUE(...) to_lvalue<decltype(__VA_ARGS__), __VA_ARGS__>
+#else
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TO_LVALUE(...) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TO_LVALUE(x) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif // TO_LVALUE hack for logging macros like INFO()
 
 // common code in asserts - for convenience
-#  define DOCTEST_ASSERT_LOG_AND_REACT(rb) \
-    if(rb.log())                           \
-      DOCTEST_BREAK_INTO_DEBUGGER();       \
+#define DOCTEST_ASSERT_LOG_AND_REACT(rb)                                                           \
+    if(rb.log())                                                                                   \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
     rb.react()
 
-#  ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#    define DOCTEST_WRAP_IN_TRY(x) x;
-#  else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#    define DOCTEST_WRAP_IN_TRY(x)                 \
-      try                                          \
-      {                                            \
-        x;                                         \
-      }                                            \
-      catch(...)                                   \
-      {                                            \
-        _DOCTEST_RB.unexpectedExceptionOccurred(); \
-      }
-#  endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#define DOCTEST_WRAP_IN_TRY(x) x;
+#else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#define DOCTEST_WRAP_IN_TRY(x)                                                                     \
+    try {                                                                                          \
+        x;                                                                                         \
+    } catch(...) { _DOCTEST_RB.unexpectedExceptionOccurred(); }
+#endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
-#  define DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type)                                                       \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                             \
-    doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__,  \
-                                               DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));           \
-    DOCTEST_WRAP_IN_TRY(                                                                                      \
-        _DOCTEST_RB.setResult(doctest::detail::ExpressionDecomposer(doctest::detail::assertType::assert_type) \
-                              << DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                        \
-    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                                 \
+#define DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type)                                              \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
+    doctest::detail::ResultBuilder _DOCTEST_RB(                                                    \
+            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                          \
+            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));                                   \
+    DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.setResult(                                                     \
+            doctest::detail::ExpressionDecomposer(doctest::detail::assertType::assert_type)        \
+            << DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                               \
+    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                      \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#  define DOCTEST_ASSERT_IMPLEMENT_1(expr, assert_type) \
-    do                                                  \
-    {                                                   \
-      DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type);    \
+#define DOCTEST_ASSERT_IMPLEMENT_1(expr, assert_type)                                              \
+    do {                                                                                           \
+        DOCTEST_ASSERT_IMPLEMENT_2(expr, assert_type);                                             \
     } while((void)0, 0)
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN)
-#    define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK)
-#    define DOCTEST_REQUIRE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE)
-#    define DOCTEST_WARN_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN_FALSE)
-#    define DOCTEST_CHECK_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK_FALSE)
-#    define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE_FALSE)
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN)
-#    define DOCTEST_CHECK(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK)
-#    define DOCTEST_REQUIRE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE)
-#    define DOCTEST_WARN_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN_FALSE)
-#    define DOCTEST_CHECK_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK_FALSE)
-#    define DOCTEST_REQUIRE_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE_FALSE)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN)
+#define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK)
+#define DOCTEST_REQUIRE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE)
+#define DOCTEST_WARN_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_WARN_FALSE)
+#define DOCTEST_CHECK_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_CHECK_FALSE)
+#define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1((__VA_ARGS__), DT_REQUIRE_FALSE)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN)
+#define DOCTEST_CHECK(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK)
+#define DOCTEST_REQUIRE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE)
+#define DOCTEST_WARN_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_WARN_FALSE)
+#define DOCTEST_CHECK_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_CHECK_FALSE)
+#define DOCTEST_REQUIRE_FALSE(expr) DOCTEST_ASSERT_IMPLEMENT_1(expr, DT_REQUIRE_FALSE)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // clang-format off
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -2592,71 +2438,49 @@ constexpr T to_lvalue = x;
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 // clang-format on
 
-#  define DOCTEST_ASSERT_THROWS(expr, assert_type)                                                               \
-    do                                                                                                           \
-    {                                                                                                            \
-      if(!doctest::detail::getTestsContextState()->no_throw)                                                     \
-      {                                                                                                          \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                                   #expr);                                                       \
-        try                                                                                                      \
-        {                                                                                                        \
-          expr;                                                                                                  \
-        }                                                                                                        \
-        catch(...)                                                                                               \
-        {                                                                                                        \
-          _DOCTEST_RB.m_threw = true;                                                                            \
-        }                                                                                                        \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
-      }                                                                                                          \
+#define DOCTEST_ASSERT_THROWS(expr, assert_type)                                                   \
+    do {                                                                                           \
+        if(!doctest::detail::getTestsContextState()->no_throw) {                                   \
+            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type,   \
+                                                       __FILE__, __LINE__, #expr);                 \
+            try {                                                                                  \
+                expr;                                                                              \
+            } catch(...) { _DOCTEST_RB.m_threw = true; }                                           \
+            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
+        }                                                                                          \
     } while((void)0, 0)
 
-#  define DOCTEST_ASSERT_THROWS_AS(expr, as, assert_type)                                                        \
-    do                                                                                                           \
-    {                                                                                                            \
-      if(!doctest::detail::getTestsContextState()->no_throw)                                                     \
-      {                                                                                                          \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                                   #expr, DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(as)));     \
-        try                                                                                                      \
-        {                                                                                                        \
-          expr;                                                                                                  \
-        }                                                                                                        \
-        catch(const DOCTEST_HANDLE_BRACED_VA_ARGS(as) &)                                                         \
-        {                                                                                                        \
-          _DOCTEST_RB.m_threw = true;                                                                            \
-          _DOCTEST_RB.m_threw_as = true;                                                                         \
-        }                                                                                                        \
-        catch(...)                                                                                               \
-        {                                                                                                        \
-          _DOCTEST_RB.unexpectedExceptionOccurred();                                                             \
-        }                                                                                                        \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
-      }                                                                                                          \
+#define DOCTEST_ASSERT_THROWS_AS(expr, as, assert_type)                                            \
+    do {                                                                                           \
+        if(!doctest::detail::getTestsContextState()->no_throw) {                                   \
+            doctest::detail::ResultBuilder _DOCTEST_RB(                                            \
+                    doctest::detail::assertType::assert_type, __FILE__, __LINE__, #expr,           \
+                    DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(as)));                             \
+            try {                                                                                  \
+                expr;                                                                              \
+            } catch(const DOCTEST_HANDLE_BRACED_VA_ARGS(as)&) {                                    \
+                _DOCTEST_RB.m_threw    = true;                                                     \
+                _DOCTEST_RB.m_threw_as = true;                                                     \
+            } catch(...) { _DOCTEST_RB.unexpectedExceptionOccurred(); }                            \
+            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
+        }                                                                                          \
     } while((void)0, 0)
 
-#  define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                              \
-    do                                                                                                           \
-    {                                                                                                            \
-      if(!doctest::detail::getTestsContextState()->no_throw)                                                     \
-      {                                                                                                          \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                                   #expr);                                                       \
-        try                                                                                                      \
-        {                                                                                                        \
-          expr;                                                                                                  \
-        }                                                                                                        \
-        catch(...)                                                                                               \
-        {                                                                                                        \
-          _DOCTEST_RB.unexpectedExceptionOccurred();                                                             \
-        }                                                                                                        \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
-      }                                                                                                          \
+#define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                  \
+    do {                                                                                           \
+        if(!doctest::detail::getTestsContextState()->no_throw) {                                   \
+            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type,   \
+                                                       __FILE__, __LINE__, #expr);                 \
+            try {                                                                                  \
+                expr;                                                                              \
+            } catch(...) { _DOCTEST_RB.unexpectedExceptionOccurred(); }                            \
+            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
+        }                                                                                          \
     } while((void)0, 0)
 
-#  define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_WARN_THROWS)
-#  define DOCTEST_CHECK_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_CHECK_THROWS)
-#  define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_REQUIRE_THROWS)
+#define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_WARN_THROWS)
+#define DOCTEST_CHECK_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_CHECK_THROWS)
+#define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_REQUIRE_THROWS)
 
 // clang-format off
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -2670,9 +2494,9 @@ constexpr T to_lvalue = x;
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 // clang-format on
 
-#  define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)
-#  define DOCTEST_CHECK_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_CHECK_NOTHROW)
-#  define DOCTEST_REQUIRE_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_REQUIRE_NOTHROW)
+#define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)
+#define DOCTEST_CHECK_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_CHECK_NOTHROW)
+#define DOCTEST_REQUIRE_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_REQUIRE_NOTHROW)
 
 // clang-format off
 #define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS(expr); } while((void)0, 0)
@@ -2686,147 +2510,152 @@ constexpr T to_lvalue = x;
 #define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_NOTHROW(expr); } while((void)0, 0)
 // clang-format on
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_BINARY_ASSERT(assert_type, expr, comp)                                                       \
-      do                                                                                                         \
-      {                                                                                                          \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                                   DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));          \
-        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(            \
-            DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                                                \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
-      } while((void)0, 0)
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_BINARY_ASSERT(assert_type, lhs, rhs, comp)                                                   \
-      do                                                                                                         \
-      {                                                                                                          \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                                   #lhs ", " #rhs);                                              \
-        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(lhs, rhs))  \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
-      } while((void)0, 0)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_BINARY_ASSERT(assert_type, expr, comp)                                             \
+    do {                                                                                           \
+        doctest::detail::ResultBuilder _DOCTEST_RB(                                                \
+                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
+                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));                               \
+        DOCTEST_WRAP_IN_TRY(                                                                       \
+                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(          \
+                        DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                                      \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
+    } while((void)0, 0)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_BINARY_ASSERT(assert_type, lhs, rhs, comp)                                         \
+    do {                                                                                           \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type,       \
+                                                   __FILE__, __LINE__, #lhs ", " #rhs);            \
+        DOCTEST_WRAP_IN_TRY(                                                                       \
+                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(lhs,      \
+                                                                                         rhs))     \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
+    } while((void)0, 0)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#  define DOCTEST_UNARY_ASSERT(assert_type, expr)                                                              \
-    do                                                                                                         \
-    {                                                                                                          \
-      doctest::detail::ResultBuilder _DOCTEST_RB(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                                 DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));          \
-      DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))                       \
-      DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+#define DOCTEST_UNARY_ASSERT(assert_type, expr)                                                    \
+    do {                                                                                           \
+        doctest::detail::ResultBuilder _DOCTEST_RB(                                                \
+                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
+                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)));                               \
+        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)))         \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
     } while((void)0, 0)
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, (__VA_ARGS__), eq)
-#    define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, (__VA_ARGS__), eq)
-#    define DOCTEST_REQUIRE_EQ(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, (__VA_ARGS__), eq)
-#    define DOCTEST_WARN_NE(...) DOCTEST_BINARY_ASSERT(DT_WARN_NE, (__VA_ARGS__), ne)
-#    define DOCTEST_CHECK_NE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, (__VA_ARGS__), ne)
-#    define DOCTEST_REQUIRE_NE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, (__VA_ARGS__), ne)
-#    define DOCTEST_WARN_GT(...) DOCTEST_BINARY_ASSERT(DT_WARN_GT, (__VA_ARGS__), gt)
-#    define DOCTEST_CHECK_GT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, (__VA_ARGS__), gt)
-#    define DOCTEST_REQUIRE_GT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, (__VA_ARGS__), gt)
-#    define DOCTEST_WARN_LT(...) DOCTEST_BINARY_ASSERT(DT_WARN_LT, (__VA_ARGS__), lt)
-#    define DOCTEST_CHECK_LT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, (__VA_ARGS__), lt)
-#    define DOCTEST_REQUIRE_LT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, (__VA_ARGS__), lt)
-#    define DOCTEST_WARN_GE(...) DOCTEST_BINARY_ASSERT(DT_WARN_GE, (__VA_ARGS__), ge)
-#    define DOCTEST_CHECK_GE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, (__VA_ARGS__), ge)
-#    define DOCTEST_REQUIRE_GE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, (__VA_ARGS__), ge)
-#    define DOCTEST_WARN_LE(...) DOCTEST_BINARY_ASSERT(DT_WARN_LE, (__VA_ARGS__), le)
-#    define DOCTEST_CHECK_LE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, (__VA_ARGS__), le)
-#    define DOCTEST_REQUIRE_LE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, (__VA_ARGS__), le)
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, (__VA_ARGS__), eq)
+#define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, (__VA_ARGS__), eq)
+#define DOCTEST_REQUIRE_EQ(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, (__VA_ARGS__), eq)
+#define DOCTEST_WARN_NE(...) DOCTEST_BINARY_ASSERT(DT_WARN_NE, (__VA_ARGS__), ne)
+#define DOCTEST_CHECK_NE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, (__VA_ARGS__), ne)
+#define DOCTEST_REQUIRE_NE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, (__VA_ARGS__), ne)
+#define DOCTEST_WARN_GT(...) DOCTEST_BINARY_ASSERT(DT_WARN_GT, (__VA_ARGS__), gt)
+#define DOCTEST_CHECK_GT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, (__VA_ARGS__), gt)
+#define DOCTEST_REQUIRE_GT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, (__VA_ARGS__), gt)
+#define DOCTEST_WARN_LT(...) DOCTEST_BINARY_ASSERT(DT_WARN_LT, (__VA_ARGS__), lt)
+#define DOCTEST_CHECK_LT(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, (__VA_ARGS__), lt)
+#define DOCTEST_REQUIRE_LT(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, (__VA_ARGS__), lt)
+#define DOCTEST_WARN_GE(...) DOCTEST_BINARY_ASSERT(DT_WARN_GE, (__VA_ARGS__), ge)
+#define DOCTEST_CHECK_GE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, (__VA_ARGS__), ge)
+#define DOCTEST_REQUIRE_GE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, (__VA_ARGS__), ge)
+#define DOCTEST_WARN_LE(...) DOCTEST_BINARY_ASSERT(DT_WARN_LE, (__VA_ARGS__), le)
+#define DOCTEST_CHECK_LE(...) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, (__VA_ARGS__), le)
+#define DOCTEST_REQUIRE_LE(...) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, (__VA_ARGS__), le)
 
-#    define DOCTEST_WARN_UNARY(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, (__VA_ARGS__))
-#    define DOCTEST_CHECK_UNARY(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, (__VA_ARGS__))
-#    define DOCTEST_REQUIRE_UNARY(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, (__VA_ARGS__))
-#    define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, (__VA_ARGS__))
-#    define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, (__VA_ARGS__))
-#    define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, (__VA_ARGS__))
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, lhs, rhs, eq)
-#    define DOCTEST_CHECK_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, lhs, rhs, eq)
-#    define DOCTEST_REQUIRE_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, lhs, rhs, eq)
-#    define DOCTEST_WARN_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_NE, lhs, rhs, ne)
-#    define DOCTEST_CHECK_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, lhs, rhs, ne)
-#    define DOCTEST_REQUIRE_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, lhs, rhs, ne)
-#    define DOCTEST_WARN_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GT, lhs, rhs, gt)
-#    define DOCTEST_CHECK_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, lhs, rhs, gt)
-#    define DOCTEST_REQUIRE_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, lhs, rhs, gt)
-#    define DOCTEST_WARN_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LT, lhs, rhs, lt)
-#    define DOCTEST_CHECK_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, lhs, rhs, lt)
-#    define DOCTEST_REQUIRE_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, lhs, rhs, lt)
-#    define DOCTEST_WARN_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GE, lhs, rhs, ge)
-#    define DOCTEST_CHECK_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, lhs, rhs, ge)
-#    define DOCTEST_REQUIRE_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, lhs, rhs, ge)
-#    define DOCTEST_WARN_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LE, lhs, rhs, le)
-#    define DOCTEST_CHECK_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, lhs, rhs, le)
-#    define DOCTEST_REQUIRE_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, lhs, rhs, le)
+#define DOCTEST_WARN_UNARY(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, (__VA_ARGS__))
+#define DOCTEST_CHECK_UNARY(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, (__VA_ARGS__))
+#define DOCTEST_REQUIRE_UNARY(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, (__VA_ARGS__))
+#define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, (__VA_ARGS__))
+#define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, (__VA_ARGS__))
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, (__VA_ARGS__))
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, lhs, rhs, eq)
+#define DOCTEST_CHECK_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, lhs, rhs, eq)
+#define DOCTEST_REQUIRE_EQ(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_EQ, lhs, rhs, eq)
+#define DOCTEST_WARN_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_NE, lhs, rhs, ne)
+#define DOCTEST_CHECK_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_NE, lhs, rhs, ne)
+#define DOCTEST_REQUIRE_NE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_NE, lhs, rhs, ne)
+#define DOCTEST_WARN_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GT, lhs, rhs, gt)
+#define DOCTEST_CHECK_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GT, lhs, rhs, gt)
+#define DOCTEST_REQUIRE_GT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GT, lhs, rhs, gt)
+#define DOCTEST_WARN_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LT, lhs, rhs, lt)
+#define DOCTEST_CHECK_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LT, lhs, rhs, lt)
+#define DOCTEST_REQUIRE_LT(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LT, lhs, rhs, lt)
+#define DOCTEST_WARN_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_GE, lhs, rhs, ge)
+#define DOCTEST_CHECK_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_GE, lhs, rhs, ge)
+#define DOCTEST_REQUIRE_GE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_GE, lhs, rhs, ge)
+#define DOCTEST_WARN_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_WARN_LE, lhs, rhs, le)
+#define DOCTEST_CHECK_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_CHECK_LE, lhs, rhs, le)
+#define DOCTEST_REQUIRE_LE(lhs, rhs) DOCTEST_BINARY_ASSERT(DT_REQUIRE_LE, lhs, rhs, le)
 
-#    define DOCTEST_WARN_UNARY(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, v)
-#    define DOCTEST_CHECK_UNARY(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, v)
-#    define DOCTEST_REQUIRE_UNARY(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, v)
-#    define DOCTEST_WARN_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, v)
-#    define DOCTEST_CHECK_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, v)
-#    define DOCTEST_REQUIRE_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, v)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_UNARY(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY, v)
+#define DOCTEST_CHECK_UNARY(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY, v)
+#define DOCTEST_REQUIRE_UNARY(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY, v)
+#define DOCTEST_WARN_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_WARN_UNARY_FALSE, v)
+#define DOCTEST_CHECK_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, v)
+#define DOCTEST_REQUIRE_UNARY_FALSE(v) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, v)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#  ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#    ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                                     \
-        do                                                                                                  \
-        {                                                                                                   \
-          int _DOCTEST_FAST_RES =                                                                           \
-              doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(     \
-                  doctest::detail::assertType::assert_type, __FILE__, __LINE__,                             \
-                  DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)), DOCTEST_HANDLE_BRACED_VA_ARGS(expr)); \
-          if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                                   \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                                  \
-          doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                                     \
-        } while((void)0, 0)
-#    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                                \
-        do                                                                                                 \
-        {                                                                                                  \
-          int _DOCTEST_FAST_RES =                                                                          \
-              doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(    \
-                  doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs, rhs); \
-          if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                                  \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                                 \
-          doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                                    \
-        } while((void)0, 0)
-#    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                                  \
+    do {                                                                                           \
+        int _DOCTEST_FAST_RES = doctest::detail::fast_binary_assert<                               \
+                doctest::detail::binaryAssertComparison::comparison>(                              \
+                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
+                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),                                \
+                DOCTEST_HANDLE_BRACED_VA_ARGS(expr));                                              \
+        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                            \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
+        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                              \
+    } while((void)0, 0)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                              \
+    do {                                                                                           \
+        int _DOCTEST_FAST_RES = doctest::detail::fast_binary_assert<                               \
+                doctest::detail::binaryAssertComparison::comparison>(                              \
+                doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs, \
+                rhs);                                                                              \
+        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                            \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
+        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                              \
+    } while((void)0, 0)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#    define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                              \
-      do                                                                                              \
-      {                                                                                               \
-        int _DOCTEST_FAST_RES = doctest::detail::fast_unary_assert(                                   \
-            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                             \
-            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)), DOCTEST_HANDLE_BRACED_VA_ARGS(expr)); \
-        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                               \
-          DOCTEST_BREAK_INTO_DEBUGGER();                                                              \
-        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                                 \
-      } while((void)0, 0)
+#define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                               \
+    do {                                                                                           \
+        int _DOCTEST_FAST_RES = doctest::detail::fast_unary_assert(                                \
+                doctest::detail::assertType::assert_type, __FILE__, __LINE__,                      \
+                DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),                                \
+                DOCTEST_HANDLE_BRACED_VA_ARGS(expr));                                              \
+        if(_DOCTEST_FAST_RES & doctest::detail::assertAction::dbgbreak)                            \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
+        doctest::detail::fastAssertThrowIfFlagSet(_DOCTEST_FAST_RES);                              \
+    } while((void)0, 0)
 
-#  else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#    ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                           \
-        doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>( \
-            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                         \
-            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)), DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
-#    else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                       \
-        doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>( \
-            doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs, rhs)
-#    endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_FAST_BINARY_ASSERT(assert_type, expr, comparison)                                  \
+    doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(      \
+            doctest::detail::assertType::assert_type, __FILE__, __LINE__,                          \
+            DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),                                    \
+            DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_FAST_BINARY_ASSERT(assert_type, lhs, rhs, comparison)                              \
+    doctest::detail::fast_binary_assert<doctest::detail::binaryAssertComparison::comparison>(      \
+            doctest::detail::assertType::assert_type, __FILE__, __LINE__, #lhs ", " #rhs, lhs,     \
+            rhs)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#    define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                               \
-      doctest::detail::fast_unary_assert(doctest::detail::assertType::assert_type, __FILE__, __LINE__, \
-                                         DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),           \
-                                         DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
+#define DOCTEST_FAST_UNARY_ASSERT(assert_type, expr)                                               \
+    doctest::detail::fast_unary_assert(doctest::detail::assertType::assert_type, __FILE__,         \
+                                       __LINE__,                                                   \
+                                       DOCTEST_TOSTR(DOCTEST_HANDLE_BRACED_VA_ARGS(expr)),         \
+                                       DOCTEST_HANDLE_BRACED_VA_ARGS(expr))
 
-#  endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 // clang-format off
 #ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
@@ -2884,82 +2713,82 @@ constexpr T to_lvalue = x;
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 // clang-format on
 
-#  ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
+#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#    undef DOCTEST_WARN_THROWS
-#    undef DOCTEST_CHECK_THROWS
-#    undef DOCTEST_REQUIRE_THROWS
-#    undef DOCTEST_WARN_THROWS_AS
-#    undef DOCTEST_CHECK_THROWS_AS
-#    undef DOCTEST_REQUIRE_THROWS_AS
-#    undef DOCTEST_WARN_NOTHROW
-#    undef DOCTEST_CHECK_NOTHROW
-#    undef DOCTEST_REQUIRE_NOTHROW
+#undef DOCTEST_WARN_THROWS
+#undef DOCTEST_CHECK_THROWS
+#undef DOCTEST_REQUIRE_THROWS
+#undef DOCTEST_WARN_THROWS_AS
+#undef DOCTEST_CHECK_THROWS_AS
+#undef DOCTEST_REQUIRE_THROWS_AS
+#undef DOCTEST_WARN_NOTHROW
+#undef DOCTEST_CHECK_NOTHROW
+#undef DOCTEST_REQUIRE_NOTHROW
 
-#    undef DOCTEST_WARN_THROWS_MESSAGE
-#    undef DOCTEST_CHECK_THROWS_MESSAGE
-#    undef DOCTEST_REQUIRE_THROWS_MESSAGE
-#    undef DOCTEST_WARN_THROWS_AS_MESSAGE
-#    undef DOCTEST_CHECK_THROWS_AS_MESSAGE
-#    undef DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#    undef DOCTEST_WARN_NOTHROW_MESSAGE
-#    undef DOCTEST_CHECK_NOTHROW_MESSAGE
-#    undef DOCTEST_REQUIRE_NOTHROW_MESSAGE
+#undef DOCTEST_WARN_THROWS_MESSAGE
+#undef DOCTEST_CHECK_THROWS_MESSAGE
+#undef DOCTEST_REQUIRE_THROWS_MESSAGE
+#undef DOCTEST_WARN_THROWS_AS_MESSAGE
+#undef DOCTEST_CHECK_THROWS_AS_MESSAGE
+#undef DOCTEST_REQUIRE_THROWS_AS_MESSAGE
+#undef DOCTEST_WARN_NOTHROW_MESSAGE
+#undef DOCTEST_CHECK_NOTHROW_MESSAGE
+#undef DOCTEST_REQUIRE_NOTHROW_MESSAGE
 
-#    ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#      define DOCTEST_WARN_THROWS(expr) ((void)0)
-#      define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#      define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#      ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#        define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#        define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#        define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#      else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#        define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
-#        define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
-#        define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
-#      endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#      define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#      define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#      define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
+#define DOCTEST_WARN_THROWS(expr) ((void)0)
+#define DOCTEST_CHECK_THROWS(expr) ((void)0)
+#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
+#define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
+#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
+#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
 
-#      define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#      define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#      define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#      define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#      define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#      define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#      define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#      define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#      define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
 
-#    else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#      undef DOCTEST_REQUIRE
-#      undef DOCTEST_REQUIRE_FALSE
-#      undef DOCTEST_REQUIRE_MESSAGE
-#      undef DOCTEST_REQUIRE_FALSE_MESSAGE
-#      undef DOCTEST_REQUIRE_EQ
-#      undef DOCTEST_REQUIRE_NE
-#      undef DOCTEST_REQUIRE_GT
-#      undef DOCTEST_REQUIRE_LT
-#      undef DOCTEST_REQUIRE_GE
-#      undef DOCTEST_REQUIRE_LE
-#      undef DOCTEST_REQUIRE_UNARY
-#      undef DOCTEST_REQUIRE_UNARY_FALSE
-#      undef DOCTEST_FAST_REQUIRE_EQ
-#      undef DOCTEST_FAST_REQUIRE_NE
-#      undef DOCTEST_FAST_REQUIRE_GT
-#      undef DOCTEST_FAST_REQUIRE_LT
-#      undef DOCTEST_FAST_REQUIRE_GE
-#      undef DOCTEST_FAST_REQUIRE_LE
-#      undef DOCTEST_FAST_REQUIRE_UNARY
-#      undef DOCTEST_FAST_REQUIRE_UNARY_FALSE
+#undef DOCTEST_REQUIRE
+#undef DOCTEST_REQUIRE_FALSE
+#undef DOCTEST_REQUIRE_MESSAGE
+#undef DOCTEST_REQUIRE_FALSE_MESSAGE
+#undef DOCTEST_REQUIRE_EQ
+#undef DOCTEST_REQUIRE_NE
+#undef DOCTEST_REQUIRE_GT
+#undef DOCTEST_REQUIRE_LT
+#undef DOCTEST_REQUIRE_GE
+#undef DOCTEST_REQUIRE_LE
+#undef DOCTEST_REQUIRE_UNARY
+#undef DOCTEST_REQUIRE_UNARY_FALSE
+#undef DOCTEST_FAST_REQUIRE_EQ
+#undef DOCTEST_FAST_REQUIRE_NE
+#undef DOCTEST_FAST_REQUIRE_GT
+#undef DOCTEST_FAST_REQUIRE_LT
+#undef DOCTEST_FAST_REQUIRE_GE
+#undef DOCTEST_FAST_REQUIRE_LE
+#undef DOCTEST_FAST_REQUIRE_UNARY
+#undef DOCTEST_FAST_REQUIRE_UNARY_FALSE
 
-#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#  endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 // =================================================================================================
 // == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
@@ -2967,232 +2796,233 @@ constexpr T to_lvalue = x;
 // =================================================================================================
 #else // DOCTEST_CONFIG_DISABLE
 
-#  define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name) \
-    namespace                                              \
-    {                                                      \
-    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>        \
-    struct der : base                                      \
-    {                                                      \
-      void f();                                            \
-    };                                                     \
-    }                                                      \
-    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>        \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
+    namespace                                                                                      \
+    {                                                                                              \
+        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
+        struct der : base                                                                          \
+        { void f(); };                                                                             \
+    }                                                                                              \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
 
-#  define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name) \
-    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>     \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
     static inline void f()
 
 // for registering tests
-#  define DOCTEST_TEST_CASE(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE(name)                                                                    \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
 
 // for registering tests with a fixture
-#  define DOCTEST_TEST_CASE_FIXTURE(x, name) \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x, DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x,                          \
+                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#    define DOCTEST_TYPE_TO_STRING_IMPL(...)
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_TYPE_TO_STRING(x) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#    define DOCTEST_TYPE_TO_STRING_IMPL(x)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#define DOCTEST_TYPE_TO_STRING_IMPL(...)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_TYPE_TO_STRING(x) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#define DOCTEST_TYPE_TO_STRING_IMPL(x)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 // for typed tests
-#  define DOCTEST_TEST_CASE_TEMPLATE(name, type, types) \
-    template<typename type>                             \
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, types)                                              \
+    template <typename type>                                                                       \
     inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
 
-#  define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id) \
-    template<typename type>                                 \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
+    template <typename type>                                                                       \
     inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
 
-#  define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, types)                                          \
+    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for subcases
-#  define DOCTEST_SUBCASE(name)
+#define DOCTEST_SUBCASE(name)
 
 // for a testsuite block
-#  define DOCTEST_TEST_SUITE(name) namespace
+#define DOCTEST_TEST_SUITE(name) namespace
 
 // for starting a testsuite block
-#  define DOCTEST_TEST_SUITE_BEGIN(name) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#define DOCTEST_TEST_SUITE_BEGIN(name) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for ending a testsuite block
-#  define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
-#  define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature) \
-    template<typename DOCTEST_UNUSED_TEMPLATE_TYPE>        \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
     static inline doctest::String DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)(signature)
 
-#  define DOCTEST_INFO(x) ((void)0)
-#  define DOCTEST_CAPTURE(x) ((void)0)
-#  define DOCTEST_ADD_MESSAGE_AT(file, line, x) ((void)0)
-#  define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) ((void)0)
-#  define DOCTEST_ADD_FAIL_AT(file, line, x) ((void)0)
-#  define DOCTEST_MESSAGE(x) ((void)0)
-#  define DOCTEST_FAIL_CHECK(x) ((void)0)
-#  define DOCTEST_FAIL(x) ((void)0)
+#define DOCTEST_INFO(x) ((void)0)
+#define DOCTEST_CAPTURE(x) ((void)0)
+#define DOCTEST_ADD_MESSAGE_AT(file, line, x) ((void)0)
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) ((void)0)
+#define DOCTEST_ADD_FAIL_AT(file, line, x) ((void)0)
+#define DOCTEST_MESSAGE(x) ((void)0)
+#define DOCTEST_FAIL_CHECK(x) ((void)0)
+#define DOCTEST_FAIL(x) ((void)0)
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN(...) ((void)0)
-#    define DOCTEST_CHECK(...) ((void)0)
-#    define DOCTEST_REQUIRE(...) ((void)0)
-#    define DOCTEST_WARN_FALSE(...) ((void)0)
-#    define DOCTEST_CHECK_FALSE(...) ((void)0)
-#    define DOCTEST_REQUIRE_FALSE(...) ((void)0)
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN(expr) ((void)0)
-#    define DOCTEST_CHECK(expr) ((void)0)
-#    define DOCTEST_REQUIRE(expr) ((void)0)
-#    define DOCTEST_WARN_FALSE(expr) ((void)0)
-#    define DOCTEST_CHECK_FALSE(expr) ((void)0)
-#    define DOCTEST_REQUIRE_FALSE(expr) ((void)0)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN(...) ((void)0)
+#define DOCTEST_CHECK(...) ((void)0)
+#define DOCTEST_REQUIRE(...) ((void)0)
+#define DOCTEST_WARN_FALSE(...) ((void)0)
+#define DOCTEST_CHECK_FALSE(...) ((void)0)
+#define DOCTEST_REQUIRE_FALSE(...) ((void)0)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN(expr) ((void)0)
+#define DOCTEST_CHECK(expr) ((void)0)
+#define DOCTEST_REQUIRE(expr) ((void)0)
+#define DOCTEST_WARN_FALSE(expr) ((void)0)
+#define DOCTEST_CHECK_FALSE(expr) ((void)0)
+#define DOCTEST_REQUIRE_FALSE(expr) ((void)0)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#  define DOCTEST_WARN_MESSAGE(cond, msg) ((void)0)
-#  define DOCTEST_CHECK_MESSAGE(cond, msg) ((void)0)
-#  define DOCTEST_REQUIRE_MESSAGE(cond, msg) ((void)0)
-#  define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) ((void)0)
-#  define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) ((void)0)
-#  define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) ((void)0)
+#define DOCTEST_WARN_MESSAGE(cond, msg) ((void)0)
+#define DOCTEST_CHECK_MESSAGE(cond, msg) ((void)0)
+#define DOCTEST_REQUIRE_MESSAGE(cond, msg) ((void)0)
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) ((void)0)
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) ((void)0)
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) ((void)0)
 
-#  define DOCTEST_WARN_THROWS(expr) ((void)0)
-#  define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#  define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#    define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#    define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#    define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
-#    define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
-#    define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
-#  define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#  define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#  define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
+#define DOCTEST_WARN_THROWS(expr) ((void)0)
+#define DOCTEST_CHECK_THROWS(expr) ((void)0)
+#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_THROWS_AS(expr, ex) ((void)0)
+#define DOCTEST_CHECK_THROWS_AS(expr, ex) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ex) ((void)0)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
+#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
+#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
 
-#  define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#  define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#  define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#  define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#  define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#  define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#  define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#  define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#  define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
 
-#  ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#    define DOCTEST_WARN_EQ(...) ((void)0)
-#    define DOCTEST_CHECK_EQ(...) ((void)0)
-#    define DOCTEST_REQUIRE_EQ(...) ((void)0)
-#    define DOCTEST_WARN_NE(...) ((void)0)
-#    define DOCTEST_CHECK_NE(...) ((void)0)
-#    define DOCTEST_REQUIRE_NE(...) ((void)0)
-#    define DOCTEST_WARN_GT(...) ((void)0)
-#    define DOCTEST_CHECK_GT(...) ((void)0)
-#    define DOCTEST_REQUIRE_GT(...) ((void)0)
-#    define DOCTEST_WARN_LT(...) ((void)0)
-#    define DOCTEST_CHECK_LT(...) ((void)0)
-#    define DOCTEST_REQUIRE_LT(...) ((void)0)
-#    define DOCTEST_WARN_GE(...) ((void)0)
-#    define DOCTEST_CHECK_GE(...) ((void)0)
-#    define DOCTEST_REQUIRE_GE(...) ((void)0)
-#    define DOCTEST_WARN_LE(...) ((void)0)
-#    define DOCTEST_CHECK_LE(...) ((void)0)
-#    define DOCTEST_REQUIRE_LE(...) ((void)0)
+#define DOCTEST_WARN_EQ(...) ((void)0)
+#define DOCTEST_CHECK_EQ(...) ((void)0)
+#define DOCTEST_REQUIRE_EQ(...) ((void)0)
+#define DOCTEST_WARN_NE(...) ((void)0)
+#define DOCTEST_CHECK_NE(...) ((void)0)
+#define DOCTEST_REQUIRE_NE(...) ((void)0)
+#define DOCTEST_WARN_GT(...) ((void)0)
+#define DOCTEST_CHECK_GT(...) ((void)0)
+#define DOCTEST_REQUIRE_GT(...) ((void)0)
+#define DOCTEST_WARN_LT(...) ((void)0)
+#define DOCTEST_CHECK_LT(...) ((void)0)
+#define DOCTEST_REQUIRE_LT(...) ((void)0)
+#define DOCTEST_WARN_GE(...) ((void)0)
+#define DOCTEST_CHECK_GE(...) ((void)0)
+#define DOCTEST_REQUIRE_GE(...) ((void)0)
+#define DOCTEST_WARN_LE(...) ((void)0)
+#define DOCTEST_CHECK_LE(...) ((void)0)
+#define DOCTEST_REQUIRE_LE(...) ((void)0)
 
-#    define DOCTEST_WARN_UNARY(...) ((void)0)
-#    define DOCTEST_CHECK_UNARY(...) ((void)0)
-#    define DOCTEST_REQUIRE_UNARY(...) ((void)0)
-#    define DOCTEST_WARN_UNARY_FALSE(...) ((void)0)
-#    define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
-#    define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
+#define DOCTEST_WARN_UNARY(...) ((void)0)
+#define DOCTEST_CHECK_UNARY(...) ((void)0)
+#define DOCTEST_REQUIRE_UNARY(...) ((void)0)
+#define DOCTEST_WARN_UNARY_FALSE(...) ((void)0)
+#define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
 
-#    define DOCTEST_FAST_WARN_EQ(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_EQ(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_EQ(...) ((void)0)
-#    define DOCTEST_FAST_WARN_NE(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_NE(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_NE(...) ((void)0)
-#    define DOCTEST_FAST_WARN_GT(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_GT(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_GT(...) ((void)0)
-#    define DOCTEST_FAST_WARN_LT(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_LT(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_LT(...) ((void)0)
-#    define DOCTEST_FAST_WARN_GE(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_GE(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_GE(...) ((void)0)
-#    define DOCTEST_FAST_WARN_LE(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_LE(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_LE(...) ((void)0)
+#define DOCTEST_FAST_WARN_EQ(...) ((void)0)
+#define DOCTEST_FAST_CHECK_EQ(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_EQ(...) ((void)0)
+#define DOCTEST_FAST_WARN_NE(...) ((void)0)
+#define DOCTEST_FAST_CHECK_NE(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_NE(...) ((void)0)
+#define DOCTEST_FAST_WARN_GT(...) ((void)0)
+#define DOCTEST_FAST_CHECK_GT(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_GT(...) ((void)0)
+#define DOCTEST_FAST_WARN_LT(...) ((void)0)
+#define DOCTEST_FAST_CHECK_LT(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_LT(...) ((void)0)
+#define DOCTEST_FAST_WARN_GE(...) ((void)0)
+#define DOCTEST_FAST_CHECK_GE(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_GE(...) ((void)0)
+#define DOCTEST_FAST_WARN_LE(...) ((void)0)
+#define DOCTEST_FAST_CHECK_LE(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_LE(...) ((void)0)
 
-#    define DOCTEST_FAST_WARN_UNARY(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_UNARY(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_UNARY(...) ((void)0)
-#    define DOCTEST_FAST_WARN_UNARY_FALSE(...) ((void)0)
-#    define DOCTEST_FAST_CHECK_UNARY_FALSE(...) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_UNARY_FALSE(...) ((void)0)
+#define DOCTEST_FAST_WARN_UNARY(...) ((void)0)
+#define DOCTEST_FAST_CHECK_UNARY(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_UNARY(...) ((void)0)
+#define DOCTEST_FAST_WARN_UNARY_FALSE(...) ((void)0)
+#define DOCTEST_FAST_CHECK_UNARY_FALSE(...) ((void)0)
+#define DOCTEST_FAST_REQUIRE_UNARY_FALSE(...) ((void)0)
 
-#  else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
-#    define DOCTEST_WARN_EQ(lhs, rhs) ((void)0)
-#    define DOCTEST_CHECK_EQ(lhs, rhs) ((void)0)
-#    define DOCTEST_REQUIRE_EQ(lhs, rhs) ((void)0)
-#    define DOCTEST_WARN_NE(lhs, rhs) ((void)0)
-#    define DOCTEST_CHECK_NE(lhs, rhs) ((void)0)
-#    define DOCTEST_REQUIRE_NE(lhs, rhs) ((void)0)
-#    define DOCTEST_WARN_GT(lhs, rhs) ((void)0)
-#    define DOCTEST_CHECK_GT(lhs, rhs) ((void)0)
-#    define DOCTEST_REQUIRE_GT(lhs, rhs) ((void)0)
-#    define DOCTEST_WARN_LT(lhs, rhs) ((void)0)
-#    define DOCTEST_CHECK_LT(lhs, rhs) ((void)0)
-#    define DOCTEST_REQUIRE_LT(lhs, rhs) ((void)0)
-#    define DOCTEST_WARN_GE(lhs, rhs) ((void)0)
-#    define DOCTEST_CHECK_GE(lhs, rhs) ((void)0)
-#    define DOCTEST_REQUIRE_GE(lhs, rhs) ((void)0)
-#    define DOCTEST_WARN_LE(lhs, rhs) ((void)0)
-#    define DOCTEST_CHECK_LE(lhs, rhs) ((void)0)
-#    define DOCTEST_REQUIRE_LE(lhs, rhs) ((void)0)
+#define DOCTEST_WARN_EQ(lhs, rhs) ((void)0)
+#define DOCTEST_CHECK_EQ(lhs, rhs) ((void)0)
+#define DOCTEST_REQUIRE_EQ(lhs, rhs) ((void)0)
+#define DOCTEST_WARN_NE(lhs, rhs) ((void)0)
+#define DOCTEST_CHECK_NE(lhs, rhs) ((void)0)
+#define DOCTEST_REQUIRE_NE(lhs, rhs) ((void)0)
+#define DOCTEST_WARN_GT(lhs, rhs) ((void)0)
+#define DOCTEST_CHECK_GT(lhs, rhs) ((void)0)
+#define DOCTEST_REQUIRE_GT(lhs, rhs) ((void)0)
+#define DOCTEST_WARN_LT(lhs, rhs) ((void)0)
+#define DOCTEST_CHECK_LT(lhs, rhs) ((void)0)
+#define DOCTEST_REQUIRE_LT(lhs, rhs) ((void)0)
+#define DOCTEST_WARN_GE(lhs, rhs) ((void)0)
+#define DOCTEST_CHECK_GE(lhs, rhs) ((void)0)
+#define DOCTEST_REQUIRE_GE(lhs, rhs) ((void)0)
+#define DOCTEST_WARN_LE(lhs, rhs) ((void)0)
+#define DOCTEST_CHECK_LE(lhs, rhs) ((void)0)
+#define DOCTEST_REQUIRE_LE(lhs, rhs) ((void)0)
 
-#    define DOCTEST_WARN_UNARY(val) ((void)0)
-#    define DOCTEST_CHECK_UNARY(val) ((void)0)
-#    define DOCTEST_REQUIRE_UNARY(val) ((void)0)
-#    define DOCTEST_WARN_UNARY_FALSE(val) ((void)0)
-#    define DOCTEST_CHECK_UNARY_FALSE(val) ((void)0)
-#    define DOCTEST_REQUIRE_UNARY_FALSE(val) ((void)0)
+#define DOCTEST_WARN_UNARY(val) ((void)0)
+#define DOCTEST_CHECK_UNARY(val) ((void)0)
+#define DOCTEST_REQUIRE_UNARY(val) ((void)0)
+#define DOCTEST_WARN_UNARY_FALSE(val) ((void)0)
+#define DOCTEST_CHECK_UNARY_FALSE(val) ((void)0)
+#define DOCTEST_REQUIRE_UNARY_FALSE(val) ((void)0)
 
-#    define DOCTEST_FAST_WARN_EQ(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_CHECK_EQ(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_EQ(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_WARN_NE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_CHECK_NE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_NE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_WARN_GT(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_CHECK_GT(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_GT(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_WARN_LT(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_CHECK_LT(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_LT(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_WARN_GE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_CHECK_GE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_GE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_WARN_LE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_CHECK_LE(lhs, rhs) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_LE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_WARN_EQ(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_CHECK_EQ(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_REQUIRE_EQ(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_WARN_NE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_CHECK_NE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_REQUIRE_NE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_WARN_GT(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_CHECK_GT(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_REQUIRE_GT(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_WARN_LT(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_CHECK_LT(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_REQUIRE_LT(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_WARN_GE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_CHECK_GE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_REQUIRE_GE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_WARN_LE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_CHECK_LE(lhs, rhs) ((void)0)
+#define DOCTEST_FAST_REQUIRE_LE(lhs, rhs) ((void)0)
 
-#    define DOCTEST_FAST_WARN_UNARY(val) ((void)0)
-#    define DOCTEST_FAST_CHECK_UNARY(val) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_UNARY(val) ((void)0)
-#    define DOCTEST_FAST_WARN_UNARY_FALSE(val) ((void)0)
-#    define DOCTEST_FAST_CHECK_UNARY_FALSE(val) ((void)0)
-#    define DOCTEST_FAST_REQUIRE_UNARY_FALSE(val) ((void)0)
+#define DOCTEST_FAST_WARN_UNARY(val) ((void)0)
+#define DOCTEST_FAST_CHECK_UNARY(val) ((void)0)
+#define DOCTEST_FAST_REQUIRE_UNARY(val) ((void)0)
+#define DOCTEST_FAST_WARN_UNARY_FALSE(val) ((void)0)
+#define DOCTEST_FAST_CHECK_UNARY_FALSE(val) ((void)0)
+#define DOCTEST_FAST_REQUIRE_UNARY_FALSE(val) ((void)0)
 
-#  endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -3216,117 +3046,117 @@ constexpr T to_lvalue = x;
 // == SHORT VERSIONS OF THE MACROS
 #if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
 
-#  define TEST_CASE DOCTEST_TEST_CASE
-#  define TEST_CASE_FIXTURE DOCTEST_TEST_CASE_FIXTURE
-#  define TYPE_TO_STRING DOCTEST_TYPE_TO_STRING
-#  define TEST_CASE_TEMPLATE DOCTEST_TEST_CASE_TEMPLATE
-#  define TEST_CASE_TEMPLATE_DEFINE DOCTEST_TEST_CASE_TEMPLATE_DEFINE
-#  define TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE
-#  define SUBCASE DOCTEST_SUBCASE
-#  define TEST_SUITE DOCTEST_TEST_SUITE
-#  define TEST_SUITE_BEGIN DOCTEST_TEST_SUITE_BEGIN
-#  define TEST_SUITE_END DOCTEST_TEST_SUITE_END
-#  define REGISTER_EXCEPTION_TRANSLATOR DOCTEST_REGISTER_EXCEPTION_TRANSLATOR
-#  define INFO DOCTEST_INFO
-#  define CAPTURE DOCTEST_CAPTURE
-#  define ADD_MESSAGE_AT DOCTEST_ADD_MESSAGE_AT
-#  define ADD_FAIL_CHECK_AT DOCTEST_ADD_FAIL_CHECK_AT
-#  define ADD_FAIL_AT DOCTEST_ADD_FAIL_AT
-#  define MESSAGE DOCTEST_MESSAGE
-#  define FAIL_CHECK DOCTEST_FAIL_CHECK
-#  define FAIL DOCTEST_FAIL
-#  define TO_LVALUE DOCTEST_TO_LVALUE
+#define TEST_CASE DOCTEST_TEST_CASE
+#define TEST_CASE_FIXTURE DOCTEST_TEST_CASE_FIXTURE
+#define TYPE_TO_STRING DOCTEST_TYPE_TO_STRING
+#define TEST_CASE_TEMPLATE DOCTEST_TEST_CASE_TEMPLATE
+#define TEST_CASE_TEMPLATE_DEFINE DOCTEST_TEST_CASE_TEMPLATE_DEFINE
+#define TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE
+#define SUBCASE DOCTEST_SUBCASE
+#define TEST_SUITE DOCTEST_TEST_SUITE
+#define TEST_SUITE_BEGIN DOCTEST_TEST_SUITE_BEGIN
+#define TEST_SUITE_END DOCTEST_TEST_SUITE_END
+#define REGISTER_EXCEPTION_TRANSLATOR DOCTEST_REGISTER_EXCEPTION_TRANSLATOR
+#define INFO DOCTEST_INFO
+#define CAPTURE DOCTEST_CAPTURE
+#define ADD_MESSAGE_AT DOCTEST_ADD_MESSAGE_AT
+#define ADD_FAIL_CHECK_AT DOCTEST_ADD_FAIL_CHECK_AT
+#define ADD_FAIL_AT DOCTEST_ADD_FAIL_AT
+#define MESSAGE DOCTEST_MESSAGE
+#define FAIL_CHECK DOCTEST_FAIL_CHECK
+#define FAIL DOCTEST_FAIL
+#define TO_LVALUE DOCTEST_TO_LVALUE
 
-#  define WARN DOCTEST_WARN
-#  define WARN_FALSE DOCTEST_WARN_FALSE
-#  define WARN_THROWS DOCTEST_WARN_THROWS
-#  define WARN_THROWS_AS DOCTEST_WARN_THROWS_AS
-#  define WARN_NOTHROW DOCTEST_WARN_NOTHROW
-#  define CHECK DOCTEST_CHECK
-#  define CHECK_FALSE DOCTEST_CHECK_FALSE
-#  define CHECK_THROWS DOCTEST_CHECK_THROWS
-#  define CHECK_THROWS_AS DOCTEST_CHECK_THROWS_AS
-#  define CHECK_NOTHROW DOCTEST_CHECK_NOTHROW
-#  define REQUIRE DOCTEST_REQUIRE
-#  define REQUIRE_FALSE DOCTEST_REQUIRE_FALSE
-#  define REQUIRE_THROWS DOCTEST_REQUIRE_THROWS
-#  define REQUIRE_THROWS_AS DOCTEST_REQUIRE_THROWS_AS
-#  define REQUIRE_NOTHROW DOCTEST_REQUIRE_NOTHROW
+#define WARN DOCTEST_WARN
+#define WARN_FALSE DOCTEST_WARN_FALSE
+#define WARN_THROWS DOCTEST_WARN_THROWS
+#define WARN_THROWS_AS DOCTEST_WARN_THROWS_AS
+#define WARN_NOTHROW DOCTEST_WARN_NOTHROW
+#define CHECK DOCTEST_CHECK
+#define CHECK_FALSE DOCTEST_CHECK_FALSE
+#define CHECK_THROWS DOCTEST_CHECK_THROWS
+#define CHECK_THROWS_AS DOCTEST_CHECK_THROWS_AS
+#define CHECK_NOTHROW DOCTEST_CHECK_NOTHROW
+#define REQUIRE DOCTEST_REQUIRE
+#define REQUIRE_FALSE DOCTEST_REQUIRE_FALSE
+#define REQUIRE_THROWS DOCTEST_REQUIRE_THROWS
+#define REQUIRE_THROWS_AS DOCTEST_REQUIRE_THROWS_AS
+#define REQUIRE_NOTHROW DOCTEST_REQUIRE_NOTHROW
 
-#  define WARN_MESSAGE DOCTEST_WARN_MESSAGE
-#  define WARN_FALSE_MESSAGE DOCTEST_WARN_FALSE_MESSAGE
-#  define WARN_THROWS_MESSAGE DOCTEST_WARN_THROWS_MESSAGE
-#  define WARN_THROWS_AS_MESSAGE DOCTEST_WARN_THROWS_AS_MESSAGE
-#  define WARN_NOTHROW_MESSAGE DOCTEST_WARN_NOTHROW_MESSAGE
-#  define CHECK_MESSAGE DOCTEST_CHECK_MESSAGE
-#  define CHECK_FALSE_MESSAGE DOCTEST_CHECK_FALSE_MESSAGE
-#  define CHECK_THROWS_MESSAGE DOCTEST_CHECK_THROWS_MESSAGE
-#  define CHECK_THROWS_AS_MESSAGE DOCTEST_CHECK_THROWS_AS_MESSAGE
-#  define CHECK_NOTHROW_MESSAGE DOCTEST_CHECK_NOTHROW_MESSAGE
-#  define REQUIRE_MESSAGE DOCTEST_REQUIRE_MESSAGE
-#  define REQUIRE_FALSE_MESSAGE DOCTEST_REQUIRE_FALSE_MESSAGE
-#  define REQUIRE_THROWS_MESSAGE DOCTEST_REQUIRE_THROWS_MESSAGE
-#  define REQUIRE_THROWS_AS_MESSAGE DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#  define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
+#define WARN_MESSAGE DOCTEST_WARN_MESSAGE
+#define WARN_FALSE_MESSAGE DOCTEST_WARN_FALSE_MESSAGE
+#define WARN_THROWS_MESSAGE DOCTEST_WARN_THROWS_MESSAGE
+#define WARN_THROWS_AS_MESSAGE DOCTEST_WARN_THROWS_AS_MESSAGE
+#define WARN_NOTHROW_MESSAGE DOCTEST_WARN_NOTHROW_MESSAGE
+#define CHECK_MESSAGE DOCTEST_CHECK_MESSAGE
+#define CHECK_FALSE_MESSAGE DOCTEST_CHECK_FALSE_MESSAGE
+#define CHECK_THROWS_MESSAGE DOCTEST_CHECK_THROWS_MESSAGE
+#define CHECK_THROWS_AS_MESSAGE DOCTEST_CHECK_THROWS_AS_MESSAGE
+#define CHECK_NOTHROW_MESSAGE DOCTEST_CHECK_NOTHROW_MESSAGE
+#define REQUIRE_MESSAGE DOCTEST_REQUIRE_MESSAGE
+#define REQUIRE_FALSE_MESSAGE DOCTEST_REQUIRE_FALSE_MESSAGE
+#define REQUIRE_THROWS_MESSAGE DOCTEST_REQUIRE_THROWS_MESSAGE
+#define REQUIRE_THROWS_AS_MESSAGE DOCTEST_REQUIRE_THROWS_AS_MESSAGE
+#define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
 
-#  define SCENARIO DOCTEST_SCENARIO
-#  define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
-#  define SCENARIO_TEMPLATE_DEFINE DOCTEST_SCENARIO_TEMPLATE_DEFINE
-#  define GIVEN DOCTEST_GIVEN
-#  define WHEN DOCTEST_WHEN
-#  define AND_WHEN DOCTEST_AND_WHEN
-#  define THEN DOCTEST_THEN
-#  define AND_THEN DOCTEST_AND_THEN
+#define SCENARIO DOCTEST_SCENARIO
+#define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
+#define SCENARIO_TEMPLATE_DEFINE DOCTEST_SCENARIO_TEMPLATE_DEFINE
+#define GIVEN DOCTEST_GIVEN
+#define WHEN DOCTEST_WHEN
+#define AND_WHEN DOCTEST_AND_WHEN
+#define THEN DOCTEST_THEN
+#define AND_THEN DOCTEST_AND_THEN
 
-#  define WARN_EQ DOCTEST_WARN_EQ
-#  define CHECK_EQ DOCTEST_CHECK_EQ
-#  define REQUIRE_EQ DOCTEST_REQUIRE_EQ
-#  define WARN_NE DOCTEST_WARN_NE
-#  define CHECK_NE DOCTEST_CHECK_NE
-#  define REQUIRE_NE DOCTEST_REQUIRE_NE
-#  define WARN_GT DOCTEST_WARN_GT
-#  define CHECK_GT DOCTEST_CHECK_GT
-#  define REQUIRE_GT DOCTEST_REQUIRE_GT
-#  define WARN_LT DOCTEST_WARN_LT
-#  define CHECK_LT DOCTEST_CHECK_LT
-#  define REQUIRE_LT DOCTEST_REQUIRE_LT
-#  define WARN_GE DOCTEST_WARN_GE
-#  define CHECK_GE DOCTEST_CHECK_GE
-#  define REQUIRE_GE DOCTEST_REQUIRE_GE
-#  define WARN_LE DOCTEST_WARN_LE
-#  define CHECK_LE DOCTEST_CHECK_LE
-#  define REQUIRE_LE DOCTEST_REQUIRE_LE
-#  define WARN_UNARY DOCTEST_WARN_UNARY
-#  define CHECK_UNARY DOCTEST_CHECK_UNARY
-#  define REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
-#  define WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
-#  define CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
-#  define REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
+#define WARN_EQ DOCTEST_WARN_EQ
+#define CHECK_EQ DOCTEST_CHECK_EQ
+#define REQUIRE_EQ DOCTEST_REQUIRE_EQ
+#define WARN_NE DOCTEST_WARN_NE
+#define CHECK_NE DOCTEST_CHECK_NE
+#define REQUIRE_NE DOCTEST_REQUIRE_NE
+#define WARN_GT DOCTEST_WARN_GT
+#define CHECK_GT DOCTEST_CHECK_GT
+#define REQUIRE_GT DOCTEST_REQUIRE_GT
+#define WARN_LT DOCTEST_WARN_LT
+#define CHECK_LT DOCTEST_CHECK_LT
+#define REQUIRE_LT DOCTEST_REQUIRE_LT
+#define WARN_GE DOCTEST_WARN_GE
+#define CHECK_GE DOCTEST_CHECK_GE
+#define REQUIRE_GE DOCTEST_REQUIRE_GE
+#define WARN_LE DOCTEST_WARN_LE
+#define CHECK_LE DOCTEST_CHECK_LE
+#define REQUIRE_LE DOCTEST_REQUIRE_LE
+#define WARN_UNARY DOCTEST_WARN_UNARY
+#define CHECK_UNARY DOCTEST_CHECK_UNARY
+#define REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
+#define WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
+#define CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
+#define REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
 
-#  define FAST_WARN_EQ DOCTEST_FAST_WARN_EQ
-#  define FAST_CHECK_EQ DOCTEST_FAST_CHECK_EQ
-#  define FAST_REQUIRE_EQ DOCTEST_FAST_REQUIRE_EQ
-#  define FAST_WARN_NE DOCTEST_FAST_WARN_NE
-#  define FAST_CHECK_NE DOCTEST_FAST_CHECK_NE
-#  define FAST_REQUIRE_NE DOCTEST_FAST_REQUIRE_NE
-#  define FAST_WARN_GT DOCTEST_FAST_WARN_GT
-#  define FAST_CHECK_GT DOCTEST_FAST_CHECK_GT
-#  define FAST_REQUIRE_GT DOCTEST_FAST_REQUIRE_GT
-#  define FAST_WARN_LT DOCTEST_FAST_WARN_LT
-#  define FAST_CHECK_LT DOCTEST_FAST_CHECK_LT
-#  define FAST_REQUIRE_LT DOCTEST_FAST_REQUIRE_LT
-#  define FAST_WARN_GE DOCTEST_FAST_WARN_GE
-#  define FAST_CHECK_GE DOCTEST_FAST_CHECK_GE
-#  define FAST_REQUIRE_GE DOCTEST_FAST_REQUIRE_GE
-#  define FAST_WARN_LE DOCTEST_FAST_WARN_LE
-#  define FAST_CHECK_LE DOCTEST_FAST_CHECK_LE
-#  define FAST_REQUIRE_LE DOCTEST_FAST_REQUIRE_LE
-#  define FAST_WARN_UNARY DOCTEST_FAST_WARN_UNARY
-#  define FAST_CHECK_UNARY DOCTEST_FAST_CHECK_UNARY
-#  define FAST_REQUIRE_UNARY DOCTEST_FAST_REQUIRE_UNARY
-#  define FAST_WARN_UNARY_FALSE DOCTEST_FAST_WARN_UNARY_FALSE
-#  define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
-#  define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
+#define FAST_WARN_EQ DOCTEST_FAST_WARN_EQ
+#define FAST_CHECK_EQ DOCTEST_FAST_CHECK_EQ
+#define FAST_REQUIRE_EQ DOCTEST_FAST_REQUIRE_EQ
+#define FAST_WARN_NE DOCTEST_FAST_WARN_NE
+#define FAST_CHECK_NE DOCTEST_FAST_CHECK_NE
+#define FAST_REQUIRE_NE DOCTEST_FAST_REQUIRE_NE
+#define FAST_WARN_GT DOCTEST_FAST_WARN_GT
+#define FAST_CHECK_GT DOCTEST_FAST_CHECK_GT
+#define FAST_REQUIRE_GT DOCTEST_FAST_REQUIRE_GT
+#define FAST_WARN_LT DOCTEST_FAST_WARN_LT
+#define FAST_CHECK_LT DOCTEST_FAST_CHECK_LT
+#define FAST_REQUIRE_LT DOCTEST_FAST_REQUIRE_LT
+#define FAST_WARN_GE DOCTEST_FAST_WARN_GE
+#define FAST_CHECK_GE DOCTEST_FAST_CHECK_GE
+#define FAST_REQUIRE_GE DOCTEST_FAST_REQUIRE_GE
+#define FAST_WARN_LE DOCTEST_FAST_WARN_LE
+#define FAST_CHECK_LE DOCTEST_FAST_CHECK_LE
+#define FAST_REQUIRE_LE DOCTEST_FAST_REQUIRE_LE
+#define FAST_WARN_UNARY DOCTEST_FAST_WARN_UNARY
+#define FAST_CHECK_UNARY DOCTEST_FAST_CHECK_UNARY
+#define FAST_REQUIRE_UNARY DOCTEST_FAST_REQUIRE_UNARY
+#define FAST_WARN_UNARY_FALSE DOCTEST_FAST_WARN_UNARY_FALSE
+#define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
+#define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
 
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
@@ -3338,23 +3168,23 @@ namespace doctest
 {
 namespace detail
 {
-DOCTEST_TYPE_TO_STRING_IMPL(bool)
-DOCTEST_TYPE_TO_STRING_IMPL(float)
-DOCTEST_TYPE_TO_STRING_IMPL(double)
-DOCTEST_TYPE_TO_STRING_IMPL(long double)
-DOCTEST_TYPE_TO_STRING_IMPL(char)
-DOCTEST_TYPE_TO_STRING_IMPL(signed char)
-DOCTEST_TYPE_TO_STRING_IMPL(unsigned char)
-DOCTEST_TYPE_TO_STRING_IMPL(wchar_t)
-DOCTEST_TYPE_TO_STRING_IMPL(short int)
-DOCTEST_TYPE_TO_STRING_IMPL(unsigned short int)
-DOCTEST_TYPE_TO_STRING_IMPL(int)
-DOCTEST_TYPE_TO_STRING_IMPL(unsigned int)
-DOCTEST_TYPE_TO_STRING_IMPL(long int)
-DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
+    DOCTEST_TYPE_TO_STRING_IMPL(bool)
+    DOCTEST_TYPE_TO_STRING_IMPL(float)
+    DOCTEST_TYPE_TO_STRING_IMPL(double)
+    DOCTEST_TYPE_TO_STRING_IMPL(long double)
+    DOCTEST_TYPE_TO_STRING_IMPL(char)
+    DOCTEST_TYPE_TO_STRING_IMPL(signed char)
+    DOCTEST_TYPE_TO_STRING_IMPL(unsigned char)
+    DOCTEST_TYPE_TO_STRING_IMPL(wchar_t)
+    DOCTEST_TYPE_TO_STRING_IMPL(short int)
+    DOCTEST_TYPE_TO_STRING_IMPL(unsigned short int)
+    DOCTEST_TYPE_TO_STRING_IMPL(int)
+    DOCTEST_TYPE_TO_STRING_IMPL(unsigned int)
+    DOCTEST_TYPE_TO_STRING_IMPL(long int)
+    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
 #ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-DOCTEST_TYPE_TO_STRING_IMPL(long long int)
-DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
+    DOCTEST_TYPE_TO_STRING_IMPL(long long int)
+    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
 #endif // DOCTEST_CONFIG_WITH_LONG_LONG
 } // namespace detail
 } // namespace doctest
@@ -3371,11 +3201,11 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT) || !defined(DOCTEST_SINGLE_HEADER)
 #ifndef DOCTEST_LIBRARY_IMPLEMENTATION
-#  define DOCTEST_LIBRARY_IMPLEMENTATION
+#define DOCTEST_LIBRARY_IMPLEMENTATION
 
-#  ifndef DOCTEST_SINGLE_HEADER
-#    include "doctest_fwd.h"
-#  endif // DOCTEST_SINGLE_HEADER
+#ifndef DOCTEST_SINGLE_HEADER
+#include "doctest_fwd.h"
+#endif // DOCTEST_SINGLE_HEADER
 
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
@@ -3395,9 +3225,9 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++11-long-long")
-#  if DOCTEST_CLANG && DOCTEST_CLANG_HAS_WARNING("-Wzero-as-null-pointer-constant")
+#if DOCTEST_CLANG && DOCTEST_CLANG_HAS_WARNING("-Wzero-as-null-pointer-constant")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wzero-as-null-pointer-constant")
-#  endif // clang - 0 as null
+#endif // clang - 0 as null
 
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")
@@ -3415,15 +3245,15 @@ DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wlong-long")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 7, 0)
 DOCTEST_GCC_SUPPRESS_WARNING("-Wzero-as-null-pointer-constant")
-#  endif // GCC 4.7+
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(4, 8, 0)
+#endif // GCC 4.7+
+#if DOCTEST_GCC >= DOCTEST_COMPILER(4, 8, 0)
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
-#  endif // GCC 4.8+
-#  if DOCTEST_GCC >= DOCTEST_COMPILER(5, 4, 0)
+#endif // GCC 4.8+
+#if DOCTEST_GCC >= DOCTEST_COMPILER(5, 4, 0)
 DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
-#  endif // GCC 5.4+
+#endif // GCC 5.4+
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
 DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
@@ -3440,55 +3270,53 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4365) // conversion from 'int' to 'unsigned', sign
 DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding in structs
 DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
 
-#  if defined(DOCTEST_NO_CPP11_COMPAT)
+#if defined(DOCTEST_NO_CPP11_COMPAT)
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
-#  endif // DOCTEST_NO_CPP11_COMPAT
+#endif // DOCTEST_NO_CPP11_COMPAT
 
 // snprintf() not in the C++98 standard
-#  if DOCTEST_MSVC
-#    define DOCTEST_SNPRINTF _snprintf
-#  else // MSVC
-#    define DOCTEST_SNPRINTF std::snprintf
-#  endif // MSVC
+#if DOCTEST_MSVC
+#define DOCTEST_SNPRINTF _snprintf
+#else // MSVC
+#define DOCTEST_SNPRINTF std::snprintf
+#endif // MSVC
 
-#  define DOCTEST_LOG_START()                           \
-    do                                                  \
-    {                                                   \
-      if(!contextState->hasLoggedCurrentTestStart)      \
-      {                                                 \
-        logTestStart(*contextState->currentTest);       \
-        contextState->hasLoggedCurrentTestStart = true; \
-      }                                                 \
+#define DOCTEST_LOG_START()                                                                        \
+    do {                                                                                           \
+        if(!contextState->hasLoggedCurrentTestStart) {                                             \
+            logTestStart(*contextState->currentTest);                                              \
+            contextState->hasLoggedCurrentTestStart = true;                                        \
+        }                                                                                          \
     } while(false)
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
 // required includes - will go only in one translation unit!
-#  include <ctime>
-#  include <cmath>
+#include <ctime>
+#include <cmath>
 // borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/onqtam/doctest/pull/37
-#  ifdef __BORLANDC__
-#    include <math.h>
-#  endif // __BORLANDC__
-#  include <new>
-#  include <cstdio>
-#  include <cstdlib>
-#  include <cstring>
-#  include <limits>
-#  include <utility>
-#  include <sstream>
-#  include <algorithm>
-#  include <iomanip>
-#  include <vector>
-#  include <set>
-#  include <exception>
-#  include <stdexcept>
-#  include <csignal>
-#  include <cfloat>
-#  if !DOCTEST_MSVC
-#    include <stdint.h>
-#  endif // !MSVC
+#ifdef __BORLANDC__
+#include <math.h>
+#endif // __BORLANDC__
+#include <new>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <utility>
+#include <sstream>
+#include <algorithm>
+#include <iomanip>
+#include <vector>
+#include <set>
+#include <exception>
+#include <stdexcept>
+#include <csignal>
+#include <cfloat>
+#if !DOCTEST_MSVC
+#include <stdint.h>
+#endif // !MSVC
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
@@ -3496,514 +3324,470 @@ namespace doctest
 {
 namespace detail
 {
-// lowers ascii letters
-char tolower(const char c) { return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c; }
+    // lowers ascii letters
+    char tolower(const char c) { return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c; }
 
-template<typename T>
-T my_max(const T & lhs, const T & rhs)
-{
-  return lhs > rhs ? lhs : rhs;
-}
+    template <typename T>
+    T my_max(const T& lhs, const T& rhs) {
+        return lhs > rhs ? lhs : rhs;
+    }
 
-// case insensitive strcmp
-int stricmp(char const * a, char const * b)
-{
-  for(;; a++, b++)
-  {
-    const int d = tolower(*a) - tolower(*b);
-    if(d != 0 || !*a)
-      return d;
-  }
-}
+    // case insensitive strcmp
+    int stricmp(char const* a, char const* b) {
+        for(;; a++, b++) {
+            const int d = tolower(*a) - tolower(*b);
+            if(d != 0 || !*a)
+                return d;
+        }
+    }
 
-void my_memcpy(void * dest, const void * src, unsigned num)
-{
-  const char * csrc = static_cast<const char *>(src);
-  char * cdest = static_cast<char *>(dest);
-  for(unsigned i = 0; i < num; ++i)
-    cdest[i] = csrc[i];
-}
+    void my_memcpy(void* dest, const void* src, unsigned num) {
+        const char* csrc  = static_cast<const char*>(src);
+        char*       cdest = static_cast<char*>(dest);
+        for(unsigned i = 0; i < num; ++i)
+            cdest[i] = csrc[i];
+    }
 
-// not using std::strlen() because of valgrind errors when optimizations are turned on
-// 'Invalid read of size 4' when the test suite len (with '\0') is not a multiple of 4
-// for details see http://stackoverflow.com/questions/35671155
-unsigned my_strlen(const char * in)
-{
-  const char * temp = in;
-  while(temp && *temp)
-    ++temp;
-  return unsigned(temp - in);
-}
+    // not using std::strlen() because of valgrind errors when optimizations are turned on
+    // 'Invalid read of size 4' when the test suite len (with '\0') is not a multiple of 4
+    // for details see http://stackoverflow.com/questions/35671155
+    unsigned my_strlen(const char* in) {
+        const char* temp = in;
+        while(temp && *temp)
+            ++temp;
+        return unsigned(temp - in);
+    }
 
-template<typename T>
-String fpToString(T value, int precision)
-{
-  std::ostringstream oss;
-  oss << std::setprecision(precision) << std::fixed << value;
-  std::string d = oss.str();
-  size_t i = d.find_last_not_of('0');
-  if(i != std::string::npos && i != d.size() - 1)
-  {
-    if(d[i] == '.')
-      i++;
-    d = d.substr(0, i + 1);
-  }
-  return d.c_str();
-}
+    template <typename T>
+    String fpToString(T value, int precision) {
+        std::ostringstream oss;
+        oss << std::setprecision(precision) << std::fixed << value;
+        std::string d = oss.str();
+        size_t      i = d.find_last_not_of('0');
+        if(i != std::string::npos && i != d.size() - 1) {
+            if(d[i] == '.')
+                i++;
+            d = d.substr(0, i + 1);
+        }
+        return d.c_str();
+    }
 
-struct Endianness
-{
-  enum Arch
-  {
-    Big,
-    Little
-  };
+    struct Endianness
+    {
+        enum Arch
+        {
+            Big,
+            Little
+        };
 
-  static Arch which()
-  {
-    union _ {
-      int asInt;
-      char asChar[sizeof(int)];
-    } u;
+        static Arch which() {
+            union _
+            {
+                int  asInt;
+                char asChar[sizeof(int)];
+            } u;
 
-    u.asInt = 1;                                            // NOLINT
-    return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
-  }
-};
+            u.asInt = 1;                                            // NOLINT
+            return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
+        }
+    };
 
-String rawMemoryToString(const void * object, unsigned size)
-{
-  // Reverse order for little endian architectures
-  int i = 0, end = static_cast<int>(size), inc = 1;
-  if(Endianness::which() == Endianness::Little)
-  {
-    i = end - 1;
-    end = inc = -1;
-  }
+    String rawMemoryToString(const void* object, unsigned size) {
+        // Reverse order for little endian architectures
+        int i = 0, end = static_cast<int>(size), inc = 1;
+        if(Endianness::which() == Endianness::Little) {
+            i   = end - 1;
+            end = inc = -1;
+        }
 
-  unsigned char const * bytes = static_cast<unsigned char const *>(object);
-  std::ostringstream os;
-  os << "0x" << std::setfill('0') << std::hex;
-  for(; i != end; i += inc)
-    os << std::setw(2) << static_cast<unsigned>(bytes[i]);
-  return os.str().c_str();
-}
+        unsigned char const* bytes = static_cast<unsigned char const*>(object);
+        std::ostringstream   os;
+        os << "0x" << std::setfill('0') << std::hex;
+        for(; i != end; i += inc)
+            os << std::setw(2) << static_cast<unsigned>(bytes[i]);
+        return os.str().c_str();
+    }
 
-std::ostream * createStream() { return new std::ostringstream(); }
-String getStreamResult(std::ostream * in)
-{
-  return static_cast<std::ostringstream *>(in)->str().c_str(); // NOLINT
-}
-void freeStream(std::ostream * in) { delete in; }
+    std::ostream* createStream() { return new std::ostringstream(); }
+    String        getStreamResult(std::ostream* in) {
+        return static_cast<std::ostringstream*>(in)->str().c_str(); // NOLINT
+    }
+    void freeStream(std::ostream* in) { delete in; }
 
-#  ifndef DOCTEST_CONFIG_DISABLE
+#ifndef DOCTEST_CONFIG_DISABLE
 
-// this holds both parameters for the command line and runtime data for tests
-struct ContextState : TestAccessibleContextState //! OCLINT too many fields
-{
-  // == parameters from the command line
+    // this holds both parameters for the command line and runtime data for tests
+    struct ContextState : TestAccessibleContextState //!OCLINT too many fields
+    {
+        // == parameters from the command line
 
-  std::vector<std::vector<String>> filters;
+        std::vector<std::vector<String> > filters;
 
-  String order_by;    // how tests should be ordered
-  unsigned rand_seed; // the seed for rand ordering
+        String   order_by;  // how tests should be ordered
+        unsigned rand_seed; // the seed for rand ordering
 
-  unsigned first; // the first (matching) test to be executed
-  unsigned last;  // the last (matching) test to be executed
+        unsigned first; // the first (matching) test to be executed
+        unsigned last;  // the last (matching) test to be executed
 
-  int abort_after;           // stop tests after this many failed assertions
-  int subcase_filter_levels; // apply the subcase filters for the first N levels
-  bool case_sensitive;       // if filtering should be case sensitive
-  bool exit;                 // if the program should be exited after the tests are ran/whatever
-  bool duration;             // print the time duration of each test case
-  bool no_exitcode;          // if the framework should return 0 as the exitcode
-  bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-  bool no_version;           // to not print the version of the framework
-  bool no_colors;            // if output to the console should be colorized
-  bool force_colors;         // forces the use of colors even when a tty cannot be detected
-  bool no_breaks;            // to not break into the debugger
-  bool no_skip;              // don't skip test cases which are marked to be skipped
-  bool no_path_in_filenames; // if the path to files should be removed from the output
-  bool no_line_numbers;      // if source code line numbers should be omitted from the output
-  bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+        int  abort_after;           // stop tests after this many failed assertions
+        int  subcase_filter_levels; // apply the subcase filters for the first N levels
+        bool case_sensitive;        // if filtering should be case sensitive
+        bool exit;         // if the program should be exited after the tests are ran/whatever
+        bool duration;     // print the time duration of each test case
+        bool no_exitcode;  // if the framework should return 0 as the exitcode
+        bool no_run;       // to not run the tests at all (can be done with an "*" exclude)
+        bool no_version;   // to not print the version of the framework
+        bool no_colors;    // if output to the console should be colorized
+        bool force_colors; // forces the use of colors even when a tty cannot be detected
+        bool no_breaks;    // to not break into the debugger
+        bool no_skip;      // don't skip test cases which are marked to be skipped
+        bool no_path_in_filenames; // if the path to files should be removed from the output
+        bool no_line_numbers;      // if source code line numbers should be omitted from the output
+        bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
 
-  bool help;             // to print the help
-  bool version;          // to print the version
-  bool count;            // if only the count of matching tests is to be retreived
-  bool list_test_cases;  // to list all tests matching the filters
-  bool list_test_suites; // to list all suites matching the filters
+        bool help;             // to print the help
+        bool version;          // to print the version
+        bool count;            // if only the count of matching tests is to be retreived
+        bool list_test_cases;  // to list all tests matching the filters
+        bool list_test_suites; // to list all suites matching the filters
 
-  // == data for the tests being ran
+        // == data for the tests being ran
 
-  unsigned numTestsPassingFilters;
-  unsigned numTestSuitesPassingFilters;
-  unsigned numFailed;
-  const TestCase * currentTest;
-  bool hasLoggedCurrentTestStart;
-  int numAssertionsForCurrentTestcase;
-  int numAssertions;
-  int numFailedAssertionsForCurrentTestcase;
-  int numFailedAssertions;
-  bool hasCurrentTestFailed;
+        unsigned        numTestsPassingFilters;
+        unsigned        numTestSuitesPassingFilters;
+        unsigned        numFailed;
+        const TestCase* currentTest;
+        bool            hasLoggedCurrentTestStart;
+        int             numAssertionsForCurrentTestcase;
+        int             numAssertions;
+        int             numFailedAssertionsForCurrentTestcase;
+        int             numFailedAssertions;
+        bool            hasCurrentTestFailed;
 
-  std::vector<IContextScope *> contexts;        // for logging with INFO() and friends
-  std::vector<std::string> exceptionalContexts; // logging from INFO() due to an exception
+        std::vector<IContextScope*> contexts;            // for logging with INFO() and friends
+        std::vector<std::string>    exceptionalContexts; // logging from INFO() due to an exception
 
-  // stuff for subcases
-  std::set<SubcaseSignature> subcasesPassed;
-  std::set<int> subcasesEnteredLevels;
-  std::vector<Subcase> subcasesStack;
-  int subcasesCurrentLevel;
-  bool subcasesHasSkipped;
+        // stuff for subcases
+        std::set<SubcaseSignature> subcasesPassed;
+        std::set<int>              subcasesEnteredLevels;
+        std::vector<Subcase>       subcasesStack;
+        int                        subcasesCurrentLevel;
+        bool                       subcasesHasSkipped;
 
-  void resetRunData()
-  {
-    numTestsPassingFilters = 0;
-    numTestSuitesPassingFilters = 0;
-    numFailed = 0;
-    numAssertions = 0;
-    numFailedAssertions = 0;
-    numFailedAssertionsForCurrentTestcase = 0;
-  }
+        void resetRunData() {
+            numTestsPassingFilters                = 0;
+            numTestSuitesPassingFilters           = 0;
+            numFailed                             = 0;
+            numAssertions                         = 0;
+            numFailedAssertions                   = 0;
+            numFailedAssertionsForCurrentTestcase = 0;
+        }
 
-  // cppcheck-suppress uninitMemberVar
-  ContextState() : filters(8) // 8 different filters total
-  {
-    resetRunData();
-  }
-};
+        // cppcheck-suppress uninitMemberVar
+        ContextState()
+                : filters(8) // 8 different filters total
+        {
+            resetRunData();
+        }
+    };
 
-ContextState * contextState = 0;
-#  endif // DOCTEST_CONFIG_DISABLE
+    ContextState* contextState = 0;
+#endif // DOCTEST_CONFIG_DISABLE
 } // namespace detail
 
-void String::copy(const String & other)
-{
-  if(other.isOnStack())
-  {
-    detail::my_memcpy(buf, other.buf, len);
-  }
-  else
-  {
-    setOnHeap();
-    data.size = other.data.size;
-    data.capacity = data.size + 1;
-    data.ptr = new char[data.capacity];
-    detail::my_memcpy(data.ptr, other.data.ptr, data.size + 1);
-  }
+void String::copy(const String& other) {
+    if(other.isOnStack()) {
+        detail::my_memcpy(buf, other.buf, len);
+    } else {
+        setOnHeap();
+        data.size     = other.data.size;
+        data.capacity = data.size + 1;
+        data.ptr      = new char[data.capacity];
+        detail::my_memcpy(data.ptr, other.data.ptr, data.size + 1);
+    }
 }
 
-String::String(const char * in)
-{
-  unsigned in_len = detail::my_strlen(in);
-  if(in_len <= last)
-  {
-    detail::my_memcpy(buf, in, in_len + 1);
-    setLast(last - in_len);
-  }
-  else
-  {
-    setOnHeap();
-    data.size = in_len;
-    data.capacity = data.size + 1;
-    data.ptr = new char[data.capacity];
-    detail::my_memcpy(data.ptr, in, in_len + 1);
-  }
+String::String(const char* in) {
+    unsigned in_len = detail::my_strlen(in);
+    if(in_len <= last) {
+        detail::my_memcpy(buf, in, in_len + 1);
+        setLast(last - in_len);
+    } else {
+        setOnHeap();
+        data.size     = in_len;
+        data.capacity = data.size + 1;
+        data.ptr      = new char[data.capacity];
+        detail::my_memcpy(data.ptr, in, in_len + 1);
+    }
 }
 
-String & String::operator+=(const String & other)
-{
-  const unsigned my_old_size = size();
-  const unsigned other_size = other.size();
-  const unsigned total_size = my_old_size + other_size;
-  if(isOnStack())
-  {
-    if(total_size < len)
-    {
-      // append to the current stack space
-      detail::my_memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-      setLast(last - total_size);
+String& String::operator+=(const String& other) {
+    const unsigned my_old_size = size();
+    const unsigned other_size  = other.size();
+    const unsigned total_size  = my_old_size + other_size;
+    if(isOnStack()) {
+        if(total_size < len) {
+            // append to the current stack space
+            detail::my_memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            setLast(last - total_size);
+        } else {
+            // alloc new chunk
+            char* temp = new char[total_size + 1];
+            // copy current data to new location before writing in the union
+            detail::my_memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            // update data in union
+            setOnHeap();
+            data.size     = total_size;
+            data.capacity = data.size + 1;
+            data.ptr      = temp;
+            // transfer the rest of the data
+            detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
+    } else {
+        if(data.capacity > total_size) {
+            // append to the current heap block
+            data.size = total_size;
+            detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        } else {
+            // resize
+            data.capacity *= 2;
+            if(data.capacity <= total_size)
+                data.capacity = total_size + 1;
+            // alloc new chunk
+            char* temp = new char[data.capacity];
+            // copy current data to new location before releasing it
+            detail::my_memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            // release old chunk
+            delete[] data.ptr;
+            // update the rest of the union members
+            data.size = total_size;
+            data.ptr  = temp;
+            // transfer the rest of the data
+            detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
     }
-    else
-    {
-      // alloc new chunk
-      char * temp = new char[total_size + 1];
-      // copy current data to new location before writing in the union
-      detail::my_memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-      // update data in union
-      setOnHeap();
-      data.size = total_size;
-      data.capacity = data.size + 1;
-      data.ptr = temp;
-      // transfer the rest of the data
-      detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-    }
-  }
-  else
-  {
-    if(data.capacity > total_size)
-    {
-      // append to the current heap block
-      data.size = total_size;
-      detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-    }
-    else
-    {
-      // resize
-      data.capacity *= 2;
-      if(data.capacity <= total_size)
-        data.capacity = total_size + 1;
-      // alloc new chunk
-      char * temp = new char[data.capacity];
-      // copy current data to new location before releasing it
-      detail::my_memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-      // release old chunk
-      delete[] data.ptr;
-      // update the rest of the union members
-      data.size = total_size;
-      data.ptr = temp;
-      // transfer the rest of the data
-      detail::my_memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-    }
-  }
 
-  return *this;
+    return *this;
 }
 
-#  ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-String::String(String && other)
-{
-  detail::my_memcpy(buf, other.buf, len);
-  other.buf[0] = '\0';
-  other.setLast();
-}
-
-String & String::operator=(String && other)
-{
-  if(this != &other)
-  {
-    if(!isOnStack())
-      delete[] data.ptr;
+#ifdef DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
+String::String(String&& other) {
     detail::my_memcpy(buf, other.buf, len);
     other.buf[0] = '\0';
     other.setLast();
-  }
-  return *this;
-}
-#  endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
-
-int String::compare(const char * other, bool no_case) const
-{
-  if(no_case)
-    return detail::stricmp(c_str(), other);
-  return std::strcmp(c_str(), other);
 }
 
-int String::compare(const String & other, bool no_case) const { return compare(other.c_str(), no_case); }
+String& String::operator=(String&& other) {
+    if(this != &other) {
+        if(!isOnStack())
+            delete[] data.ptr;
+        detail::my_memcpy(buf, other.buf, len);
+        other.buf[0] = '\0';
+        other.setLast();
+    }
+    return *this;
+}
+#endif // DOCTEST_CONFIG_WITH_RVALUE_REFERENCES
 
-std::ostream & operator<<(std::ostream & stream, const String & in)
-{
-  stream << in.c_str();
-  return stream;
+int String::compare(const char* other, bool no_case) const {
+    if(no_case)
+        return detail::stricmp(c_str(), other);
+    return std::strcmp(c_str(), other);
+}
+
+int String::compare(const String& other, bool no_case) const {
+    return compare(other.c_str(), no_case);
+}
+
+std::ostream& operator<<(std::ostream& stream, const String& in) {
+    stream << in.c_str();
+    return stream;
 }
 
 Approx::Approx(double value)
-: m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value)
-{
-}
+        : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
+        , m_scale(1.0)
+        , m_value(value) {}
 
-bool operator==(double lhs, Approx const & rhs)
-{
-  // Thanks to Richard Harris for his help refining this formula
-  return std::fabs(lhs - rhs.m_value)
-         < rhs.m_epsilon * (rhs.m_scale + detail::my_max(std::fabs(lhs), std::fabs(rhs.m_value)));
+bool operator==(double lhs, Approx const& rhs) {
+    // Thanks to Richard Harris for his help refining this formula
+    return std::fabs(lhs - rhs.m_value) <
+           rhs.m_epsilon * (rhs.m_scale + detail::my_max(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 
 String Approx::toString() const { return String("Approx( ") + doctest::toString(m_value) + " )"; }
 
-#  ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(char * in) { return toString(static_cast<const char *>(in)); }
-String toString(const char * in) { return String("\"") + (in ? in : "{null string}") + "\""; }
-#  endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+String toString(char* in) { return toString(static_cast<const char*>(in)); }
+String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 String toString(bool in) { return in ? "true" : "false"; }
 String toString(float in) { return detail::fpToString(in, 5) + "f"; }
 String toString(double in) { return detail::fpToString(in, 10); }
 String toString(double long in) { return detail::fpToString(in, 15); }
 
-String toString(char in)
-{
-  char buf[64];
-  std::sprintf(buf, "%d", in);
-  return buf;
+String toString(char in) {
+    char buf[64];
+    std::sprintf(buf, "%d", in);
+    return buf;
 }
 
-String toString(char signed in)
-{
-  char buf[64];
-  std::sprintf(buf, "%d", in);
-  return buf;
+String toString(char signed in) {
+    char buf[64];
+    std::sprintf(buf, "%d", in);
+    return buf;
 }
 
-String toString(char unsigned in)
-{
-  char buf[64];
-  std::sprintf(buf, "%ud", in);
-  return buf;
+String toString(char unsigned in) {
+    char buf[64];
+    std::sprintf(buf, "%ud", in);
+    return buf;
 }
 
-String toString(int short in)
-{
-  char buf[64];
-  std::sprintf(buf, "%d", in);
-  return buf;
+String toString(int short in) {
+    char buf[64];
+    std::sprintf(buf, "%d", in);
+    return buf;
 }
 
-String toString(int short unsigned in)
-{
-  char buf[64];
-  std::sprintf(buf, "%u", in);
-  return buf;
+String toString(int short unsigned in) {
+    char buf[64];
+    std::sprintf(buf, "%u", in);
+    return buf;
 }
 
-String toString(int in)
-{
-  char buf[64];
-  std::sprintf(buf, "%d", in);
-  return buf;
+String toString(int in) {
+    char buf[64];
+    std::sprintf(buf, "%d", in);
+    return buf;
 }
 
-String toString(int unsigned in)
-{
-  char buf[64];
-  std::sprintf(buf, "%u", in);
-  return buf;
+String toString(int unsigned in) {
+    char buf[64];
+    std::sprintf(buf, "%u", in);
+    return buf;
 }
 
-String toString(int long in)
-{
-  char buf[64];
-  std::sprintf(buf, "%ld", in);
-  return buf;
+String toString(int long in) {
+    char buf[64];
+    std::sprintf(buf, "%ld", in);
+    return buf;
 }
 
-String toString(int long unsigned in)
-{
-  char buf[64];
-  std::sprintf(buf, "%lu", in);
-  return buf;
+String toString(int long unsigned in) {
+    char buf[64];
+    std::sprintf(buf, "%lu", in);
+    return buf;
 }
 
-#  ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-String toString(int long long in)
-{
-  char buf[64];
-  std::sprintf(buf, "%lld", in);
-  return buf;
+#ifdef DOCTEST_CONFIG_WITH_LONG_LONG
+String toString(int long long in) {
+    char buf[64];
+    std::sprintf(buf, "%lld", in);
+    return buf;
 }
-String toString(int long long unsigned in)
-{
-  char buf[64];
-  std::sprintf(buf, "%llu", in);
-  return buf;
+String toString(int long long unsigned in) {
+    char buf[64];
+    std::sprintf(buf, "%llu", in);
+    return buf;
 }
-#  endif // DOCTEST_CONFIG_WITH_LONG_LONG
+#endif // DOCTEST_CONFIG_WITH_LONG_LONG
 
-#  ifdef DOCTEST_CONFIG_WITH_NULLPTR
+#ifdef DOCTEST_CONFIG_WITH_NULLPTR
 String toString(std::nullptr_t) { return "nullptr"; }
-#  endif // DOCTEST_CONFIG_WITH_NULLPTR
+#endif // DOCTEST_CONFIG_WITH_NULLPTR
 
 } // namespace doctest
 
-#  ifdef DOCTEST_CONFIG_DISABLE
+#ifdef DOCTEST_CONFIG_DISABLE
 namespace doctest
 {
 bool isRunningInTest() { return false; }
-Context::Context(int, const char * const *) {}
+Context::Context(int, const char* const*) {}
 Context::~Context() {}
-void Context::applyCommandLine(int, const char * const *) {}
-void Context::addFilter(const char *, const char *) {}
+void Context::applyCommandLine(int, const char* const*) {}
+void Context::addFilter(const char*, const char*) {}
 void Context::clearFilters() {}
-void Context::setOption(const char *, int) {}
-void Context::setOption(const char *, const char *) {}
+void Context::setOption(const char*, int) {}
+void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
-int Context::run() { return 0; }
+int  Context::run() { return 0; }
 } // namespace doctest
-#  else // DOCTEST_CONFIG_DISABLE
+#else // DOCTEST_CONFIG_DISABLE
 
-#    if !defined(DOCTEST_CONFIG_COLORS_NONE)
-#      if !defined(DOCTEST_CONFIG_COLORS_WINDOWS) && !defined(DOCTEST_CONFIG_COLORS_ANSI)
-#        ifdef DOCTEST_PLATFORM_WINDOWS
-#          define DOCTEST_CONFIG_COLORS_WINDOWS
-#        else // linux
-#          define DOCTEST_CONFIG_COLORS_ANSI
-#        endif // platform
-#      endif   // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
-#    endif     // DOCTEST_CONFIG_COLORS_NONE
+#if !defined(DOCTEST_CONFIG_COLORS_NONE)
+#if !defined(DOCTEST_CONFIG_COLORS_WINDOWS) && !defined(DOCTEST_CONFIG_COLORS_ANSI)
+#ifdef DOCTEST_PLATFORM_WINDOWS
+#define DOCTEST_CONFIG_COLORS_WINDOWS
+#else // linux
+#define DOCTEST_CONFIG_COLORS_ANSI
+#endif // platform
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
+#endif // DOCTEST_CONFIG_COLORS_NONE
 
-#    define DOCTEST_PRINTF_COLORED(buffer, color) \
-      do                                          \
-      {                                           \
-        Color col(color);                         \
-        std::printf("%s", buffer);                \
-      } while((void)0, 0)
+#define DOCTEST_PRINTF_COLORED(buffer, color)                                                      \
+    do {                                                                                           \
+        Color col(color);                                                                          \
+        std::printf("%s", buffer);                                                                 \
+    } while((void)0, 0)
 
 // the buffer size used for snprintf() calls
-#    if !defined(DOCTEST_SNPRINTF_BUFFER_LENGTH)
-#      define DOCTEST_SNPRINTF_BUFFER_LENGTH 1024
-#    endif // DOCTEST_SNPRINTF_BUFFER_LENGTH
+#if !defined(DOCTEST_SNPRINTF_BUFFER_LENGTH)
+#define DOCTEST_SNPRINTF_BUFFER_LENGTH 1024
+#endif // DOCTEST_SNPRINTF_BUFFER_LENGTH
 
-#    if DOCTEST_MSVC || defined(__MINGW32__)
-#      if DOCTEST_MSVC >= DOCTEST_COMPILER(17, 0, 0)
-#        define DOCTEST_WINDOWS_SAL_IN_OPT _In_opt_
-#      else // MSVC
-#        define DOCTEST_WINDOWS_SAL_IN_OPT
-#      endif // MSVC
-extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(DOCTEST_WINDOWS_SAL_IN_OPT const char *);
+#if DOCTEST_MSVC || defined(__MINGW32__)
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(17, 0, 0)
+#define DOCTEST_WINDOWS_SAL_IN_OPT _In_opt_
+#else // MSVC
+#define DOCTEST_WINDOWS_SAL_IN_OPT
+#endif // MSVC
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(
+        DOCTEST_WINDOWS_SAL_IN_OPT const char*);
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
-#    endif   // MSVC || __MINGW32__
+#endif // MSVC || __MINGW32__
 
-#    ifdef DOCTEST_CONFIG_COLORS_ANSI
-#      include <unistd.h>
-#    endif // DOCTEST_CONFIG_COLORS_ANSI
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
+#include <unistd.h>
+#endif // DOCTEST_CONFIG_COLORS_ANSI
 
-#    ifdef DOCTEST_PLATFORM_WINDOWS
+#ifdef DOCTEST_PLATFORM_WINDOWS
 
 // defines for a leaner windows.h
-#      ifndef WIN32_MEAN_AND_LEAN
-#        define WIN32_MEAN_AND_LEAN
-#      endif // WIN32_MEAN_AND_LEAN
-#      ifndef VC_EXTRA_LEAN
-#        define VC_EXTRA_LEAN
-#      endif // VC_EXTRA_LEAN
-#      ifndef NOMINMAX
-#        define NOMINMAX
-#      endif // NOMINMAX
+#ifndef WIN32_MEAN_AND_LEAN
+#define WIN32_MEAN_AND_LEAN
+#endif // WIN32_MEAN_AND_LEAN
+#ifndef VC_EXTRA_LEAN
+#define VC_EXTRA_LEAN
+#endif // VC_EXTRA_LEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif // NOMINMAX
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
 // not sure what AfxWin.h is for - here I do what Catch does
-#      ifdef __AFXDLL
-#        include <AfxWin.h>
-#      else
-#        include <windows.h>
-#      endif
-#      include <io.h>
+#ifdef __AFXDLL
+#include <AfxWin.h>
+#else
+#include <windows.h>
+#endif
+#include <io.h>
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
-#    else // DOCTEST_PLATFORM_WINDOWS
+#else // DOCTEST_PLATFORM_WINDOWS
 
-#      include <sys/time.h>
+#include <sys/time.h>
 
-#    endif // DOCTEST_PLATFORM_WINDOWS
+#endif // DOCTEST_PLATFORM_WINDOWS
 
 namespace doctest_detail_test_suite_ns
 {
 // holds the current test suite
-doctest::detail::TestSuite & getCurrentTestSuite()
-{
-  static doctest::detail::TestSuite data;
-  return data;
+doctest::detail::TestSuite& getCurrentTestSuite() {
+    static doctest::detail::TestSuite data;
+    return data;
 }
 } // namespace doctest_detail_test_suite_ns
 
@@ -4011,70 +3795,68 @@ namespace doctest
 {
 namespace detail
 {
-TestCase::TestCase(funcType test,
-                   const char * file,
-                   unsigned line,
-                   const TestSuite & test_suite,
-                   const char * type,
-                   int template_id)
-: m_test(test), m_name(0), m_type(type), m_test_suite(test_suite.m_test_suite), m_description(test_suite.m_description),
-  m_skip(test_suite.m_skip), m_may_fail(test_suite.m_may_fail), m_should_fail(test_suite.m_should_fail),
-  m_expected_failures(test_suite.m_expected_failures), m_timeout(test_suite.m_timeout), m_file(file), m_line(line),
-  m_template_id(template_id)
-{
-}
+    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
+                       const char* type, int template_id)
+            : m_test(test)
+            , m_name(0)
+            , m_type(type)
+            , m_test_suite(test_suite.m_test_suite)
+            , m_description(test_suite.m_description)
+            , m_skip(test_suite.m_skip)
+            , m_may_fail(test_suite.m_may_fail)
+            , m_should_fail(test_suite.m_should_fail)
+            , m_expected_failures(test_suite.m_expected_failures)
+            , m_timeout(test_suite.m_timeout)
+            , m_file(file)
+            , m_line(line)
+            , m_template_id(template_id) {}
 
-TestCase & TestCase::operator*(const char * in)
-{
-  m_name = in;
-  // make a new name with an appended type for templated test case
-  if(m_template_id != -1)
-  {
-    m_full_name = String(m_name) + m_type;
-    // redirect the name to point to the newly constructed full name
-    m_name = m_full_name.c_str();
-  }
-  return *this;
-}
+    TestCase& TestCase::operator*(const char* in) {
+        m_name = in;
+        // make a new name with an appended type for templated test case
+        if(m_template_id != -1) {
+            m_full_name = String(m_name) + m_type;
+            // redirect the name to point to the newly constructed full name
+            m_name = m_full_name.c_str();
+        }
+        return *this;
+    }
 
-TestCase & TestCase::operator=(const TestCase & other)
-{
-  m_test = other.m_test;
-  m_full_name = other.m_full_name;
-  m_name = other.m_name;
-  m_type = other.m_type;
-  m_test_suite = other.m_test_suite;
-  m_description = other.m_description;
-  m_skip = other.m_skip;
-  m_may_fail = other.m_may_fail;
-  m_should_fail = other.m_should_fail;
-  m_expected_failures = other.m_expected_failures;
-  m_timeout = other.m_timeout;
-  m_file = other.m_file;
-  m_line = other.m_line;
-  m_template_id = other.m_template_id;
+    TestCase& TestCase::operator=(const TestCase& other) {
+        m_test              = other.m_test;
+        m_full_name         = other.m_full_name;
+        m_name              = other.m_name;
+        m_type              = other.m_type;
+        m_test_suite        = other.m_test_suite;
+        m_description       = other.m_description;
+        m_skip              = other.m_skip;
+        m_may_fail          = other.m_may_fail;
+        m_should_fail       = other.m_should_fail;
+        m_expected_failures = other.m_expected_failures;
+        m_timeout           = other.m_timeout;
+        m_file              = other.m_file;
+        m_line              = other.m_line;
+        m_template_id       = other.m_template_id;
 
-  if(m_template_id != -1)
-    m_name = m_full_name.c_str();
-  return *this;
-}
+        if(m_template_id != -1)
+            m_name = m_full_name.c_str();
+        return *this;
+    }
 
-bool TestCase::operator<(const TestCase & other) const
-{
-  if(m_line != other.m_line)
-    return m_line < other.m_line;
-  const int file_cmp = std::strcmp(m_file, other.m_file);
-  if(file_cmp != 0)
-    return file_cmp < 0;
-  return m_template_id < other.m_template_id;
-}
+    bool TestCase::operator<(const TestCase& other) const {
+        if(m_line != other.m_line)
+            return m_line < other.m_line;
+        const int file_cmp = std::strcmp(m_file, other.m_file);
+        if(file_cmp != 0)
+            return file_cmp < 0;
+        return m_template_id < other.m_template_id;
+    }
 
-const char * getAssertString(assertType::Enum val)
-{
-  DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4062) // enumerator 'x' in switch of enum 'y' is not handled
-  switch(val)
-  { //! OCLINT missing default in switch statements
-    // clang-format off
+    const char* getAssertString(assertType::Enum val) {
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(
+                4062) // enumerator 'x' in switch of enum 'y' is not handled
+        switch(val) { //!OCLINT missing default in switch statements
+            // clang-format off
             case assertType::DT_WARN                    : return "WARN";
             case assertType::DT_CHECK                   : return "CHECK";
             case assertType::DT_REQUIRE                 : return "REQUIRE";
@@ -4146,350 +3928,329 @@ const char * getAssertString(assertType::Enum val)
             case assertType::DT_FAST_WARN_UNARY_FALSE   : return "FAST_WARN_UNARY_FALSE";
             case assertType::DT_FAST_CHECK_UNARY_FALSE  : return "FAST_CHECK_UNARY_FALSE";
             case assertType::DT_FAST_REQUIRE_UNARY_FALSE: return "FAST_REQUIRE_UNARY_FALSE";
-      // clang-format on
-  }
-  DOCTEST_MSVC_SUPPRESS_WARNING_POP
-  return "";
-}
-
-bool checkIfShouldThrow(assertType::Enum assert_type)
-{
-  if(assert_type & assertType::is_require) //! OCLINT bitwise operator in conditional
-    return true;
-
-  if((assert_type & assertType::is_check) //! OCLINT bitwise operator in conditional
-     && contextState->abort_after > 0 && contextState->numFailedAssertions >= contextState->abort_after)
-    return true;
-
-  return false;
-}
-void fastAssertThrowIfFlagSet(int flags)
-{
-  if(flags & assertAction::shouldthrow) //! OCLINT bitwise operator in conditional
-    throwException();
-}
-void throwException()
-{
-#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-  throw TestFailureException();
-#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-}
-
-// matching of a string against a wildcard mask (case sensitivity configurable) taken from
-// http://www.emoticode.net/c/simple-wildcard-string-compare-globbing-function.html
-int wildcmp(const char * str, const char * wild, bool caseSensitive)
-{
-  const char * cp = 0;
-  const char * mp = 0;
-
-  // rolled my own tolower() to not include more headers
-  while((*str) && (*wild != '*'))
-  {
-    if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) && (*wild != '?'))
-    {
-      return 0;
+                // clang-format on
+        }
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        return "";
     }
-    wild++;
-    str++;
-  }
 
-  while(*str)
-  {
-    if(*wild == '*')
-    {
-      if(!*++wild)
-      {
-        return 1;
-      }
-      mp = wild;
-      cp = str + 1;
+    bool checkIfShouldThrow(assertType::Enum assert_type) {
+        if(assert_type & assertType::is_require) //!OCLINT bitwise operator in conditional
+            return true;
+
+        if((assert_type & assertType::is_check) //!OCLINT bitwise operator in conditional
+           && contextState->abort_after > 0 &&
+           contextState->numFailedAssertions >= contextState->abort_after)
+            return true;
+
+        return false;
     }
-    else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) || (*wild == '?'))
-    {
-      wild++;
-      str++;
+    void fastAssertThrowIfFlagSet(int flags) {
+        if(flags & assertAction::shouldthrow) //!OCLINT bitwise operator in conditional
+            throwException();
     }
-    else
-    {
-      wild = mp;  //! OCLINT parameter reassignment
-      str = cp++; //! OCLINT parameter reassignment
+    void throwException() {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        throw TestFailureException();
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
-  }
 
-  while(*wild == '*')
-  {
-    wild++;
-  }
-  return !*wild;
-}
+    // matching of a string against a wildcard mask (case sensitivity configurable) taken from
+    // http://www.emoticode.net/c/simple-wildcard-string-compare-globbing-function.html
+    int wildcmp(const char* str, const char* wild, bool caseSensitive) {
+        const char* cp = 0;
+        const char* mp = 0;
 
-//// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
-// unsigned hashStr(unsigned const char* str) {
-//    unsigned long hash = 5381;
-//    char          c;
-//    while((c = *str++))
-//        hash = ((hash << 5) + hash) + c; // hash * 33 + c
-//    return hash;
-//}
+        // rolled my own tolower() to not include more headers
+        while((*str) && (*wild != '*')) {
+            if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
+               (*wild != '?')) {
+                return 0;
+            }
+            wild++;
+            str++;
+        }
 
-// checks if the name matches any of the filters (and can be configured what to do when empty)
-bool matchesAny(const char * name, const std::vector<String> & filters, int matchEmpty, bool caseSensitive)
-{
-  if(filters.empty() && matchEmpty)
-    return true;
-  for(unsigned i = 0; i < filters.size(); ++i)
-    if(wildcmp(name, filters[i].c_str(), caseSensitive))
-      return true;
-  return false;
-}
+        while(*str) {
+            if(*wild == '*') {
+                if(!*++wild) {
+                    return 1;
+                }
+                mp = wild;
+                cp = str + 1;
+            } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
+                      (*wild == '?')) {
+                wild++;
+                str++;
+            } else {
+                wild = mp;   //!OCLINT parameter reassignment
+                str  = cp++; //!OCLINT parameter reassignment
+            }
+        }
 
-#    ifdef DOCTEST_PLATFORM_WINDOWS
+        while(*wild == '*') {
+            wild++;
+        }
+        return !*wild;
+    }
 
-typedef unsigned long long UInt64;
+    //// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+    //unsigned hashStr(unsigned const char* str) {
+    //    unsigned long hash = 5381;
+    //    char          c;
+    //    while((c = *str++))
+    //        hash = ((hash << 5) + hash) + c; // hash * 33 + c
+    //    return hash;
+    //}
 
-UInt64 getCurrentTicks()
-{
-  static UInt64 hz = 0, hzo = 0;
-  if(!hz)
-  {
-    QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER *>(&hz));
-    QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER *>(&hzo));
-  }
-  UInt64 t;
-  QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER *>(&t));
-  return ((t - hzo) * 1000000) / hz;
-}
-#    else  // DOCTEST_PLATFORM_WINDOWS
+    // checks if the name matches any of the filters (and can be configured what to do when empty)
+    bool matchesAny(const char* name, const std::vector<String>& filters, int matchEmpty,
+                    bool caseSensitive) {
+        if(filters.empty() && matchEmpty)
+            return true;
+        for(unsigned i = 0; i < filters.size(); ++i)
+            if(wildcmp(name, filters[i].c_str(), caseSensitive))
+                return true;
+        return false;
+    }
 
-typedef uint64_t UInt64;
+#ifdef DOCTEST_PLATFORM_WINDOWS
 
-UInt64 getCurrentTicks()
-{
-  timeval t;
-  gettimeofday(&t, 0);
-  return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
-}
-#    endif // DOCTEST_PLATFORM_WINDOWS
+    typedef unsigned long long UInt64;
 
-class Timer
-{
-public:
-  Timer() : m_ticks(0) {}
-  void start() { m_ticks = getCurrentTicks(); }
-  unsigned int getElapsedMicroseconds() const { return static_cast<unsigned int>(getCurrentTicks() - m_ticks); }
-  unsigned int getElapsedMilliseconds() const { return static_cast<unsigned int>(getElapsedMicroseconds() / 1000); }
-  double getElapsedSeconds() const { return getElapsedMicroseconds() / 1000000.0; }
+    UInt64 getCurrentTicks() {
+        static UInt64 hz = 0, hzo = 0;
+        if(!hz) {
+            QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&hz));
+            QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&hzo));
+        }
+        UInt64 t;
+        QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&t));
+        return ((t - hzo) * 1000000) / hz;
+    }
+#else  // DOCTEST_PLATFORM_WINDOWS
 
-private:
-  UInt64 m_ticks;
-};
+    typedef uint64_t UInt64;
 
-TestAccessibleContextState * getTestsContextState() { return contextState; }
+    UInt64 getCurrentTicks() {
+        timeval t;
+        gettimeofday(&t, 0);
+        return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
+    }
+#endif // DOCTEST_PLATFORM_WINDOWS
 
-bool SubcaseSignature::operator<(const SubcaseSignature & other) const
-{
-  if(m_line != other.m_line)
-    return m_line < other.m_line;
-  if(std::strcmp(m_file, other.m_file) != 0)
-    return std::strcmp(m_file, other.m_file) < 0;
-  return std::strcmp(m_name, other.m_name) < 0;
-}
+    class Timer
+    {
+    public:
+        Timer()
+                : m_ticks(0) {}
+        void         start() { m_ticks = getCurrentTicks(); }
+        unsigned int getElapsedMicroseconds() const {
+            return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
+        }
+        unsigned int getElapsedMilliseconds() const {
+            return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
+        }
+        double getElapsedSeconds() const { return getElapsedMicroseconds() / 1000000.0; }
 
-Subcase::Subcase(const char * name, const char * file, int line) : m_signature(name, file, line), m_entered(false)
-{
-  ContextState * s = contextState;
+    private:
+        UInt64 m_ticks;
+    };
 
-  // if we have already completed it
-  if(s->subcasesPassed.count(m_signature) != 0)
-    return;
+    TestAccessibleContextState* getTestsContextState() { return contextState; }
 
-  // check subcase filters
-  if(s->subcasesCurrentLevel < s->subcase_filter_levels)
-  {
-    if(!matchesAny(m_signature.m_name, s->filters[6], 1, s->case_sensitive))
-      return;
-    if(matchesAny(m_signature.m_name, s->filters[7], 0, s->case_sensitive))
-      return;
-  }
+    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
+        if(m_line != other.m_line)
+            return m_line < other.m_line;
+        if(std::strcmp(m_file, other.m_file) != 0)
+            return std::strcmp(m_file, other.m_file) < 0;
+        return std::strcmp(m_name, other.m_name) < 0;
+    }
 
-  // if a Subcase on the same level has already been entered
-  if(s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0)
-  {
-    s->subcasesHasSkipped = true;
-    return;
-  }
+    Subcase::Subcase(const char* name, const char* file, int line)
+            : m_signature(name, file, line)
+            , m_entered(false) {
+        ContextState* s = contextState;
 
-  s->subcasesStack.push_back(*this);
-  if(s->hasLoggedCurrentTestStart)
-    logTestEnd();
-  s->hasLoggedCurrentTestStart = false;
+        // if we have already completed it
+        if(s->subcasesPassed.count(m_signature) != 0)
+            return;
 
-  s->subcasesEnteredLevels.insert(s->subcasesCurrentLevel++);
-  m_entered = true;
-}
+        // check subcase filters
+        if(s->subcasesCurrentLevel < s->subcase_filter_levels) {
+            if(!matchesAny(m_signature.m_name, s->filters[6], 1, s->case_sensitive))
+                return;
+            if(matchesAny(m_signature.m_name, s->filters[7], 0, s->case_sensitive))
+                return;
+        }
 
-Subcase::Subcase(const Subcase & other)
-: m_signature(other.m_signature.m_name, other.m_signature.m_file, other.m_signature.m_line), m_entered(other.m_entered)
-{
-}
+        // if a Subcase on the same level has already been entered
+        if(s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0) {
+            s->subcasesHasSkipped = true;
+            return;
+        }
 
-Subcase::~Subcase()
-{
-  if(m_entered)
-  {
-    ContextState * s = contextState;
+        s->subcasesStack.push_back(*this);
+        if(s->hasLoggedCurrentTestStart)
+            logTestEnd();
+        s->hasLoggedCurrentTestStart = false;
 
-    s->subcasesCurrentLevel--;
-    // only mark the subcase as passed if no subcases have been skipped
-    if(s->subcasesHasSkipped == false)
-      s->subcasesPassed.insert(m_signature);
+        s->subcasesEnteredLevels.insert(s->subcasesCurrentLevel++);
+        m_entered = true;
+    }
 
-    if(!s->subcasesStack.empty())
-      s->subcasesStack.pop_back();
-    if(s->hasLoggedCurrentTestStart)
-      logTestEnd();
-    s->hasLoggedCurrentTestStart = false;
-  }
-}
+    Subcase::Subcase(const Subcase& other)
+            : m_signature(other.m_signature.m_name, other.m_signature.m_file,
+                          other.m_signature.m_line)
+            , m_entered(other.m_entered) {}
 
-Result::~Result() {}
+    Subcase::~Subcase() {
+        if(m_entered) {
+            ContextState* s = contextState;
 
-Result & Result::operator=(const Result & other)
-{
-  m_passed = other.m_passed;
-  m_decomposition = other.m_decomposition;
+            s->subcasesCurrentLevel--;
+            // only mark the subcase as passed if no subcases have been skipped
+            if(s->subcasesHasSkipped == false)
+                s->subcasesPassed.insert(m_signature);
 
-  return *this;
-}
+            if(!s->subcasesStack.empty())
+                s->subcasesStack.pop_back();
+            if(s->hasLoggedCurrentTestStart)
+                logTestEnd();
+            s->hasLoggedCurrentTestStart = false;
+        }
+    }
 
-// for sorting tests by file/line
-int fileOrderComparator(const void * a, const void * b)
-{
-  const TestCase * lhs = *static_cast<TestCase * const *>(a);
-  const TestCase * rhs = *static_cast<TestCase * const *>(b);
-#    if DOCTEST_MSVC
-  // this is needed because MSVC gives different case for drive letters
-  // for __FILE__ when evaluated in a header and a source file
-  const int res = stricmp(lhs->m_file, rhs->m_file);
-#    else  // MSVC
-  const int res = std::strcmp(lhs->m_file, rhs->m_file);
-#    endif // MSVC
-  if(res != 0)
-    return res;
-  return static_cast<int>(lhs->m_line - rhs->m_line);
-}
+    Result::~Result() {}
 
-// for sorting tests by suite/file/line
-int suiteOrderComparator(const void * a, const void * b)
-{
-  const TestCase * lhs = *static_cast<TestCase * const *>(a);
-  const TestCase * rhs = *static_cast<TestCase * const *>(b);
+    Result& Result::operator=(const Result& other) {
+        m_passed        = other.m_passed;
+        m_decomposition = other.m_decomposition;
 
-  const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
-  if(res != 0)
-    return res;
-  return fileOrderComparator(a, b);
-}
+        return *this;
+    }
 
-// for sorting tests by name/suite/file/line
-int nameOrderComparator(const void * a, const void * b)
-{
-  const TestCase * lhs = *static_cast<TestCase * const *>(a);
-  const TestCase * rhs = *static_cast<TestCase * const *>(b);
+    // for sorting tests by file/line
+    int fileOrderComparator(const void* a, const void* b) {
+        const TestCase* lhs = *static_cast<TestCase* const*>(a);
+        const TestCase* rhs = *static_cast<TestCase* const*>(b);
+#if DOCTEST_MSVC
+        // this is needed because MSVC gives different case for drive letters
+        // for __FILE__ when evaluated in a header and a source file
+        const int res = stricmp(lhs->m_file, rhs->m_file);
+#else  // MSVC
+        const int res = std::strcmp(lhs->m_file, rhs->m_file);
+#endif // MSVC
+        if(res != 0)
+            return res;
+        return static_cast<int>(lhs->m_line - rhs->m_line);
+    }
 
-  const int res_name = std::strcmp(lhs->m_name, rhs->m_name);
-  if(res_name != 0)
-    return res_name;
-  return suiteOrderComparator(a, b);
-}
+    // for sorting tests by suite/file/line
+    int suiteOrderComparator(const void* a, const void* b) {
+        const TestCase* lhs = *static_cast<TestCase* const*>(a);
+        const TestCase* rhs = *static_cast<TestCase* const*>(b);
 
-// sets the current test suite
-int setTestSuite(const TestSuite & ts)
-{
-  doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
-  return 0;
-}
+        const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
+        if(res != 0)
+            return res;
+        return fileOrderComparator(a, b);
+    }
 
-// all the registered tests
-std::set<TestCase> & getRegisteredTests()
-{
-  static std::set<TestCase> data;
-  return data;
-}
+    // for sorting tests by name/suite/file/line
+    int nameOrderComparator(const void* a, const void* b) {
+        const TestCase* lhs = *static_cast<TestCase* const*>(a);
+        const TestCase* rhs = *static_cast<TestCase* const*>(b);
 
-// used by the macros for registering tests
-int regTest(const TestCase & tc)
-{
-  getRegisteredTests().insert(tc);
-  return 0;
-}
+        const int res_name = std::strcmp(lhs->m_name, rhs->m_name);
+        if(res_name != 0)
+            return res_name;
+        return suiteOrderComparator(a, b);
+    }
 
-struct Color
-{
-  enum Code
-  {
-    None = 0,
-    White,
-    Red,
-    Green,
-    Blue,
-    Cyan,
-    Yellow,
-    Grey,
+    // sets the current test suite
+    int setTestSuite(const TestSuite& ts) {
+        doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+        return 0;
+    }
 
-    Bright = 0x10,
+    // all the registered tests
+    std::set<TestCase>& getRegisteredTests() {
+        static std::set<TestCase> data;
+        return data;
+    }
 
-    BrightRed = Bright | Red,
-    BrightGreen = Bright | Green,
-    LightGrey = Bright | Grey,
-    BrightWhite = Bright | White
-  };
-  explicit Color(Code code) { use(code); }
-  ~Color() { use(None); }
+    // used by the macros for registering tests
+    int regTest(const TestCase& tc) {
+        getRegisteredTests().insert(tc);
+        return 0;
+    }
 
-  static void use(Code code);
-  static void init();
-};
+    struct Color
+    {
+        enum Code
+        {
+            None = 0,
+            White,
+            Red,
+            Green,
+            Blue,
+            Cyan,
+            Yellow,
+            Grey,
 
-#    ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-HANDLE g_stdoutHandle;
-WORD g_originalForegroundAttributes;
-WORD g_originalBackgroundAttributes;
-bool g_attrsInitted = false;
-#    endif // DOCTEST_CONFIG_COLORS_WINDOWS
+            Bright = 0x10,
 
-void Color::init()
-{
-#    ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-  if(!g_attrsInitted)
-  {
-    g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-    g_attrsInitted = true;
-    CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-    GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
-    g_originalForegroundAttributes =
-        csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-    g_originalBackgroundAttributes =
-        csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-  }
-#    endif // DOCTEST_CONFIG_COLORS_WINDOWS
-}
+            BrightRed   = Bright | Red,
+            BrightGreen = Bright | Green,
+            LightGrey   = Bright | Grey,
+            BrightWhite = Bright | White
+        };
+        explicit Color(Code code) { use(code); }
+        ~Color() { use(None); }
 
-void Color::use(Code
-#    ifndef DOCTEST_CONFIG_COLORS_NONE
-                    code
-#    endif // DOCTEST_CONFIG_COLORS_NONE
-)
-{
-  const ContextState * p = contextState;
-  if(p->no_colors)
-    return;
-#    ifdef DOCTEST_CONFIG_COLORS_ANSI
-  if(isatty(STDOUT_FILENO) == false && p->force_colors == false)
-    return;
+        static void use(Code code);
+        static void init();
+    };
 
-  const char * col = "";
-  // clang-format off
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+    HANDLE g_stdoutHandle;
+    WORD   g_originalForegroundAttributes;
+    WORD   g_originalBackgroundAttributes;
+    bool   g_attrsInitted = false;
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+
+    void Color::init() {
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+        if(!g_attrsInitted) {
+            g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            g_attrsInitted = true;
+            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+            GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
+            g_originalForegroundAttributes =
+                    csbiInfo.wAttributes &
+                    ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+            g_originalBackgroundAttributes =
+                    csbiInfo.wAttributes &
+                    ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+        }
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+    }
+
+    void Color::use(Code
+#ifndef DOCTEST_CONFIG_COLORS_NONE
+                            code
+#endif // DOCTEST_CONFIG_COLORS_NONE
+    ) {
+        const ContextState* p = contextState;
+        if(p->no_colors)
+            return;
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
+        if(isatty(STDOUT_FILENO) == false && p->force_colors == false)
+            return;
+
+        const char* col = "";
+        // clang-format off
         switch(code) { //!OCLINT missing break in switch statement / unnecessary default statement in covered switch statement
             case Color::Red:         col = "[0;31m"; break;
             case Color::Green:       col = "[0;32m"; break;
@@ -4506,17 +4267,18 @@ void Color::use(Code
             case Color::White:
             default:                 col = "[0m";
         }
-  // clang-format on
-  std::printf("\033%s", col);
-#    endif // DOCTEST_CONFIG_COLORS_ANSI
+        // clang-format on
+        std::printf("\033%s", col);
+#endif // DOCTEST_CONFIG_COLORS_ANSI
 
-#    ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-  if(isatty(fileno(stdout)) == false && p->force_colors == false)
-    return;
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+        if(isatty(fileno(stdout)) == false && p->force_colors == false)
+            return;
 
-#      define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(g_stdoutHandle, x | g_originalBackgroundAttributes)
+#define DOCTEST_SET_ATTR(x)                                                                        \
+    SetConsoleTextAttribute(g_stdoutHandle, x | g_originalBackgroundAttributes)
 
-  // clang-format off
+        // clang-format off
         switch (code) {
             case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
             case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
@@ -4534,32 +4296,29 @@ void Color::use(Code
             default:                 DOCTEST_SET_ATTR(g_originalForegroundAttributes);
         }
 // clang-format on
-#      undef DOCTEST_SET_ATTR
-#    endif // DOCTEST_CONFIG_COLORS_WINDOWS
-}
+#undef DOCTEST_SET_ATTR
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+    }
 
-std::vector<const IExceptionTranslator *> & getExceptionTranslators()
-{
-  static std::vector<const IExceptionTranslator *> data;
-  return data;
-}
+    std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
+        static std::vector<const IExceptionTranslator*> data;
+        return data;
+    }
 
-void registerExceptionTranslatorImpl(const IExceptionTranslator * translateFunction)
-{
-  if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), translateFunction)
-     == getExceptionTranslators().end())
-    getExceptionTranslators().push_back(translateFunction);
-}
+    void registerExceptionTranslatorImpl(const IExceptionTranslator* translateFunction) {
+        if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(),
+                     translateFunction) == getExceptionTranslators().end())
+            getExceptionTranslators().push_back(translateFunction);
+    }
 
-String translateActiveException()
-{
-#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-  String res;
-  std::vector<const IExceptionTranslator *> & translators = getExceptionTranslators();
-  for(size_t i = 0; i < translators.size(); ++i)
-    if(translators[i]->translate(res))
-      return res;
-  // clang-format off
+    String translateActiveException() {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        String                                    res;
+        std::vector<const IExceptionTranslator*>& translators = getExceptionTranslators();
+        for(size_t i = 0; i < translators.size(); ++i)
+            if(translators[i]->translate(res))
+                return res;
+        // clang-format off
         try {
             throw;
         } catch(std::exception& ex) {
@@ -4572,902 +4331,822 @@ String translateActiveException()
             return "unknown exception";
         }
 // clang-format on
-#    else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-  return "";
-#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-}
-
-void writeStringToStream(std::ostream * stream, const String & str) { *stream << str; }
-
-#    ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-void toStream(std::ostream * stream, char * in) { *stream << in; }
-void toStream(std::ostream * stream, const char * in) { *stream << in; }
-#    endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-void toStream(std::ostream * stream, bool in) { *stream << std::boolalpha << in << std::noboolalpha; }
-void toStream(std::ostream * stream, float in) { *stream << in; }
-void toStream(std::ostream * stream, double in) { *stream << in; }
-void toStream(std::ostream * stream, double long in) { *stream << in; }
-
-void toStream(std::ostream * stream, char in) { *stream << in; }
-void toStream(std::ostream * stream, char signed in) { *stream << in; }
-void toStream(std::ostream * stream, char unsigned in) { *stream << in; }
-void toStream(std::ostream * stream, int short in) { *stream << in; }
-void toStream(std::ostream * stream, int short unsigned in) { *stream << in; }
-void toStream(std::ostream * stream, int in) { *stream << in; }
-void toStream(std::ostream * stream, int unsigned in) { *stream << in; }
-void toStream(std::ostream * stream, int long in) { *stream << in; }
-void toStream(std::ostream * stream, int long unsigned in) { *stream << in; }
-
-#    ifdef DOCTEST_CONFIG_WITH_LONG_LONG
-void toStream(std::ostream * stream, int long long in) { *stream << in; }
-void toStream(std::ostream * stream, int long long unsigned in) { *stream << in; }
-#    endif // DOCTEST_CONFIG_WITH_LONG_LONG
-
-void addToContexts(IContextScope * ptr) { contextState->contexts.push_back(ptr); }
-void popFromContexts() { contextState->contexts.pop_back(); }
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-void useContextIfExceptionOccurred(IContextScope * ptr)
-{
-  if(std::uncaught_exception())
-  {
-    std::ostringstream stream;
-    ptr->build(&stream);
-    contextState->exceptionalContexts.push_back(stream.str());
-  }
-}
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
-void printSummary();
-
-#    if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-void reportFatal(const std::string &) {}
-struct FatalConditionHandler
-{
-  void reset() {}
-};
-#    else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
-
-void reportFatal(const std::string & message)
-{
-  DOCTEST_LOG_START();
-
-  contextState->numAssertions += contextState->numAssertionsForCurrentTestcase;
-  logTestException(message.c_str(), true);
-  logTestEnd();
-  contextState->numFailed++;
-
-  printSummary();
-}
-
-#      ifdef DOCTEST_PLATFORM_WINDOWS
-
-struct SignalDefs
-{
-  DWORD id;
-  const char * name;
-};
-// There is no 1-1 mapping between signals and windows exceptions.
-// Windows can easily distinguish between SO and SigSegV,
-// but SigInt, SigTerm, etc are handled differently.
-SignalDefs signalDefs[] = {
-    {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
-    {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
-    {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
-    {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
-};
-
-struct FatalConditionHandler
-{
-  static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo)
-  {
-    for(size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
-    {
-      if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id)
-      {
-        reportFatal(signalDefs[i].name);
-      }
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+        return "";
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
-    // If its not an exception we care about, pass it along.
-    // This stops us from eating debugger breaks etc.
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
 
-  FatalConditionHandler()
-  {
-    isSet = true;
-    // 32k seems enough for doctest to handle stack overflow,
-    // but the value was found experimentally, so there is no strong guarantee
-    guaranteeSize = 32 * 1024;
-    exceptionHandlerHandle = 0;
-    // Register as first handler in current chain
-    exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
-    // Pass in guarantee size to be filled
-    SetThreadStackGuarantee(&guaranteeSize);
-  }
+    void writeStringToStream(std::ostream* stream, const String& str) { *stream << str; }
 
-  static void reset()
-  {
-    if(isSet)
-    {
-      // Unregister handler and restore the old guarantee
-      RemoveVectoredExceptionHandler(exceptionHandlerHandle);
-      SetThreadStackGuarantee(&guaranteeSize);
-      exceptionHandlerHandle = 0;
-      isSet = false;
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+    void toStream(std::ostream* stream, char* in) { *stream << in; }
+    void toStream(std::ostream* stream, const char* in) { *stream << in; }
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+    void toStream(std::ostream* stream, bool in) {
+        *stream << std::boolalpha << in << std::noboolalpha;
     }
-  }
-
-  ~FatalConditionHandler() { reset(); }
-
-private:
-  static bool isSet;
-  static ULONG guaranteeSize;
-  static PVOID exceptionHandlerHandle;
-};
-
-bool FatalConditionHandler::isSet = false;
-ULONG FatalConditionHandler::guaranteeSize = 0;
-PVOID FatalConditionHandler::exceptionHandlerHandle = 0;
-
-#      else // DOCTEST_PLATFORM_WINDOWS
-
-struct SignalDefs
-{
-  int id;
-  const char * name;
-};
-SignalDefs signalDefs[] = {
-    {SIGINT, "SIGINT - Terminal interrupt signal"},    {SIGILL, "SIGILL - Illegal instruction signal"},
-    {SIGFPE, "SIGFPE - Floating point error signal"},  {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
-    {SIGTERM, "SIGTERM - Termination request signal"}, {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
-
-struct FatalConditionHandler
-{
-  static bool isSet;
-  static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)];
-  static stack_t oldSigStack;
-  static char altStackMem[SIGSTKSZ];
-
-  static void handleSignal(int sig)
-  {
-    std::string name = "<unknown signal>";
-    for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
-    {
-      SignalDefs & def = signalDefs[i];
-      if(sig == def.id)
-      {
-        name = def.name;
-        break;
-      }
-    }
-    reset();
-    reportFatal(name);
-    raise(sig);
-  }
-
-  FatalConditionHandler()
-  {
-    isSet = true;
-    stack_t sigStack;
-    sigStack.ss_sp = altStackMem;
-    sigStack.ss_size = SIGSTKSZ;
-    sigStack.ss_flags = 0;
-    sigaltstack(&sigStack, &oldSigStack);
-    struct sigaction sa = {0};
-
-    sa.sa_handler = handleSignal; // NOLINT
-    sa.sa_flags = SA_ONSTACK;
-    for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
-    {
-      sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
-    }
-  }
-
-  ~FatalConditionHandler() { reset(); }
-  static void reset()
-  {
-    if(isSet)
-    {
-      // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-      for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
-      {
-        sigaction(signalDefs[i].id, &oldSigActions[i], 0);
-      } // Return the old stack
-      sigaltstack(&oldSigStack, 0);
-      isSet = false;
-    }
-  }
-};
-
-bool FatalConditionHandler::isSet = false;
-struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)] = {};
-stack_t FatalConditionHandler::oldSigStack = {};
-char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
-
-#      endif // DOCTEST_PLATFORM_WINDOWS
-#    endif   // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
-
-// depending on the current options this will remove the path of filenames
-const char * fileForOutput(const char * file)
-{
-  if(contextState->no_path_in_filenames)
-  {
-    const char * back = std::strrchr(file, '\\');
-    const char * forward = std::strrchr(file, '/');
-    if(back || forward)
-    {
-      if(back > forward)
-        forward = back;
-      return forward + 1;
-    }
-  }
-  return file;
-}
-
-// depending on the current options this will substitute the line numbers with 0
-int lineForOutput(int line)
-{
-  if(contextState->no_line_numbers)
-    return 0;
-  return line;
-}
-
-#    ifdef DOCTEST_PLATFORM_MAC
-#      include <sys/types.h>
-#      include <unistd.h>
-#      include <sys/sysctl.h>
-// The following function is taken directly from the following technical note:
-// http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
-// Returns true if the current process is being debugged (either
-// running under the debugger or has a debugger attached post facto).
-bool isDebuggerActive()
-{
-  int mib[4];
-  kinfo_proc info;
-  size_t size;
-  // Initialize the flags so that, if sysctl fails for some bizarre
-  // reason, we get a predictable result.
-  info.kp_proc.p_flag = 0;
-  // Initialize mib, which tells sysctl the info we want, in this case
-  // we're looking for information about a specific process ID.
-  mib[0] = CTL_KERN;
-  mib[1] = KERN_PROC;
-  mib[2] = KERN_PROC_PID;
-  mib[3] = getpid();
-  // Call sysctl.
-  size = sizeof(info);
-  if(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, 0, 0) != 0)
-  {
-    fprintf(stderr, "\n** Call to sysctl failed - unable to determine if debugger is "
-                    "active **\n\n");
-    return false;
-  }
-  // We're being debugged if the P_TRACED flag is set.
-  return ((info.kp_proc.p_flag & P_TRACED) != 0);
-}
-#    elif DOCTEST_MSVC || defined(__MINGW32__)
-bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
-#    else
-bool isDebuggerActive() { return false; }
-#    endif // Platform
-
-#    ifdef DOCTEST_PLATFORM_WINDOWS
-void myOutputDebugString(const String & text) { ::OutputDebugStringA(text.c_str()); }
-#    else
-// TODO: integration with XCode and other IDEs
-void myOutputDebugString(const String &) {}
-#    endif // Platform
-
-const char * getSeparator()
-{
-  return "===============================================================================\n";
-}
-
-void printToDebugConsole(const String & text)
-{
-  if(isDebuggerActive())
-    myOutputDebugString(text.c_str());
-}
-
-void addFailedAssert(assertType::Enum assert_type)
-{
-  if((assert_type & assertType::is_warn) == 0)
-  { //! OCLINT bitwise operator in conditional
-    contextState->numFailedAssertions++;
-    contextState->numFailedAssertionsForCurrentTestcase++;
-    contextState->hasCurrentTestFailed = true;
-  }
-}
-
-void logTestStart(const TestCase & tc)
-{
-  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)\n", fileForOutput(tc.m_file), lineForOutput(tc.m_line));
-
-  char ts1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(ts1, DOCTEST_COUNTOF(ts1), "TEST SUITE: ");
-  char ts2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(ts2, DOCTEST_COUNTOF(ts2), "%s\n", tc.m_test_suite);
-  char n1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(n1, DOCTEST_COUNTOF(n1), "TEST CASE:  ");
-  char n2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(n2, DOCTEST_COUNTOF(n2), "%s\n", tc.m_name);
-  char d1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(d1, DOCTEST_COUNTOF(d1), "DESCRIPTION: ");
-  char d2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(d2, DOCTEST_COUNTOF(d2), "%s\n", tc.m_description);
-
-  // hack for BDD style of macros - to not print "TEST CASE:"
-  char scenario[] = "  Scenario:";
-  if(std::string(tc.m_name).substr(0, DOCTEST_COUNTOF(scenario) - 1) == scenario)
-    n1[0] = '\0';
-
-  DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-
-  String forDebugConsole;
-  if(tc.m_description)
-  {
-    DOCTEST_PRINTF_COLORED(d1, Color::Yellow);
-    DOCTEST_PRINTF_COLORED(d2, Color::None);
-    forDebugConsole += d1;
-    forDebugConsole += d2;
-  }
-  if(tc.m_test_suite && tc.m_test_suite[0] != '\0')
-  {
-    DOCTEST_PRINTF_COLORED(ts1, Color::Yellow);
-    DOCTEST_PRINTF_COLORED(ts2, Color::None);
-    forDebugConsole += ts1;
-    forDebugConsole += ts2;
-  }
-  DOCTEST_PRINTF_COLORED(n1, Color::Yellow);
-  DOCTEST_PRINTF_COLORED(n2, Color::None);
-
-  String subcaseStuff;
-  std::vector<Subcase> & subcasesStack = contextState->subcasesStack;
-  for(unsigned i = 0; i < subcasesStack.size(); ++i)
-  {
-    if(subcasesStack[i].m_signature.m_name[0] != '\0')
-    {
-      char subcase[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-      DOCTEST_SNPRINTF(subcase, DOCTEST_COUNTOF(loc), "  %s\n", subcasesStack[i].m_signature.m_name);
-      DOCTEST_PRINTF_COLORED(subcase, Color::None);
-      subcaseStuff += subcase;
-    }
-  }
-
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(getSeparator()) + loc + forDebugConsole.c_str() + n1 + n2 + subcaseStuff.c_str() + "\n");
-}
-
-void logTestEnd() {}
-
-void logTestException(const String & what, bool crash)
-{
-  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-
-  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED!\n");
-
-  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  info1[0] = 0;
-  info2[0] = 0;
-  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), crash ? "crashed:\n" : "threw exception:\n");
-  DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "  %s\n", what.c_str());
-
-  std::string contextStr;
-
-  if(!contextState->exceptionalContexts.empty())
-  {
-    contextStr += "with context:\n";
-    for(size_t i = contextState->exceptionalContexts.size(); i > 0; --i)
-    {
-      contextStr += "  ";
-      contextStr += contextState->exceptionalContexts[i - 1];
-      contextStr += "\n";
-    }
-  }
-
-  DOCTEST_PRINTF_COLORED(msg, Color::Red);
-  DOCTEST_PRINTF_COLORED(info1, Color::None);
-  DOCTEST_PRINTF_COLORED(info2, Color::Cyan);
-  DOCTEST_PRINTF_COLORED(contextStr.c_str(), Color::None);
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(msg) + info1 + info2 + contextStr.c_str() + "\n");
-}
-
-String logContext()
-{
-  std::ostringstream stream;
-  std::vector<IContextScope *> & contexts = contextState->contexts;
-  if(!contexts.empty())
-    stream << "with context:\n";
-  for(size_t i = 0; i < contexts.size(); ++i)
-  {
-    stream << "  ";
-    contexts[i]->build(&stream);
-    stream << "\n";
-  }
-  return stream.str().c_str();
-}
-
-const char * getFailString(assertType::Enum assert_type)
-{
-  if(assert_type & assertType::is_warn) //! OCLINT bitwise operator in conditional
-    return "WARNING";
-  if(assert_type & assertType::is_check) //! OCLINT bitwise operator in conditional
-    return "ERROR";
-  if(assert_type & assertType::is_require) //! OCLINT bitwise operator in conditional
-    return "FATAL ERROR";
-  return "";
-}
-
-void logAssert(bool passed,
-               const char * decomposition,
-               bool threw,
-               const String & exception,
-               const char * expr,
-               assertType::Enum assert_type,
-               const char * file,
-               int line)
-{
-  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
-
-  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", passed ? "PASSED" : getFailString(assert_type));
-
-  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n", getAssertString(assert_type), expr);
-
-  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  info2[0] = 0;
-  info3[0] = 0;
-  if(threw)
-  {
-    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
-    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
-  }
-  else
-  {
-    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "with expansion:\n");
-    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s( %s )\n", getAssertString(assert_type), decomposition);
-  }
-
-  const bool isWarn = assert_type & assertType::is_warn;
-  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-  DOCTEST_PRINTF_COLORED(msg, passed ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
-  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-  DOCTEST_PRINTF_COLORED(info2, Color::None);
-  DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
-  String context = logContext();
-  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
-}
-
-void logAssertThrows(bool threw, const char * expr, assertType::Enum assert_type, const char * file, int line)
-{
-  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
-
-  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", threw ? "PASSED" : getFailString(assert_type));
-
-  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n", getAssertString(assert_type), expr);
-
-  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  info2[0] = 0;
-
-  if(!threw)
-    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
-
-  const bool isWarn = assert_type & assertType::is_warn;
-  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-  DOCTEST_PRINTF_COLORED(msg, threw ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
-  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-  DOCTEST_PRINTF_COLORED(info2, Color::None);
-  String context = logContext();
-  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(loc) + msg + info1 + info2 + context.c_str() + "\n");
-}
-
-void logAssertThrowsAs(bool threw,
-                       bool threw_as,
-                       const char * as,
-                       const String & exception,
-                       const char * expr,
-                       assertType::Enum assert_type,
-                       const char * file,
-                       int line)
-{
-  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
-
-  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", threw_as ? "PASSED" : getFailString(assert_type));
-
-  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s, %s )\n", getAssertString(assert_type), expr, as);
-
-  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  info2[0] = 0;
-  info3[0] = 0;
-
-  if(!threw)
-  { //! OCLINT inverted logic
-    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
-  }
-  else if(!threw_as)
-  {
-    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw a different exception:\n");
-    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
-  }
-
-  const bool isWarn = assert_type & assertType::is_warn;
-  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-  DOCTEST_PRINTF_COLORED(msg, threw_as ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
-  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-  DOCTEST_PRINTF_COLORED(info2, Color::None);
-  DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
-  String context = logContext();
-  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
-}
-
-void logAssertNothrow(bool threw,
-                      const String & exception,
-                      const char * expr,
-                      assertType::Enum assert_type,
-                      const char * file,
-                      int line)
-{
-  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file), lineForOutput(line));
-
-  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", threw ? getFailString(assert_type) : "PASSED");
-
-  char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n", getAssertString(assert_type), expr);
-
-  char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  info2[0] = 0;
-  info3[0] = 0;
-  if(threw)
-  {
-    DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
-    DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
-  }
-
-  const bool isWarn = assert_type & assertType::is_warn;
-  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-  DOCTEST_PRINTF_COLORED(msg, threw ? isWarn ? Color::Yellow : Color::Red : Color::BrightGreen);
-  DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
-  DOCTEST_PRINTF_COLORED(info2, Color::None);
-  DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
-  String context = logContext();
-  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
-}
-
-ResultBuilder::ResultBuilder(assertType::Enum assert_type,
-                             const char * file,
-                             int line,
-                             const char * expr,
-                             const char * exception_type)
-: m_assert_type(assert_type), m_file(file), m_line(line), m_expr(expr), m_exception_type(exception_type),
-  m_threw(false), m_threw_as(false), m_failed(false)
-{
-#    if DOCTEST_MSVC
-  if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-    ++m_expr;
-#    endif // MSVC
-}
-
-ResultBuilder::~ResultBuilder() {}
-
-void ResultBuilder::unexpectedExceptionOccurred()
-{
-  m_threw = true;
-
-  m_exception = translateActiveException();
-}
-
-bool ResultBuilder::log()
-{
-  if((m_assert_type & assertType::is_warn) == 0) //! OCLINT bitwise operator in conditional
-    contextState->numAssertionsForCurrentTestcase++;
-
-  if(m_assert_type & assertType::is_throws)
-  { //! OCLINT bitwise operator in conditional
-    m_failed = !m_threw;
-  }
-  else if(m_assert_type & //! OCLINT bitwise operator in conditional
-          assertType::is_throws_as)
-  {
-    m_failed = !m_threw_as;
-  }
-  else if(m_assert_type & //! OCLINT bitwise operator in conditional
-          assertType::is_nothrow)
-  {
-    m_failed = m_threw;
-  }
-  else
-  {
-    m_failed = m_result;
-  }
-
-  if(m_failed || contextState->success)
-  {
-    DOCTEST_LOG_START();
-
-    if(m_assert_type & assertType::is_throws)
-    { //! OCLINT bitwise operator in conditional
-      logAssertThrows(m_threw, m_expr, m_assert_type, m_file, m_line);
-    }
-    else if(m_assert_type & //! OCLINT bitwise operator in conditional
-            assertType::is_throws_as)
-    {
-      logAssertThrowsAs(m_threw, m_threw_as, m_exception_type, m_exception, m_expr, m_assert_type, m_file, m_line);
-    }
-    else if(m_assert_type & //! OCLINT bitwise operator in conditional
-            assertType::is_nothrow)
-    {
-      logAssertNothrow(m_threw, m_exception, m_expr, m_assert_type, m_file, m_line);
-    }
-    else
-    {
-      logAssert(m_result.m_passed, m_result.m_decomposition.c_str(), m_threw, m_exception, m_expr, m_assert_type,
-                m_file, m_line);
-    }
-  }
-
-  if(m_failed)
-    addFailedAssert(m_assert_type);
-
-  return m_failed && isDebuggerActive() && !contextState->no_breaks; // break into debugger
-}
-
-void ResultBuilder::react() const
-{
-  if(m_failed && checkIfShouldThrow(m_assert_type))
-    throwException();
-}
-
-MessageBuilder::MessageBuilder(const char * file, int line, assertType::Enum severity)
-: m_stream(createStream()), m_file(file), m_line(line), m_severity(severity)
-{
-}
-
-bool MessageBuilder::log()
-{
-  DOCTEST_LOG_START();
-
-  const bool isWarn = m_severity & assertType::is_warn;
-
-  // warn is just a message in this context so we dont treat it as an assert
-  if(!isWarn)
-  {
-    contextState->numAssertionsForCurrentTestcase++;
-    addFailedAssert(m_severity);
-  }
-
-  char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(m_file), lineForOutput(m_line));
-  char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-  DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n", isWarn ? "MESSAGE" : getFailString(m_severity));
-
-  DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
-  DOCTEST_PRINTF_COLORED(msg, isWarn ? Color::Yellow : Color::Red);
-
-  String info = getStreamResult(m_stream);
-  if(info.size())
-  {
-    DOCTEST_PRINTF_COLORED("  ", Color::None);
-    DOCTEST_PRINTF_COLORED(info.c_str(), Color::None);
-    DOCTEST_PRINTF_COLORED("\n", Color::None);
-  }
-  String context = logContext();
-  DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
-  DOCTEST_PRINTF_COLORED("\n", Color::None);
-
-  printToDebugConsole(String(loc) + msg + "  " + info.c_str() + "\n" + context.c_str() + "\n");
-
-  return isDebuggerActive() && !contextState->no_breaks && !isWarn; // break into debugger
-}
-
-void MessageBuilder::react()
-{
-  if(m_severity & assertType::is_require) //! OCLINT bitwise operator in conditional
-    throwException();
-}
-
-MessageBuilder::~MessageBuilder() { freeStream(m_stream); }
-
-// the implementation of parseFlag()
-bool parseFlagImpl(int argc, const char * const * argv, const char * pattern)
-{
-  for(int i = argc - 1; i >= 0; --i)
-  {
-    const char * temp = std::strstr(argv[i], pattern);
-    if(temp && my_strlen(temp) == my_strlen(pattern))
-    {
-      // eliminate strings in which the chars before the option are not '-'
-      bool noBadCharsFound = true; //! OCLINT prefer early exits and continue
-      while(temp != argv[i])
-      {
-        if(*--temp != '-')
-        {
-          noBadCharsFound = false;
-          break;
+    void toStream(std::ostream* stream, float in) { *stream << in; }
+    void toStream(std::ostream* stream, double in) { *stream << in; }
+    void toStream(std::ostream* stream, double long in) { *stream << in; }
+
+    void toStream(std::ostream* stream, char in) { *stream << in; }
+    void toStream(std::ostream* stream, char signed in) { *stream << in; }
+    void toStream(std::ostream* stream, char unsigned in) { *stream << in; }
+    void toStream(std::ostream* stream, int short in) { *stream << in; }
+    void toStream(std::ostream* stream, int short unsigned in) { *stream << in; }
+    void toStream(std::ostream* stream, int in) { *stream << in; }
+    void toStream(std::ostream* stream, int unsigned in) { *stream << in; }
+    void toStream(std::ostream* stream, int long in) { *stream << in; }
+    void toStream(std::ostream* stream, int long unsigned in) { *stream << in; }
+
+#ifdef DOCTEST_CONFIG_WITH_LONG_LONG
+    void toStream(std::ostream* stream, int long long in) { *stream << in; }
+    void toStream(std::ostream* stream, int long long unsigned in) { *stream << in; }
+#endif // DOCTEST_CONFIG_WITH_LONG_LONG
+
+    void addToContexts(IContextScope* ptr) { contextState->contexts.push_back(ptr); }
+    void popFromContexts() { contextState->contexts.pop_back(); }
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+    void useContextIfExceptionOccurred(IContextScope* ptr) {
+        if(std::uncaught_exception()) {
+            std::ostringstream stream;
+            ptr->build(&stream);
+            contextState->exceptionalContexts.push_back(stream.str());
         }
-      }
-      if(noBadCharsFound && argv[i][0] == '-')
-        return true;
     }
-  }
-  return false;
-}
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-// locates a flag on the command line
-bool parseFlag(int argc, const char * const * argv, const char * pattern)
-{
-#    ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-  if(!parseFlagImpl(argc, argv, pattern))
-    return parseFlagImpl(argc, argv, pattern + 3); // 3 for "dt-"
-  return true;
-#    else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-  return parseFlagImpl(argc, argv, pattern);
-#    endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-}
+    void printSummary();
 
-// the implementation of parseOption()
-bool parseOptionImpl(int argc, const char * const * argv, const char * pattern, String & res)
-{
-  for(int i = argc - 1; i >= 0; --i)
-  {
-    const char * temp = std::strstr(argv[i], pattern);
-    if(temp)
-    { //! OCLINT prefer early exits and continue
-      // eliminate matches in which the chars before the option are not '-'
-      bool noBadCharsFound = true;
-      const char * curr = argv[i];
-      while(curr != temp)
-      {
-        if(*curr++ != '-')
-        {
-          noBadCharsFound = false;
-          break;
+#if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
+    void reportFatal(const std::string&) {}
+    struct FatalConditionHandler
+    {
+        void reset() {}
+    };
+#else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+    void reportFatal(const std::string& message) {
+        DOCTEST_LOG_START();
+
+        contextState->numAssertions += contextState->numAssertionsForCurrentTestcase;
+        logTestException(message.c_str(), true);
+        logTestEnd();
+        contextState->numFailed++;
+
+        printSummary();
+    }
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+
+    struct SignalDefs
+    {
+        DWORD       id;
+        const char* name;
+    };
+    // There is no 1-1 mapping between signals and windows exceptions.
+    // Windows can easily distinguish between SO and SigSegV,
+    // but SigInt, SigTerm, etc are handled differently.
+    SignalDefs signalDefs[] = {
+            {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
+            {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
+            {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
+            {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
+    };
+
+    struct FatalConditionHandler
+    {
+        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
+            for(size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
+                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+                    reportFatal(signalDefs[i].name);
+                }
+            }
+            // If its not an exception we care about, pass it along.
+            // This stops us from eating debugger breaks etc.
+            return EXCEPTION_CONTINUE_SEARCH;
         }
-      }
-      if(noBadCharsFound && argv[i][0] == '-')
-      {
-        temp += my_strlen(pattern);
-        const unsigned len = my_strlen(temp);
-        if(len)
-        {
-          res = temp;
-          return true;
+
+        FatalConditionHandler() {
+            isSet = true;
+            // 32k seems enough for doctest to handle stack overflow,
+            // but the value was found experimentally, so there is no strong guarantee
+            guaranteeSize          = 32 * 1024;
+            exceptionHandlerHandle = 0;
+            // Register as first handler in current chain
+            exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+            // Pass in guarantee size to be filled
+            SetThreadStackGuarantee(&guaranteeSize);
         }
-      }
-    }
-  }
-  return false;
-}
 
-// parses an option and returns the string after the '=' character
-bool parseOption(int argc,
-                 const char * const * argv,
-                 const char * pattern,
-                 String & res,
-                 const String & defaultVal = String())
-{
-  res = defaultVal;
-#    ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-  if(!parseOptionImpl(argc, argv, pattern, res))
-    return parseOptionImpl(argc, argv, pattern + 3, res); // 3 for "dt-"
-  return true;
-#    else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-  return parseOptionImpl(argc, argv, pattern, res);
-#    endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-}
+        static void reset() {
+            if(isSet) {
+                // Unregister handler and restore the old guarantee
+                RemoveVectoredExceptionHandler(exceptionHandlerHandle);
+                SetThreadStackGuarantee(&guaranteeSize);
+                exceptionHandlerHandle = 0;
+                isSet                  = false;
+            }
+        }
 
-// parses a comma separated list of words after a pattern in one of the arguments in argv
-bool parseCommaSepArgs(int argc, const char * const * argv, const char * pattern, std::vector<String> & res)
-{
-  String filtersString;
-  if(parseOption(argc, argv, pattern, filtersString))
-  {
-    // tokenize with "," as a separator
-    // cppcheck-suppress strtokCalled
-    char * pch = std::strtok(filtersString.c_str(), ","); // modifies the string
-    while(pch != 0)
+        ~FatalConditionHandler() { reset(); }
+
+    private:
+        static bool  isSet;
+        static ULONG guaranteeSize;
+        static PVOID exceptionHandlerHandle;
+    };
+
+    bool  FatalConditionHandler::isSet                  = false;
+    ULONG FatalConditionHandler::guaranteeSize          = 0;
+    PVOID FatalConditionHandler::exceptionHandlerHandle = 0;
+
+#else // DOCTEST_PLATFORM_WINDOWS
+
+    struct SignalDefs
     {
-      if(my_strlen(pch))
-        res.push_back(pch);
-      // uses the strtok() internal state to go to the next token
-      // cppcheck-suppress strtokCalled
-      pch = std::strtok(0, ",");
-    }
-    return true;
-  }
-  return false;
-}
+        int         id;
+        const char* name;
+    };
+    SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
+                               {SIGILL, "SIGILL - Illegal instruction signal"},
+                               {SIGFPE, "SIGFPE - Floating point error signal"},
+                               {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+                               {SIGTERM, "SIGTERM - Termination request signal"},
+                               {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
 
-enum optionType
-{
-  option_bool,
-  option_int
-};
-
-// parses an int/bool option from the command line
-bool parseIntOption(int argc, const char * const * argv, const char * pattern, optionType type, int & res)
-{
-  String parsedValue;
-  if(!parseOption(argc, argv, pattern, parsedValue))
-    return false;
-
-  if(type == 0)
-  {
-    // boolean
-    const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
-    const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
-
-    // if the value matches any of the positive/negative possibilities
-    for(unsigned i = 0; i < 4; i++)
+    struct FatalConditionHandler
     {
-      if(parsedValue.compare(positive[i], true) == 0)
-      {
-        res = 1; //! OCLINT parameter reassignment
+        static bool             isSet;
+        static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)];
+        static stack_t          oldSigStack;
+        static char             altStackMem[SIGSTKSZ];
+
+        static void handleSignal(int sig) {
+            std::string name = "<unknown signal>";
+            for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
+                SignalDefs& def = signalDefs[i];
+                if(sig == def.id) {
+                    name = def.name;
+                    break;
+                }
+            }
+            reset();
+            reportFatal(name);
+            raise(sig);
+        }
+
+        FatalConditionHandler() {
+            isSet = true;
+            stack_t sigStack;
+            sigStack.ss_sp    = altStackMem;
+            sigStack.ss_size  = SIGSTKSZ;
+            sigStack.ss_flags = 0;
+            sigaltstack(&sigStack, &oldSigStack);
+            struct sigaction sa = {0};
+
+            sa.sa_handler = handleSignal; // NOLINT
+            sa.sa_flags   = SA_ONSTACK;
+            for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
+                sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
+            }
+        }
+
+        ~FatalConditionHandler() { reset(); }
+        static void reset() {
+            if(isSet) {
+                // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
+                for(std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
+                    sigaction(signalDefs[i].id, &oldSigActions[i], 0);
+                }
+                // Return the old stack
+                sigaltstack(&oldSigStack, 0);
+                isSet = false;
+            }
+        }
+    };
+
+    bool             FatalConditionHandler::isSet = false;
+    struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)] =
+            {};
+    stack_t FatalConditionHandler::oldSigStack           = {};
+    char    FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+
+#endif // DOCTEST_PLATFORM_WINDOWS
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+
+    // depending on the current options this will remove the path of filenames
+    const char* fileForOutput(const char* file) {
+        if(contextState->no_path_in_filenames) {
+            const char* back    = std::strrchr(file, '\\');
+            const char* forward = std::strrchr(file, '/');
+            if(back || forward) {
+                if(back > forward)
+                    forward = back;
+                return forward + 1;
+            }
+        }
+        return file;
+    }
+
+    // depending on the current options this will substitute the line numbers with 0
+    int lineForOutput(int line) {
+        if(contextState->no_line_numbers)
+            return 0;
+        return line;
+    }
+
+#ifdef DOCTEST_PLATFORM_MAC
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/sysctl.h>
+    // The following function is taken directly from the following technical note:
+    // http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
+    // Returns true if the current process is being debugged (either
+    // running under the debugger or has a debugger attached post facto).
+    bool isDebuggerActive() {
+        int        mib[4];
+        kinfo_proc info;
+        size_t     size;
+        // Initialize the flags so that, if sysctl fails for some bizarre
+        // reason, we get a predictable result.
+        info.kp_proc.p_flag = 0;
+        // Initialize mib, which tells sysctl the info we want, in this case
+        // we're looking for information about a specific process ID.
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_PROC;
+        mib[2] = KERN_PROC_PID;
+        mib[3] = getpid();
+        // Call sysctl.
+        size = sizeof(info);
+        if(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, 0, 0) != 0) {
+            fprintf(stderr, "\n** Call to sysctl failed - unable to determine if debugger is "
+                            "active **\n\n");
+            return false;
+        }
+        // We're being debugged if the P_TRACED flag is set.
+        return ((info.kp_proc.p_flag & P_TRACED) != 0);
+    }
+#elif DOCTEST_MSVC || defined(__MINGW32__)
+    bool  isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
+#else
+    bool isDebuggerActive() { return false; }
+#endif // Platform
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    void myOutputDebugString(const String& text) { ::OutputDebugStringA(text.c_str()); }
+#else
+    // TODO: integration with XCode and other IDEs
+    void myOutputDebugString(const String&) {}
+#endif // Platform
+
+    const char* getSeparator() {
+        return "===============================================================================\n";
+    }
+
+    void printToDebugConsole(const String& text) {
+        if(isDebuggerActive())
+            myOutputDebugString(text.c_str());
+    }
+
+    void addFailedAssert(assertType::Enum assert_type) {
+        if((assert_type & assertType::is_warn) == 0) { //!OCLINT bitwise operator in conditional
+            contextState->numFailedAssertions++;
+            contextState->numFailedAssertionsForCurrentTestcase++;
+            contextState->hasCurrentTestFailed = true;
+        }
+    }
+
+    void logTestStart(const TestCase& tc) {
+        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)\n", fileForOutput(tc.m_file),
+                         lineForOutput(tc.m_line));
+
+        char ts1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(ts1, DOCTEST_COUNTOF(ts1), "TEST SUITE: ");
+        char ts2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(ts2, DOCTEST_COUNTOF(ts2), "%s\n", tc.m_test_suite);
+        char n1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(n1, DOCTEST_COUNTOF(n1), "TEST CASE:  ");
+        char n2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(n2, DOCTEST_COUNTOF(n2), "%s\n", tc.m_name);
+        char d1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(d1, DOCTEST_COUNTOF(d1), "DESCRIPTION: ");
+        char d2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(d2, DOCTEST_COUNTOF(d2), "%s\n", tc.m_description);
+
+        // hack for BDD style of macros - to not print "TEST CASE:"
+        char scenario[] = "  Scenario:";
+        if(std::string(tc.m_name).substr(0, DOCTEST_COUNTOF(scenario) - 1) == scenario)
+            n1[0] = '\0';
+
+        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+
+        String forDebugConsole;
+        if(tc.m_description) {
+            DOCTEST_PRINTF_COLORED(d1, Color::Yellow);
+            DOCTEST_PRINTF_COLORED(d2, Color::None);
+            forDebugConsole += d1;
+            forDebugConsole += d2;
+        }
+        if(tc.m_test_suite && tc.m_test_suite[0] != '\0') {
+            DOCTEST_PRINTF_COLORED(ts1, Color::Yellow);
+            DOCTEST_PRINTF_COLORED(ts2, Color::None);
+            forDebugConsole += ts1;
+            forDebugConsole += ts2;
+        }
+        DOCTEST_PRINTF_COLORED(n1, Color::Yellow);
+        DOCTEST_PRINTF_COLORED(n2, Color::None);
+
+        String                subcaseStuff;
+        std::vector<Subcase>& subcasesStack = contextState->subcasesStack;
+        for(unsigned i = 0; i < subcasesStack.size(); ++i) {
+            if(subcasesStack[i].m_signature.m_name[0] != '\0') {
+                char subcase[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+                DOCTEST_SNPRINTF(subcase, DOCTEST_COUNTOF(loc), "  %s\n",
+                                 subcasesStack[i].m_signature.m_name);
+                DOCTEST_PRINTF_COLORED(subcase, Color::None);
+                subcaseStuff += subcase;
+            }
+        }
+
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(getSeparator()) + loc + forDebugConsole.c_str() + n1 + n2 +
+                            subcaseStuff.c_str() + "\n");
+    }
+
+    void logTestEnd() {}
+
+    void logTestException(const String& what, bool crash) {
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED!\n");
+
+        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        info1[0] = 0;
+        info2[0] = 0;
+        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1),
+                         crash ? "crashed:\n" : "threw exception:\n");
+        DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "  %s\n", what.c_str());
+
+        std::string contextStr;
+
+        if(!contextState->exceptionalContexts.empty()) {
+            contextStr += "with context:\n";
+            for(size_t i = contextState->exceptionalContexts.size(); i > 0; --i) {
+                contextStr += "  ";
+                contextStr += contextState->exceptionalContexts[i - 1];
+                contextStr += "\n";
+            }
+        }
+
+        DOCTEST_PRINTF_COLORED(msg, Color::Red);
+        DOCTEST_PRINTF_COLORED(info1, Color::None);
+        DOCTEST_PRINTF_COLORED(info2, Color::Cyan);
+        DOCTEST_PRINTF_COLORED(contextStr.c_str(), Color::None);
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(msg) + info1 + info2 + contextStr.c_str() + "\n");
+    }
+
+    String logContext() {
+        std::ostringstream           stream;
+        std::vector<IContextScope*>& contexts = contextState->contexts;
+        if(!contexts.empty())
+            stream << "with context:\n";
+        for(size_t i = 0; i < contexts.size(); ++i) {
+            stream << "  ";
+            contexts[i]->build(&stream);
+            stream << "\n";
+        }
+        return stream.str().c_str();
+    }
+
+    const char* getFailString(assertType::Enum assert_type) {
+        if(assert_type & assertType::is_warn) //!OCLINT bitwise operator in conditional
+            return "WARNING";
+        if(assert_type & assertType::is_check) //!OCLINT bitwise operator in conditional
+            return "ERROR";
+        if(assert_type & assertType::is_require) //!OCLINT bitwise operator in conditional
+            return "FATAL ERROR";
+        return "";
+    }
+
+    void logAssert(bool passed, const char* decomposition, bool threw, const String& exception,
+                   const char* expr, assertType::Enum assert_type, const char* file, int line) {
+        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
+                         lineForOutput(line));
+
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
+                         passed ? "PASSED" : getFailString(assert_type));
+
+        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n",
+                         getAssertString(assert_type), expr);
+
+        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        info2[0] = 0;
+        info3[0] = 0;
+        if(threw) {
+            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
+            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
+        } else {
+            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "with expansion:\n");
+            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s( %s )\n",
+                             getAssertString(assert_type), decomposition);
+        }
+
+        const bool isWarn = assert_type & assertType::is_warn;
+        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+        DOCTEST_PRINTF_COLORED(msg,
+                               passed ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
+        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+        DOCTEST_PRINTF_COLORED(info2, Color::None);
+        DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
+        String context = logContext();
+        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
+    }
+
+    void logAssertThrows(bool threw, const char* expr, assertType::Enum assert_type,
+                         const char* file, int line) {
+        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
+                         lineForOutput(line));
+
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
+                         threw ? "PASSED" : getFailString(assert_type));
+
+        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n",
+                         getAssertString(assert_type), expr);
+
+        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        info2[0] = 0;
+
+        if(!threw)
+            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
+
+        const bool isWarn = assert_type & assertType::is_warn;
+        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+        DOCTEST_PRINTF_COLORED(msg,
+                               threw ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
+        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+        DOCTEST_PRINTF_COLORED(info2, Color::None);
+        String context = logContext();
+        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(loc) + msg + info1 + info2 + context.c_str() + "\n");
+    }
+
+    void logAssertThrowsAs(bool threw, bool threw_as, const char* as, const String& exception,
+                           const char* expr, assertType::Enum assert_type, const char* file,
+                           int line) {
+        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
+                         lineForOutput(line));
+
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
+                         threw_as ? "PASSED" : getFailString(assert_type));
+
+        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s, %s )\n",
+                         getAssertString(assert_type), expr, as);
+
+        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        info2[0] = 0;
+        info3[0] = 0;
+
+        if(!threw) { //!OCLINT inverted logic
+            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "didn't throw at all\n");
+        } else if(!threw_as) {
+            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw a different exception:\n");
+            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
+        }
+
+        const bool isWarn = assert_type & assertType::is_warn;
+        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+        DOCTEST_PRINTF_COLORED(msg,
+                               threw_as ? Color::BrightGreen : isWarn ? Color::Yellow : Color::Red);
+        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+        DOCTEST_PRINTF_COLORED(info2, Color::None);
+        DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
+        String context = logContext();
+        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
+    }
+
+    void logAssertNothrow(bool threw, const String& exception, const char* expr,
+                          assertType::Enum assert_type, const char* file, int line) {
+        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(file),
+                         lineForOutput(line));
+
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
+                         threw ? getFailString(assert_type) : "PASSED");
+
+        char info1[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(info1, DOCTEST_COUNTOF(info1), "  %s( %s )\n",
+                         getAssertString(assert_type), expr);
+
+        char info2[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        char info3[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        info2[0] = 0;
+        info3[0] = 0;
+        if(threw) {
+            DOCTEST_SNPRINTF(info2, DOCTEST_COUNTOF(info2), "threw exception:\n");
+            DOCTEST_SNPRINTF(info3, DOCTEST_COUNTOF(info3), "  %s\n", exception.c_str());
+        }
+
+        const bool isWarn = assert_type & assertType::is_warn;
+        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+        DOCTEST_PRINTF_COLORED(msg,
+                               threw ? isWarn ? Color::Yellow : Color::Red : Color::BrightGreen);
+        DOCTEST_PRINTF_COLORED(info1, Color::Cyan);
+        DOCTEST_PRINTF_COLORED(info2, Color::None);
+        DOCTEST_PRINTF_COLORED(info3, Color::Cyan);
+        String context = logContext();
+        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(loc) + msg + info1 + info2 + info3 + context.c_str() + "\n");
+    }
+
+    ResultBuilder::ResultBuilder(assertType::Enum assert_type, const char* file, int line,
+                                 const char* expr, const char* exception_type)
+            : m_assert_type(assert_type)
+            , m_file(file)
+            , m_line(line)
+            , m_expr(expr)
+            , m_exception_type(exception_type)
+            , m_threw(false)
+            , m_threw_as(false)
+            , m_failed(false) {
+#if DOCTEST_MSVC
+        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+            ++m_expr;
+#endif // MSVC
+    }
+
+    ResultBuilder::~ResultBuilder() {}
+
+    void ResultBuilder::unexpectedExceptionOccurred() {
+        m_threw = true;
+
+        m_exception = translateActiveException();
+    }
+
+    bool ResultBuilder::log() {
+        if((m_assert_type & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
+            contextState->numAssertionsForCurrentTestcase++;
+
+        if(m_assert_type & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+            m_failed = !m_threw;
+        } else if(m_assert_type & //!OCLINT bitwise operator in conditional
+                  assertType::is_throws_as) {
+            m_failed = !m_threw_as;
+        } else if(m_assert_type & //!OCLINT bitwise operator in conditional
+                  assertType::is_nothrow) {
+            m_failed = m_threw;
+        } else {
+            m_failed = m_result;
+        }
+
+        if(m_failed || contextState->success) {
+            DOCTEST_LOG_START();
+
+            if(m_assert_type & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+                logAssertThrows(m_threw, m_expr, m_assert_type, m_file, m_line);
+            } else if(m_assert_type & //!OCLINT bitwise operator in conditional
+                      assertType::is_throws_as) {
+                logAssertThrowsAs(m_threw, m_threw_as, m_exception_type, m_exception, m_expr,
+                                  m_assert_type, m_file, m_line);
+            } else if(m_assert_type & //!OCLINT bitwise operator in conditional
+                      assertType::is_nothrow) {
+                logAssertNothrow(m_threw, m_exception, m_expr, m_assert_type, m_file, m_line);
+            } else {
+                logAssert(m_result.m_passed, m_result.m_decomposition.c_str(), m_threw, m_exception,
+                          m_expr, m_assert_type, m_file, m_line);
+            }
+        }
+
+        if(m_failed)
+            addFailedAssert(m_assert_type);
+
+        return m_failed && isDebuggerActive() && !contextState->no_breaks; // break into debugger
+    }
+
+    void ResultBuilder::react() const {
+        if(m_failed && checkIfShouldThrow(m_assert_type))
+            throwException();
+    }
+
+    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity)
+            : m_stream(createStream())
+            , m_file(file)
+            , m_line(line)
+            , m_severity(severity) {}
+
+    bool MessageBuilder::log() {
+        DOCTEST_LOG_START();
+
+        const bool isWarn = m_severity & assertType::is_warn;
+
+        // warn is just a message in this context so we dont treat it as an assert
+        if(!isWarn) {
+            contextState->numAssertionsForCurrentTestcase++;
+            addFailedAssert(m_severity);
+        }
+
+        char loc[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(loc, DOCTEST_COUNTOF(loc), "%s(%d)", fileForOutput(m_file),
+                         lineForOutput(m_line));
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), " %s!\n",
+                         isWarn ? "MESSAGE" : getFailString(m_severity));
+
+        DOCTEST_PRINTF_COLORED(loc, Color::LightGrey);
+        DOCTEST_PRINTF_COLORED(msg, isWarn ? Color::Yellow : Color::Red);
+
+        String info = getStreamResult(m_stream);
+        if(info.size()) {
+            DOCTEST_PRINTF_COLORED("  ", Color::None);
+            DOCTEST_PRINTF_COLORED(info.c_str(), Color::None);
+            DOCTEST_PRINTF_COLORED("\n", Color::None);
+        }
+        String context = logContext();
+        DOCTEST_PRINTF_COLORED(context.c_str(), Color::None);
+        DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+        printToDebugConsole(String(loc) + msg + "  " + info.c_str() + "\n" + context.c_str() +
+                            "\n");
+
+        return isDebuggerActive() && !contextState->no_breaks && !isWarn; // break into debugger
+    }
+
+    void MessageBuilder::react() {
+        if(m_severity & assertType::is_require) //!OCLINT bitwise operator in conditional
+            throwException();
+    }
+
+    MessageBuilder::~MessageBuilder() { freeStream(m_stream); }
+
+    // the implementation of parseFlag()
+    bool parseFlagImpl(int argc, const char* const* argv, const char* pattern) {
+        for(int i = argc - 1; i >= 0; --i) {
+            const char* temp = std::strstr(argv[i], pattern);
+            if(temp && my_strlen(temp) == my_strlen(pattern)) {
+                // eliminate strings in which the chars before the option are not '-'
+                bool noBadCharsFound = true; //!OCLINT prefer early exits and continue
+                while(temp != argv[i]) {
+                    if(*--temp != '-') {
+                        noBadCharsFound = false;
+                        break;
+                    }
+                }
+                if(noBadCharsFound && argv[i][0] == '-')
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // locates a flag on the command line
+    bool parseFlag(int argc, const char* const* argv, const char* pattern) {
+#ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+        if(!parseFlagImpl(argc, argv, pattern))
+            return parseFlagImpl(argc, argv, pattern + 3); // 3 for "dt-"
         return true;
-      }
-      if(parsedValue.compare(negative[i], true) == 0)
-      {
-        res = 0; //! OCLINT parameter reassignment
+#else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+        return parseFlagImpl(argc, argv, pattern);
+#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+    }
+
+    // the implementation of parseOption()
+    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String& res) {
+        for(int i = argc - 1; i >= 0; --i) {
+            const char* temp = std::strstr(argv[i], pattern);
+            if(temp) { //!OCLINT prefer early exits and continue
+                // eliminate matches in which the chars before the option are not '-'
+                bool        noBadCharsFound = true;
+                const char* curr            = argv[i];
+                while(curr != temp) {
+                    if(*curr++ != '-') {
+                        noBadCharsFound = false;
+                        break;
+                    }
+                }
+                if(noBadCharsFound && argv[i][0] == '-') {
+                    temp += my_strlen(pattern);
+                    const unsigned len = my_strlen(temp);
+                    if(len) {
+                        res = temp;
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    // parses an option and returns the string after the '=' character
+    bool parseOption(int argc, const char* const* argv, const char* pattern, String& res,
+                     const String& defaultVal = String()) {
+        res = defaultVal;
+#ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+        if(!parseOptionImpl(argc, argv, pattern, res))
+            return parseOptionImpl(argc, argv, pattern + 3, res); // 3 for "dt-"
         return true;
-      }
+#else  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+        return parseOptionImpl(argc, argv, pattern, res);
+#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
     }
-  }
-  else
-  {
-    // integer
-    int theInt = std::atoi(parsedValue.c_str()); // NOLINT
-    if(theInt != 0)
+
+    // parses a comma separated list of words after a pattern in one of the arguments in argv
+    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
+                           std::vector<String>& res) {
+        String filtersString;
+        if(parseOption(argc, argv, pattern, filtersString)) {
+            // tokenize with "," as a separator
+            // cppcheck-suppress strtokCalled
+            char* pch = std::strtok(filtersString.c_str(), ","); // modifies the string
+            while(pch != 0) {
+                if(my_strlen(pch))
+                    res.push_back(pch);
+                // uses the strtok() internal state to go to the next token
+                // cppcheck-suppress strtokCalled
+                pch = std::strtok(0, ",");
+            }
+            return true;
+        }
+        return false;
+    }
+
+    enum optionType
     {
-      res = theInt; //! OCLINT parameter reassignment
-      return true;
+        option_bool,
+        option_int
+    };
+
+    // parses an int/bool option from the command line
+    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
+                        int& res) {
+        String parsedValue;
+        if(!parseOption(argc, argv, pattern, parsedValue))
+            return false;
+
+        if(type == 0) {
+            // boolean
+            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
+            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
+
+            // if the value matches any of the positive/negative possibilities
+            for(unsigned i = 0; i < 4; i++) {
+                if(parsedValue.compare(positive[i], true) == 0) {
+                    res = 1; //!OCLINT parameter reassignment
+                    return true;
+                }
+                if(parsedValue.compare(negative[i], true) == 0) {
+                    res = 0; //!OCLINT parameter reassignment
+                    return true;
+                }
+            }
+        } else {
+            // integer
+            int theInt = std::atoi(parsedValue.c_str()); // NOLINT
+            if(theInt != 0) {
+                res = theInt; //!OCLINT parameter reassignment
+                return true;
+            }
+        }
+        return false;
     }
-  }
-  return false;
-}
 
-void printVersion()
-{
-  if(contextState->no_version == false)
-  {
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("doctest version is \"%s\"\n", DOCTEST_VERSION_STR);
-  }
-}
+    void printVersion() {
+        if(contextState->no_version == false) {
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+            std::printf("doctest version is \"%s\"\n", DOCTEST_VERSION_STR);
+        }
+    }
 
-void printHelp()
-{
-  printVersion();
-  // clang-format off
+    void printHelp() {
+        printVersion();
+        // clang-format off
         DOCTEST_PRINTF_COLORED("[doctest]\n", Color::Cyan);
         DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
         std::printf("boolean values: \"1/on/yes/true\" or \"0/off/no/false\"\n");
@@ -5526,100 +5205,104 @@ void printHelp()
         std::printf(" -npf, --no-path-filenames=<bool>      only filenames and no paths in output\n");
         std::printf(" -nln, --no-line-numbers=<bool>        0 instead of real line numbers in output\n");
         // ========================================================================================= << 79
-  // clang-format on
+        // clang-format on
 
-  DOCTEST_PRINTF_COLORED("\n[doctest] ", Color::Cyan);
-  std::printf("for more information visit the project documentation\n\n");
-}
-
-void printSummary()
-{
-  const ContextState * p = contextState;
-
-  DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-  if(p->count || p->list_test_cases)
-  {
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("unskipped test cases passing the current filters: %u\n", p->numTestsPassingFilters);
-  }
-  else if(p->list_test_suites)
-  {
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("unskipped test cases passing the current filters: %u\n", p->numTestsPassingFilters);
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("test suites with unskipped test cases passing the current filters: %u\n",
-                p->numTestSuitesPassingFilters);
-  }
-  else
-  {
-    const bool anythingFailed = p->numFailed > 0 || p->numFailedAssertions > 0;
-
-    char buff[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "test cases: %6u", p->numTestsPassingFilters);
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed", p->numTestsPassingFilters - p->numFailed);
-    DOCTEST_PRINTF_COLORED(buff, (p->numTestsPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6u failed", p->numFailed);
-    DOCTEST_PRINTF_COLORED(buff, p->numFailed > 0 ? Color::Red : Color::None);
-
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    if(p->no_skipped_summary == false)
-    {
-      const int numSkipped = static_cast<unsigned>(getRegisteredTests().size()) - p->numTestsPassingFilters;
-      DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d skipped", numSkipped);
-      DOCTEST_PRINTF_COLORED(buff, numSkipped == 0 ? Color::None : Color::Yellow);
+        DOCTEST_PRINTF_COLORED("\n[doctest] ", Color::Cyan);
+        std::printf("for more information visit the project documentation\n\n");
     }
-    DOCTEST_PRINTF_COLORED("\n", Color::None);
 
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    void printSummary() {
+        const ContextState* p = contextState;
 
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "assertions: %6d", p->numAssertions);
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed", p->numAssertions - p->numFailedAssertions);
-    DOCTEST_PRINTF_COLORED(buff, (p->numAssertions == 0 || anythingFailed) ? Color::None : Color::Green);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d failed", p->numFailedAssertions);
-    DOCTEST_PRINTF_COLORED(buff, p->numFailedAssertions > 0 ? Color::Red : Color::None);
+        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+        if(p->count || p->list_test_cases) {
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+            std::printf("unskipped test cases passing the current filters: %u\n",
+                        p->numTestsPassingFilters);
+        } else if(p->list_test_suites) {
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+            std::printf("unskipped test cases passing the current filters: %u\n",
+                        p->numTestsPassingFilters);
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+            std::printf("test suites with unskipped test cases passing the current filters: %u\n",
+                        p->numTestSuitesPassingFilters);
+        } else {
+            const bool anythingFailed = p->numFailed > 0 || p->numFailedAssertions > 0;
 
-    DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " |\n");
-    DOCTEST_PRINTF_COLORED(buff, Color::None);
+            char buff[DOCTEST_SNPRINTF_BUFFER_LENGTH];
 
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    DOCTEST_PRINTF_COLORED("Status: ", Color::None);
-    const char * result = (p->numFailed > 0) ? "FAILURE!\n" : "SUCCESS!\n";
-    DOCTEST_PRINTF_COLORED(result, p->numFailed > 0 ? Color::Red : Color::Green);
-  }
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
 
-  // remove any coloring
-  DOCTEST_PRINTF_COLORED("", Color::None);
-}
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "test cases: %6u",
+                             p->numTestsPassingFilters);
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed",
+                             p->numTestsPassingFilters - p->numFailed);
+            DOCTEST_PRINTF_COLORED(buff, (p->numTestsPassingFilters == 0 || anythingFailed) ?
+                                                 Color::None :
+                                                 Color::Green);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6u failed", p->numFailed);
+            DOCTEST_PRINTF_COLORED(buff, p->numFailed > 0 ? Color::Red : Color::None);
+
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            if(p->no_skipped_summary == false) {
+                const int numSkipped = static_cast<unsigned>(getRegisteredTests().size()) -
+                                       p->numTestsPassingFilters;
+                DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d skipped", numSkipped);
+                DOCTEST_PRINTF_COLORED(buff, numSkipped == 0 ? Color::None : Color::Yellow);
+            }
+            DOCTEST_PRINTF_COLORED("\n", Color::None);
+
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "assertions: %6d", p->numAssertions);
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d passed",
+                             p->numAssertions - p->numFailedAssertions);
+            DOCTEST_PRINTF_COLORED(buff, (p->numAssertions == 0 || anythingFailed) ? Color::None :
+                                                                                     Color::Green);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " | ");
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), "%6d failed", p->numFailedAssertions);
+            DOCTEST_PRINTF_COLORED(buff, p->numFailedAssertions > 0 ? Color::Red : Color::None);
+
+            DOCTEST_SNPRINTF(buff, DOCTEST_COUNTOF(buff), " |\n");
+            DOCTEST_PRINTF_COLORED(buff, Color::None);
+
+            DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+            DOCTEST_PRINTF_COLORED("Status: ", Color::None);
+            const char* result = (p->numFailed > 0) ? "FAILURE!\n" : "SUCCESS!\n";
+            DOCTEST_PRINTF_COLORED(result, p->numFailed > 0 ? Color::Red : Color::Green);
+        }
+
+        // remove any coloring
+        DOCTEST_PRINTF_COLORED("", Color::None);
+    }
 } // namespace detail
 
 bool isRunningInTest() { return detail::contextState != 0; }
 
-Context::Context(int argc, const char * const * argv) : p(new detail::ContextState) { parseArgs(argc, argv, true); }
+Context::Context(int argc, const char* const* argv)
+        : p(new detail::ContextState) {
+    parseArgs(argc, argv, true);
+}
 
 Context::~Context() { delete p; }
 
-void Context::applyCommandLine(int argc, const char * const * argv) { parseArgs(argc, argv); }
+void Context::applyCommandLine(int argc, const char* const* argv) { parseArgs(argc, argv); }
 
 // parses args
-void Context::parseArgs(int argc, const char * const * argv, bool withDefaults)
-{
-  using namespace detail;
+void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
+    using namespace detail;
 
-  // clang-format off
+    // clang-format off
     parseCommaSepArgs(argc, argv, "dt-source-file=",        p->filters[0]);
     parseCommaSepArgs(argc, argv, "dt-sf=",                 p->filters[0]);
     parseCommaSepArgs(argc, argv, "dt-source-file-exclude=",p->filters[1]);
@@ -5636,33 +5319,34 @@ void Context::parseArgs(int argc, const char * const * argv, bool withDefaults)
     parseCommaSepArgs(argc, argv, "dt-sc=",                 p->filters[6]);
     parseCommaSepArgs(argc, argv, "dt-subcase-exclude=",    p->filters[7]);
     parseCommaSepArgs(argc, argv, "dt-sce=",                p->filters[7]);
-  // clang-format on
+    // clang-format on
 
-  int intRes = 0;
-  String strRes;
+    int    intRes = 0;
+    String strRes;
 
-#    define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                             \
-      if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_bool, intRes)      \
-         || parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_bool, intRes)) \
-        p->var = !!intRes;                                                                       \
-      else if(parseFlag(argc, argv, #name) || parseFlag(argc, argv, #sname))                     \
-        p->var = true;                                                                           \
-      else if(withDefaults)                                                                      \
-      p->var = default
+#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
+    if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_bool, intRes) ||       \
+       parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_bool, intRes))        \
+        p->var = !!intRes;                                                                         \
+    else if(parseFlag(argc, argv, #name) || parseFlag(argc, argv, #sname))                         \
+        p->var = true;                                                                             \
+    else if(withDefaults)                                                                          \
+    p->var = default
 
-#    define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                 \
-      if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_int, intRes)      \
-         || parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_int, intRes)) \
-        p->var = intRes;                                                                        \
-      else if(withDefaults)                                                                     \
-      p->var = default
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
+    if(parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), option_int, intRes) ||        \
+       parseIntOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), option_int, intRes))         \
+        p->var = intRes;                                                                           \
+    else if(withDefaults)                                                                          \
+    p->var = default
 
-#    define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                           \
-      if(parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), strRes, default)                      \
-         || parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), strRes, default) || withDefaults) \
-      p->var = strRes
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
+    if(parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(name, =), strRes, default) ||              \
+       parseOption(argc, argv, DOCTEST_STR_CONCAT_TOSTR(sname, =), strRes, default) ||             \
+       withDefaults)                                                                               \
+    p->var = strRes
 
-  // clang-format off
+    // clang-format off
     DOCTEST_PARSE_STR_OPTION(dt-order-by, dt-ob, order_by, "file");
     DOCTEST_PARSE_INT_OPTION(dt-rand-seed, dt-rs, rand_seed, 0);
 
@@ -5687,361 +5371,327 @@ void Context::parseArgs(int argc, const char * const * argv, bool withDefaults)
     DOCTEST_PARSE_AS_BOOL_OR_FLAG(dt-no-path-filenames, dt-npf, no_path_in_filenames, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG(dt-no-line-numbers, dt-nln, no_line_numbers, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG(dt-no-skipped-summary, dt-nss, no_skipped_summary, false);
-  // clang-format on
+    // clang-format on
 
-#    undef DOCTEST_PARSE_STR_OPTION
-#    undef DOCTEST_PARSE_INT_OPTION
-#    undef DOCTEST_PARSE_AS_BOOL_OR_FLAG
+#undef DOCTEST_PARSE_STR_OPTION
+#undef DOCTEST_PARSE_INT_OPTION
+#undef DOCTEST_PARSE_AS_BOOL_OR_FLAG
 
-  if(withDefaults)
-  {
-    p->help = false;
-    p->version = false;
-    p->count = false;
-    p->list_test_cases = false;
-    p->list_test_suites = false;
-  }
-  if(parseFlag(argc, argv, "dt-help") || parseFlag(argc, argv, "dt-h") || parseFlag(argc, argv, "dt-?"))
-  {
-    p->help = true;
-    p->exit = true;
-  }
-  if(parseFlag(argc, argv, "dt-version") || parseFlag(argc, argv, "dt-v"))
-  {
-    p->version = true;
-    p->exit = true;
-  }
-  if(parseFlag(argc, argv, "dt-count") || parseFlag(argc, argv, "dt-c"))
-  {
-    p->count = true;
-    p->exit = true;
-  }
-  if(parseFlag(argc, argv, "dt-list-test-cases") || parseFlag(argc, argv, "dt-ltc"))
-  {
-    p->list_test_cases = true;
-    p->exit = true;
-  }
-  if(parseFlag(argc, argv, "dt-list-test-suites") || parseFlag(argc, argv, "dt-lts"))
-  {
-    p->list_test_suites = true;
-    p->exit = true;
-  }
+    if(withDefaults) {
+        p->help             = false;
+        p->version          = false;
+        p->count            = false;
+        p->list_test_cases  = false;
+        p->list_test_suites = false;
+    }
+    if(parseFlag(argc, argv, "dt-help") || parseFlag(argc, argv, "dt-h") ||
+       parseFlag(argc, argv, "dt-?")) {
+        p->help = true;
+        p->exit = true;
+    }
+    if(parseFlag(argc, argv, "dt-version") || parseFlag(argc, argv, "dt-v")) {
+        p->version = true;
+        p->exit    = true;
+    }
+    if(parseFlag(argc, argv, "dt-count") || parseFlag(argc, argv, "dt-c")) {
+        p->count = true;
+        p->exit  = true;
+    }
+    if(parseFlag(argc, argv, "dt-list-test-cases") || parseFlag(argc, argv, "dt-ltc")) {
+        p->list_test_cases = true;
+        p->exit            = true;
+    }
+    if(parseFlag(argc, argv, "dt-list-test-suites") || parseFlag(argc, argv, "dt-lts")) {
+        p->list_test_suites = true;
+        p->exit             = true;
+    }
 }
 
 // allows the user to add procedurally to the filters from the command line
-void Context::addFilter(const char * filter, const char * value) { setOption(filter, value); }
+void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
 
 // allows the user to clear all filters from the command line
-void Context::clearFilters()
-{
-  for(unsigned i = 0; i < p->filters.size(); ++i)
-    p->filters[i].clear();
+void Context::clearFilters() {
+    for(unsigned i = 0; i < p->filters.size(); ++i)
+        p->filters[i].clear();
 }
 
 // allows the user to override procedurally the int/bool options from the command line
-void Context::setOption(const char * option, int value) { setOption(option, toString(value).c_str()); }
+void Context::setOption(const char* option, int value) {
+    setOption(option, toString(value).c_str());
+}
 
 // allows the user to override procedurally the string options from the command line
-void Context::setOption(const char * option, const char * value)
-{
-  String argv = String("-") + option + "=" + value;
-  const char * lvalue = argv.c_str();
-  parseArgs(1, &lvalue);
+void Context::setOption(const char* option, const char* value) {
+    String      argv   = String("-") + option + "=" + value;
+    const char* lvalue = argv.c_str();
+    parseArgs(1, &lvalue);
 }
 
 // users should query this in their main() and exit the program if true
 bool Context::shouldExit() { return p->exit; }
 
 // the main function that does all the filtering and test running
-int Context::run()
-{
-  using namespace detail;
+int Context::run() {
+    using namespace detail;
 
-  Color::init();
+    Color::init();
 
-  contextState = p;
-  p->resetRunData();
+    contextState = p;
+    p->resetRunData();
 
-  // handle version, help and no_run
-  if(p->no_run || p->version || p->help)
-  {
-    if(p->version)
-      printVersion();
-    if(p->help)
-      printHelp();
+    // handle version, help and no_run
+    if(p->no_run || p->version || p->help) {
+        if(p->version)
+            printVersion();
+        if(p->help)
+            printHelp();
+
+        contextState = 0;
+
+        return EXIT_SUCCESS;
+    }
+
+    printVersion();
+    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+    std::printf("run with \"--help\" for options\n");
+
+    unsigned i = 0; // counter used for loops - here for VC6
+
+    std::set<TestCase>& registeredTests = getRegisteredTests();
+
+    std::vector<const TestCase*> testArray;
+    for(std::set<TestCase>::iterator it = registeredTests.begin(); it != registeredTests.end();
+        ++it)
+        testArray.push_back(&(*it));
+
+    // sort the collected records
+    if(!testArray.empty()) {
+        if(p->order_by.compare("file", true) == 0) {
+            std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), fileOrderComparator);
+        } else if(p->order_by.compare("suite", true) == 0) {
+            std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), suiteOrderComparator);
+        } else if(p->order_by.compare("name", true) == 0) {
+            std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), nameOrderComparator);
+        } else if(p->order_by.compare("rand", true) == 0) {
+            std::srand(p->rand_seed);
+
+            // random_shuffle implementation
+            const TestCase** first = &testArray[0];
+            for(i = testArray.size() - 1; i > 0; --i) {
+                int idxToSwap = std::rand() % (i + 1); // NOLINT
+
+                const TestCase* temp = first[i];
+
+                first[i]         = first[idxToSwap];
+                first[idxToSwap] = temp;
+            }
+        }
+    }
+
+    if(p->list_test_cases) {
+        DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+        std::printf("listing all test case names\n");
+        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+    }
+
+    std::set<String> testSuitesPassingFilters;
+    if(p->list_test_suites) {
+        DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
+        std::printf("listing all test suites\n");
+        DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
+    }
+
+    // invoke the registered functions if they match the filter criteria (or just count them)
+    for(i = 0; i < testArray.size(); i++) {
+        const TestCase& data = *testArray[i];
+
+        if(data.m_skip && !p->no_skip)
+            continue;
+
+        if(!matchesAny(data.m_file, p->filters[0], 1, p->case_sensitive))
+            continue;
+        if(matchesAny(data.m_file, p->filters[1], 0, p->case_sensitive))
+            continue;
+        if(!matchesAny(data.m_test_suite, p->filters[2], 1, p->case_sensitive))
+            continue;
+        if(matchesAny(data.m_test_suite, p->filters[3], 0, p->case_sensitive))
+            continue;
+        if(!matchesAny(data.m_name, p->filters[4], 1, p->case_sensitive))
+            continue;
+        if(matchesAny(data.m_name, p->filters[5], 0, p->case_sensitive))
+            continue;
+
+        p->numTestsPassingFilters++;
+
+        // do not execute the test if we are to only count the number of filter passing tests
+        if(p->count)
+            continue;
+
+        // print the name of the test and don't execute it
+        if(p->list_test_cases) {
+            std::printf("%s\n", data.m_name);
+            continue;
+        }
+
+        // print the name of the test suite if not done already and don't execute it
+        if(p->list_test_suites) {
+            if((testSuitesPassingFilters.count(data.m_test_suite) == 0) &&
+               data.m_test_suite[0] != '\0') {
+                std::printf("%s\n", data.m_test_suite);
+                testSuitesPassingFilters.insert(data.m_test_suite);
+                p->numTestSuitesPassingFilters++;
+            }
+            continue;
+        }
+
+        // skip the test if it is not in the execution range
+        if((p->last < p->numTestsPassingFilters && p->first <= p->last) ||
+           (p->first > p->numTestsPassingFilters))
+            continue;
+
+        // execute the test if it passes all the filtering
+        {
+            p->currentTest = &data;
+
+            bool failed                              = false;
+            p->hasLoggedCurrentTestStart             = false;
+            p->numFailedAssertionsForCurrentTestcase = 0;
+            p->subcasesPassed.clear();
+            double duration = 0;
+            Timer  timer;
+            timer.start();
+            do {
+                // if the start has been logged from a previous iteration of this loop
+                if(p->hasLoggedCurrentTestStart)
+                    logTestEnd();
+                p->hasLoggedCurrentTestStart = false;
+
+                // if logging successful tests - force the start log
+                if(p->success)
+                    DOCTEST_LOG_START();
+
+                // reset the assertion state
+                p->numAssertionsForCurrentTestcase = 0;
+                p->hasCurrentTestFailed            = false;
+
+                // reset some of the fields for subcases (except for the set of fully passed ones)
+                p->subcasesHasSkipped   = false;
+                p->subcasesCurrentLevel = 0;
+                p->subcasesEnteredLevels.clear();
+
+                // reset stuff for logging with INFO()
+                p->exceptionalContexts.clear();
+
+// execute the test
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+                    FatalConditionHandler fatalConditionHandler; // Handle signals
+                    data.m_test();
+                    fatalConditionHandler.reset();
+                    if(contextState->hasCurrentTestFailed)
+                        failed = true;
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                } catch(const TestFailureException&) { failed = true; } catch(...) {
+                    DOCTEST_LOG_START();
+                    logTestException(translateActiveException());
+                    failed = true;
+                }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+                p->numAssertions += p->numAssertionsForCurrentTestcase;
+
+                // exit this loop if enough assertions have failed
+                if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after) {
+                    p->subcasesHasSkipped = false;
+                    DOCTEST_PRINTF_COLORED("Aborting - too many failed asserts!\n", Color::Red);
+                }
+
+            } while(p->subcasesHasSkipped == true);
+
+            duration = timer.getElapsedSeconds();
+
+            if(Approx(p->currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
+               Approx(duration).epsilon(DBL_EPSILON) > p->currentTest->m_timeout) {
+                failed = true;
+                DOCTEST_LOG_START();
+                char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+                DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg),
+                                 "Test case exceeded time limit of %.6f!\n",
+                                 p->currentTest->m_timeout);
+                DOCTEST_PRINTF_COLORED(msg, Color::Red);
+            }
+
+            if(p->duration) {
+                char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+                DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "%.6f s: %s\n", duration,
+                                 p->currentTest->m_name);
+                DOCTEST_PRINTF_COLORED(msg, Color::None);
+            }
+
+            if(data.m_should_fail) {
+                DOCTEST_LOG_START();
+                if(failed) {
+                    failed = false;
+                    DOCTEST_PRINTF_COLORED("Failed as expected so marking it as not failed\n",
+                                           Color::Yellow);
+                } else {
+                    failed = true;
+                    DOCTEST_PRINTF_COLORED("Should have failed but didn't! Marking it as failed!\n",
+                                           Color::Red);
+                }
+            } else if(failed && data.m_may_fail) {
+                DOCTEST_LOG_START();
+                failed = false;
+                DOCTEST_PRINTF_COLORED("Allowed to fail so marking it as not failed\n",
+                                       Color::Yellow);
+            } else if(data.m_expected_failures > 0) {
+                DOCTEST_LOG_START();
+                char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+                if(p->numFailedAssertionsForCurrentTestcase == data.m_expected_failures) {
+                    failed = false;
+                    DOCTEST_SNPRINTF(
+                            msg, DOCTEST_COUNTOF(msg),
+                            "Failed exactly %d times as expected so marking it as not failed!\n",
+                            data.m_expected_failures);
+                    DOCTEST_PRINTF_COLORED(msg, Color::Yellow);
+                } else {
+                    failed = true;
+                    DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg),
+                                     "Didn't fail exactly %d times so marking it as failed!\n",
+                                     data.m_expected_failures);
+                    DOCTEST_PRINTF_COLORED(msg, Color::Red);
+                }
+            }
+
+            if(p->hasLoggedCurrentTestStart)
+                logTestEnd();
+
+            if(failed) // if any subcase has failed - the whole test case has failed
+                p->numFailed++;
+
+            // stop executing tests if enough assertions have failed
+            if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after)
+                break;
+        }
+    }
+
+    printSummary();
 
     contextState = 0;
 
+    if(p->numFailed && !p->no_exitcode)
+        return EXIT_FAILURE;
     return EXIT_SUCCESS;
-  }
-
-  printVersion();
-  DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-  std::printf("run with \"--help\" for options\n");
-
-  unsigned i = 0; // counter used for loops - here for VC6
-
-  std::set<TestCase> & registeredTests = getRegisteredTests();
-
-  std::vector<const TestCase *> testArray;
-  for(std::set<TestCase>::iterator it = registeredTests.begin(); it != registeredTests.end(); ++it)
-    testArray.push_back(&(*it));
-
-  // sort the collected records
-  if(!testArray.empty())
-  {
-    if(p->order_by.compare("file", true) == 0)
-    {
-      std::qsort(&testArray[0], testArray.size(), sizeof(TestCase *), fileOrderComparator);
-    }
-    else if(p->order_by.compare("suite", true) == 0)
-    {
-      std::qsort(&testArray[0], testArray.size(), sizeof(TestCase *), suiteOrderComparator);
-    }
-    else if(p->order_by.compare("name", true) == 0)
-    {
-      std::qsort(&testArray[0], testArray.size(), sizeof(TestCase *), nameOrderComparator);
-    }
-    else if(p->order_by.compare("rand", true) == 0)
-    {
-      std::srand(p->rand_seed);
-
-      // random_shuffle implementation
-      const TestCase ** first = &testArray[0];
-      for(i = testArray.size() - 1; i > 0; --i)
-      {
-        int idxToSwap = std::rand() % (i + 1); // NOLINT
-
-        const TestCase * temp = first[i];
-
-        first[i] = first[idxToSwap];
-        first[idxToSwap] = temp;
-      }
-    }
-  }
-
-  if(p->list_test_cases)
-  {
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("listing all test case names\n");
-    DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-  }
-
-  std::set<String> testSuitesPassingFilters;
-  if(p->list_test_suites)
-  {
-    DOCTEST_PRINTF_COLORED("[doctest] ", Color::Cyan);
-    std::printf("listing all test suites\n");
-    DOCTEST_PRINTF_COLORED(getSeparator(), Color::Yellow);
-  }
-
-  // invoke the registered functions if they match the filter criteria (or just count them)
-  for(i = 0; i < testArray.size(); i++)
-  {
-    const TestCase & data = *testArray[i];
-
-    if(data.m_skip && !p->no_skip)
-      continue;
-
-    if(!matchesAny(data.m_file, p->filters[0], 1, p->case_sensitive))
-      continue;
-    if(matchesAny(data.m_file, p->filters[1], 0, p->case_sensitive))
-      continue;
-    if(!matchesAny(data.m_test_suite, p->filters[2], 1, p->case_sensitive))
-      continue;
-    if(matchesAny(data.m_test_suite, p->filters[3], 0, p->case_sensitive))
-      continue;
-    if(!matchesAny(data.m_name, p->filters[4], 1, p->case_sensitive))
-      continue;
-    if(matchesAny(data.m_name, p->filters[5], 0, p->case_sensitive))
-      continue;
-
-    p->numTestsPassingFilters++;
-
-    // do not execute the test if we are to only count the number of filter passing tests
-    if(p->count)
-      continue;
-
-    // print the name of the test and don't execute it
-    if(p->list_test_cases)
-    {
-      std::printf("%s\n", data.m_name);
-      continue;
-    }
-
-    // print the name of the test suite if not done already and don't execute it
-    if(p->list_test_suites)
-    {
-      if((testSuitesPassingFilters.count(data.m_test_suite) == 0) && data.m_test_suite[0] != '\0')
-      {
-        std::printf("%s\n", data.m_test_suite);
-        testSuitesPassingFilters.insert(data.m_test_suite);
-        p->numTestSuitesPassingFilters++;
-      }
-      continue;
-    }
-
-    // skip the test if it is not in the execution range
-    if((p->last < p->numTestsPassingFilters && p->first <= p->last) || (p->first > p->numTestsPassingFilters))
-      continue;
-
-    // execute the test if it passes all the filtering
-    {
-      p->currentTest = &data;
-
-      bool failed = false;
-      p->hasLoggedCurrentTestStart = false;
-      p->numFailedAssertionsForCurrentTestcase = 0;
-      p->subcasesPassed.clear();
-      double duration = 0;
-      Timer timer;
-      timer.start();
-      do
-      {
-        // if the start has been logged from a previous iteration of this loop
-        if(p->hasLoggedCurrentTestStart)
-          logTestEnd();
-        p->hasLoggedCurrentTestStart = false;
-
-        // if logging successful tests - force the start log
-        if(p->success)
-          DOCTEST_LOG_START();
-
-        // reset the assertion state
-        p->numAssertionsForCurrentTestcase = 0;
-        p->hasCurrentTestFailed = false;
-
-        // reset some of the fields for subcases (except for the set of fully passed ones)
-        p->subcasesHasSkipped = false;
-        p->subcasesCurrentLevel = 0;
-        p->subcasesEnteredLevels.clear();
-
-        // reset stuff for logging with INFO()
-        p->exceptionalContexts.clear();
-
-// execute the test
-#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        try
-        {
-#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-          FatalConditionHandler fatalConditionHandler; // Handle signals
-          data.m_test();
-          fatalConditionHandler.reset();
-          if(contextState->hasCurrentTestFailed)
-            failed = true;
-#    ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        }
-        catch(const TestFailureException &)
-        {
-          failed = true;
-        }
-        catch(...)
-        {
-          DOCTEST_LOG_START();
-          logTestException(translateActiveException());
-          failed = true;
-        }
-#    endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-        p->numAssertions += p->numAssertionsForCurrentTestcase;
-
-        // exit this loop if enough assertions have failed
-        if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after)
-        {
-          p->subcasesHasSkipped = false;
-          DOCTEST_PRINTF_COLORED("Aborting - too many failed asserts!\n", Color::Red);
-        }
-
-      } while(p->subcasesHasSkipped == true);
-
-      duration = timer.getElapsedSeconds();
-
-      if(Approx(p->currentTest->m_timeout).epsilon(DBL_EPSILON) != 0
-         && Approx(duration).epsilon(DBL_EPSILON) > p->currentTest->m_timeout)
-      {
-        failed = true;
-        DOCTEST_LOG_START();
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "Test case exceeded time limit of %.6f!\n",
-                         p->currentTest->m_timeout);
-        DOCTEST_PRINTF_COLORED(msg, Color::Red);
-      }
-
-      if(p->duration)
-      {
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "%.6f s: %s\n", duration, p->currentTest->m_name);
-        DOCTEST_PRINTF_COLORED(msg, Color::None);
-      }
-
-      if(data.m_should_fail)
-      {
-        DOCTEST_LOG_START();
-        if(failed)
-        {
-          failed = false;
-          DOCTEST_PRINTF_COLORED("Failed as expected so marking it as not failed\n", Color::Yellow);
-        }
-        else
-        {
-          failed = true;
-          DOCTEST_PRINTF_COLORED("Should have failed but didn't! Marking it as failed!\n", Color::Red);
-        }
-      }
-      else if(failed && data.m_may_fail)
-      {
-        DOCTEST_LOG_START();
-        failed = false;
-        DOCTEST_PRINTF_COLORED("Allowed to fail so marking it as not failed\n", Color::Yellow);
-      }
-      else if(data.m_expected_failures > 0)
-      {
-        DOCTEST_LOG_START();
-        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
-        if(p->numFailedAssertionsForCurrentTestcase == data.m_expected_failures)
-        {
-          failed = false;
-          DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg),
-                           "Failed exactly %d times as expected so marking it as not failed!\n",
-                           data.m_expected_failures);
-          DOCTEST_PRINTF_COLORED(msg, Color::Yellow);
-        }
-        else
-        {
-          failed = true;
-          DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "Didn't fail exactly %d times so marking it as failed!\n",
-                           data.m_expected_failures);
-          DOCTEST_PRINTF_COLORED(msg, Color::Red);
-        }
-      }
-
-      if(p->hasLoggedCurrentTestStart)
-        logTestEnd();
-
-      if(failed) // if any subcase has failed - the whole test case has failed
-        p->numFailed++;
-
-      // stop executing tests if enough assertions have failed
-      if(p->abort_after > 0 && p->numFailedAssertions >= p->abort_after)
-        break;
-    }
-  }
-
-  printSummary();
-
-  contextState = 0;
-
-  if(p->numFailed && !p->no_exitcode)
-    return EXIT_FAILURE;
-  return EXIT_SUCCESS;
 }
 } // namespace doctest
 
-#  endif // DOCTEST_CONFIG_DISABLE
+#endif // DOCTEST_CONFIG_DISABLE
 
-#  ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-int main(int argc, char ** argv) { return doctest::Context(argc, argv).run(); }
-#  endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,7 @@
 /** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
-#include <tvm/Variable.h>
 #include "Mockup.h"
+#include <tvm/Variable.h>
 
 #include <tvm/scheme/internal/SchemeAbilities.h>
 
@@ -33,18 +33,14 @@ void testVariable()
   std::cout << (dv3 == dv4->primitive()) << std::endl;
 }
 
-
 void testDataGraphSimple()
 {
   auto robot = std::make_shared<RobotMockup>();
   auto f1 = std::make_shared<SomeRobotFunction1>(robot);
   auto user = std::make_shared<tvm::graph::internal::Inputs>();
-  user->addInput(f1, SomeRobotFunction1::Output::Value,
-                     SomeRobotFunction1::Output::Jacobian,
-                     SomeRobotFunction1::Output::Velocity,
-                     SomeRobotFunction1::Output::NormalAcceleration,
-                     SomeRobotFunction1::Output::JDot);
-
+  user->addInput(f1, SomeRobotFunction1::Output::Value, SomeRobotFunction1::Output::Jacobian,
+                 SomeRobotFunction1::Output::Velocity, SomeRobotFunction1::Output::NormalAcceleration,
+                 SomeRobotFunction1::Output::JDot);
 
   std::cout << "g0: adding only the robot" << std::endl;
   tvm::graph::CallGraph g0;
@@ -88,8 +84,6 @@ void testDataGraphSimple()
   g4.execute();
 
   std::cout << std::endl << "----------------------" << std::endl << std::endl;
-
-
 }
 
 void testBadGraph()
@@ -100,13 +94,11 @@ void testBadGraph()
   auto user1 = std::make_shared<tvm::graph::internal::Inputs>();
   try
   {
-    user1->addInput(f1, SomeRobotFunction2::Output::Value,
-                        SomeRobotFunction2::Output::Jacobian,
-                        SomeRobotFunction2::Output::Velocity,
-                        SomeRobotFunction2::Output::NormalAcceleration,
-                        SomeRobotFunction2::Output::JDot);
+    user1->addInput(f1, SomeRobotFunction2::Output::Value, SomeRobotFunction2::Output::Jacobian,
+                    SomeRobotFunction2::Output::Velocity, SomeRobotFunction2::Output::NormalAcceleration,
+                    SomeRobotFunction2::Output::JDot);
   }
-  catch (const std::exception & e)
+  catch(const std::exception & e)
   {
     std::cout << e.what() << std::endl;
   }
@@ -118,8 +110,14 @@ void testBadGraph()
 
   tvm::graph::CallGraph g2;
   g2.add(user2);
-  try { g2.update(); }
-  catch (const std::exception & e) { std::cout << "Got exception: " << e.what() << std::endl; }
+  try
+  {
+    g2.update();
+  }
+  catch(const std::exception & e)
+  {
+    std::cout << "Got exception: " << e.what() << std::endl;
+  }
 
   std::cout << std::endl << "----------------------" << std::endl << std::endl;
 
@@ -128,11 +126,16 @@ void testBadGraph()
   user3->addInput(cik, ::LinearConstraint::Output::A, ::LinearConstraint::Output::b);
   tvm::graph::CallGraph g3;
   g3.add(user3);
-  try { g3.update(); }
-  catch (const std::exception & e) { std::cout << "Got exception: " << e.what() << std::endl; }
+  try
+  {
+    g3.update();
+  }
+  catch(const std::exception & e)
+  {
+    std::cout << "Got exception: " << e.what() << std::endl;
+  }
 
   std::cout << std::endl << "----------------------" << std::endl << std::endl;
-
 }
 
 void testDataGraphComplex()
@@ -142,7 +145,7 @@ void testDataGraphComplex()
     auto f1 = std::make_shared<SomeRobotFunction1>(robot);
     auto f2 = std::make_shared<SomeRobotFunction2>(robot);
 
-    //IK-like
+    // IK-like
     auto cik1 = std::make_shared<KinematicLinearizedConstraint>("Linearized f1", f1);
     auto cik2 = std::make_shared<KinematicLinearizedConstraint>("Linearized f2", f2);
 
@@ -157,7 +160,7 @@ void testDataGraphComplex()
 
     std::cout << std::endl << "----------------------" << std::endl << std::endl;
 
-    //ID-like
+    // ID-like
     auto cid0 = std::make_shared<DynamicEquation>("EoM", robot);
     auto cid1 = std::make_shared<DynamicLinearizedConstraint>("Linearized f1", f1);
 
@@ -176,7 +179,7 @@ void testDataGraphComplex()
     auto f1 = std::make_shared<SomeRobotFunction1>(robot);
     auto f2 = std::make_shared<SomeRobotFunction2>(robot);
 
-    //IK-like
+    // IK-like
     auto cik1 = std::make_shared<BetterKinematicLinearizedConstraint>("Linearized f1", f1);
     auto cik2 = std::make_shared<BetterKinematicLinearizedConstraint>("Linearized f2", f2);
 
@@ -191,7 +194,7 @@ void testDataGraphComplex()
 
     std::cout << std::endl << "----------------------" << std::endl << std::endl;
 
-    //ID-like
+    // ID-like
     auto cid0 = std::make_shared<DynamicEquation>("EoM", robot);
     auto cid1 = std::make_shared<BetterDynamicLinearizedConstraint>("Linearized f1", f1);
 
@@ -208,22 +211,23 @@ void testDataGraphComplex()
 
 int main()
 {
-  //testVariable();
-  //testDataGraphSimple();
-  //testBadGraph();
-  //testDataGraphComplex();
-  //solverTest01();
-  //solverTest02();
+  // testVariable();
+  // testDataGraphSimple();
+  // testBadGraph();
+  // testDataGraphComplex();
+  // solverTest01();
+  // solverTest02();
 
   minimalKin();
   minimalKinSub();
-  //minimalDyn();
+  // minimalDyn();
 
   auto l = tvm::graph::internal::Logger::logger().log();
-  //for (const auto& p : l.types_)
+  // for (const auto& p : l.types_)
   //  std::cout << l.generateDot(tvm::graph::internal::Log::Pointer(p.second.back(), p.first)) << std::endl;
 
-  //std::cout << l.generateDot(reinterpret_cast<tvm::graph::CallGraph*>(l.graphOutputs_.begin()->first.value)) << std::endl;
+  // std::cout << l.generateDot(reinterpret_cast<tvm::graph::CallGraph*>(l.graphOutputs_.begin()->first.value)) <<
+  // std::endl;
 #ifdef WIN32
   system("pause");
 #endif


### PR DESCRIPTION
This PR adds a clang-format file to the repository and apply it to the code. I've added some formatting blocks where I could identify it was useful (I've mostly checked the style effect on examples and public includes)

While at it, I've updated all copyright notices to use the short form.

I'm opening this as a PR so we can have a look at the style (and maybe change it) before we merge it.  I advise it's looked at with whitespace changes filtered out otherwise it's unreadable :D