### PR TITLE
Erase pending events when a task is removed

### DIFF
--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -27,8 +27,8 @@ public:
     double scalarizationWeight;
   };
 
-  void addScalarWeigthEvent(constraint::abstract::LinearConstraint * c);
-  void addVectorWeigthEvent(constraint::abstract::LinearConstraint * c);
+  void addScalarWeightEvent(constraint::abstract::LinearConstraint * c);
+  void addVectorWeightEvent(constraint::abstract::LinearConstraint * c);
 
   void addConstraint(LinearConstraintPtr c);
   void removeConstraint(LinearConstraintPtr c);
@@ -80,7 +80,7 @@ private:
   bool hiddenVariableChange_;
 };
 
-inline void SolverEvents::addScalarWeigthEvent(constraint::abstract::LinearConstraint * c)
+inline void SolverEvents::addScalarWeightEvent(constraint::abstract::LinearConstraint * c)
 {
   for(auto & e : weightEvents_)
   {
@@ -94,7 +94,7 @@ inline void SolverEvents::addScalarWeigthEvent(constraint::abstract::LinearConst
   weightEvents_.push_back({c, true, false});
 }
 
-inline void SolverEvents::addVectorWeigthEvent(constraint::abstract::LinearConstraint * c)
+inline void SolverEvents::addVectorWeightEvent(constraint::abstract::LinearConstraint * c)
 {
   for(auto & e : weightEvents_)
   {

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -28,8 +28,11 @@ void ControlProblem::add(TaskWithRequirementsPtr tr)
 void ControlProblem::remove(TaskWithRequirements * tr)
 {
   auto it = std::find_if(tr_.begin(), tr_.end(), [tr](const TaskWithRequirementsPtr & p) { return p.get() == tr; });
-  if(it != tr_.end())
-    tr_.erase(it);
+  if(it == tr_.end())
+  {
+    return;
+  }
+  tr_.erase(it);
   notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
   callbackTokens_.erase(tr);
   finalized_ = false;

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -57,7 +57,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
             throw std::runtime_error(
                 "[WeightedLeastSquares::updateComputationData_] "
                 "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
-          se.addScalarWeigthEvent(c.constraint.get());
+          se.addScalarWeightEvent(c.constraint.get());
         }
         break;
         case ProblemDefinitionEvent::Type::AnisotropicWeightChange: {
@@ -66,7 +66,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
             throw std::runtime_error(
                 "[WeightedLeastSquares::updateComputationData_] "
                 "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
-          se.addVectorWeigthEvent(c.constraint.get());
+          se.addVectorWeightEvent(c.constraint.get());
         }
         break;
         case ProblemDefinitionEvent::Type::TaskAddition:

--- a/tests/EventsTest.cpp
+++ b/tests/EventsTest.cpp
@@ -113,6 +113,17 @@ TEST_CASE("Simple add/Remove constraint")
   pb.add(t1);
   solver.solve(pb);
   FAST_CHECK_UNARY(x->value().isApprox(Vector2d(0, 2. / 3)));
+
+  t1->requirements.weight() = 3;
+  pb.remove(t1.get());
+  pb.add(t1);
+  solver.solve(pb);
+  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(-0.4, 0)));
+
+  t1->requirements.weight() = 100.0;
+  pb.remove(t1.get());
+  solver.solve(pb);
+  FAST_CHECK_UNARY(x->value().isApprox(Vector2d(1. / 2, 3. / 2)));
 }
 
 TEST_CASE("Add/Remove variables from problem")


### PR DESCRIPTION
This PR fixes an issue that arises in the current master with the newly added test cases in this PR, i.e. the following sequence will lead to a crash:

```cpp
auto t1 = pb.add(...);
solver.solve(pb);

t1->requirements.weight() = 2;
pb.remove(t1.get());
solver.solve(pb); // <-- crash
```

The issue is that removing the task immediately removes it from the problem, however pending events are still in the queue. When the events are processed we try to access the TaskWithRequirements associated to the event emitter which has now been removed and this crashes.

In the future we could do something similar pruning for redundant work (e.g. in the `AddTask`/`WeightChange` sequence we can skip `WeightChange`) but for now those sequences only push extra unnecessary work and do not cause a bug so I refrained from changing it.

Furthermore it can be tricky, e.g. `RemoveTask`/`AddTask` cannot be collapsed into a no-op if `RemoveTask` insertion erased other events so the pruning process has to happen globally.