### PR TITLE
Return early if we try to remove a constraint that is not in the problem/Fix segfault when removing nullptr

### DIFF
--- a/include/tvm/utils/internal/map.h
+++ b/include/tvm/utils/internal/map.h
@@ -13,7 +13,10 @@ class IdLess
 {
 public:
   using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
-  constexpr bool operator()(const T * const lhs, const T * const rhs) const { return lhs->id() < rhs->id(); }
+  constexpr bool operator()(const T * const lhs, const T * const rhs) const
+  {
+    return lhs && rhs && lhs->id() < rhs->id();
+  }
   constexpr bool operator()(const T & lhs, const T & rhs) const { return lhs.id() < rhs.id(); }
 };
 
@@ -22,7 +25,10 @@ class IdEqual
 {
 public:
   using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
-  constexpr bool operator()(const T * const lhs, const T * const rhs) const { return lhs->id() == rhs->id(); }
+  constexpr bool operator()(const T * const lhs, const T * const rhs) const
+  {
+    return lhs && rhs && lhs->id() == rhs->id();
+  }
   constexpr bool operator()(const T & lhs, const T & rhs) const { return lhs.id() == rhs.id(); }
 };
 
@@ -31,7 +37,7 @@ class HashId
 {
 public:
   using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
-  std::size_t operator()(const T * key) const { return std::hash<int>()(key->id()); }
+  std::size_t operator()(const T * key) const { return key ? std::hash<int>()(key->id()) : std::hash<int>()(-1); }
   std::size_t operator()(const T & key) const { return std::hash<int>()(key.id()); }
 };
 

--- a/src/LinearizedControlProblem.cpp
+++ b/src/LinearizedControlProblem.cpp
@@ -60,8 +60,11 @@ void LinearizedControlProblem::add(TaskWithRequirementsPtr tr)
 void LinearizedControlProblem::remove(TaskWithRequirements * tr)
 {
   ControlProblem::remove(tr);
-  // if the above line did not throw, tr exists in the problem and in constraints_
   auto it = constraints_.find(tr);
+  if(it == constraints_.end())
+  {
+    return;
+  }
   assert(it != constraints_.end());
   updater_.removeInput(it->second.constraint.get());
   constraints_.erase(it);

--- a/src/LinearizedControlProblem.cpp
+++ b/src/LinearizedControlProblem.cpp
@@ -65,7 +65,6 @@ void LinearizedControlProblem::remove(TaskWithRequirements * tr)
   {
     return;
   }
-  assert(it != constraints_.end());
   updater_.removeInput(it->second.constraint.get());
   constraints_.erase(it);
 }


### PR DESCRIPTION
This PR contains two patches:

1. Return early when we remove a task that is not in the problem (`ControlProblem::remove(tr)` does not throw as indicated in the comment)
2. Avoid a segfault when attempting to access the map with id with nullptr