### PR TITLE
New task dynamics: OneStepToZero

### DIFF
--- a/include/tvm/task_dynamics/OneStepToZero.h
+++ b/include/tvm/task_dynamics/OneStepToZero.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2021 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
+
+#pragma once
+
+#include <tvm/task_dynamics/abstract/TaskDynamics.h>
+
+namespace tvm
+{
+
+namespace task_dynamics
+{
+
+/** Compute \f$ e^{(d)*} = - \sum_{i=0}^{d-1} \frac{d!}{i! dt^{k-i}} \f$ (Order d)
+ *  with \f$ dt \f$ an integration step. That is, compute the desired d-th derivative of \f$ e \f$
+ *  such that if\f$ e(t+dt) \f$ was equal to its Taylor expansion of order d, achieving
+ *  \f$ e^{(d)*} \f$ would bring \f$ e \f$ to 0 in on step \f$ dt \f$.
+ */
+class TVM_DLLAPI OneStepToZero : public abstract::TaskDynamics
+{
+public:
+  static void checkParam(Order d, double dt);
+
+  class TVM_DLLAPI Impl : public abstract::TaskDynamicsImpl
+  {
+  public:
+    Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, Order d, double dt);
+    void updateValue() override;
+
+    ~Impl() override = default;
+
+  private:
+    double dt_;
+  };
+
+  OneStepToZero(Order d, double dt);
+
+protected:
+  std::unique_ptr<abstract::TaskDynamicsImpl> impl_(FunctionPtr f,
+                                                    constraint::Type t,
+                                                    const Eigen::VectorXd & rhs) const override;
+  Order order_() const override;
+
+  TASK_DYNAMICS_DERIVED_FACTORY(d_, dt_)
+
+private:
+  Order d_;
+  double dt_;
+};
+
+} // namespace task_dynamics
+
+} // namespace tvm

--- a/include/tvm/task_dynamics/enums.h
+++ b/include/tvm/task_dynamics/enums.h
@@ -12,7 +12,7 @@ namespace task_dynamics
 
 enum class Order
 {
-  Zero,
+  Zero = 0,
   One,
   Two
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TVM_SOURCES
 
   task_dynamics/Constant.cpp
   task_dynamics/None.cpp
+  task_dynamics/OneStepToZero.cpp
   task_dynamics/Proportional.cpp
   task_dynamics/ProportionalDerivative.cpp
   task_dynamics/Reference.cpp
@@ -200,6 +201,7 @@ set(TVM_HEADERS
   ${TVM_INCLUDE_DIR}/task_dynamics/enums.h
   ${TVM_INCLUDE_DIR}/task_dynamics/FeedForward.h
   ${TVM_INCLUDE_DIR}/task_dynamics/None.h
+  ${TVM_INCLUDE_DIR}/task_dynamics/OneStepToZero.h
   ${TVM_INCLUDE_DIR}/task_dynamics/ProportionalDerivative.h
   ${TVM_INCLUDE_DIR}/task_dynamics/Proportional.h
   ${TVM_INCLUDE_DIR}/task_dynamics/Reference.h

--- a/src/task_dynamics/OneStepToZero.cpp
+++ b/src/task_dynamics/OneStepToZero.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2021 CNRS-AIST JRL and CNRS-UM LIRMM
+ */
+
+#include <tvm/task_dynamics/OneStepToZero.h>
+
+#include <tvm/function/abstract/Function.h>
+
+namespace tvm
+{
+
+namespace task_dynamics
+{
+
+void OneStepToZero::checkParam(Order d, double dt)
+{
+  if(d == Order::Zero)
+    throw std::runtime_error("[task_dynamics::OneStepToZero] This task dynamics only work for order from 1. For order "
+                             "0, maybe task_dynamics::None would fit you need.");
+
+  if(d > Order::Two)
+    throw std::runtime_error("[task_dynamics::OneStepToZero] Implementation only accepts order up to 2.");
+
+  if(dt <= 0)
+    throw std::runtime_error("[task_dynamics::OneStepToZero] dt needs to be positive");
+}
+
+OneStepToZero::OneStepToZero(Order d, double dt) : d_(d), dt_(dt) { checkParam(d, dt); }
+
+std::unique_ptr<abstract::TaskDynamicsImpl> OneStepToZero::impl_(FunctionPtr f,
+                                                                 constraint::Type t,
+                                                                 const Eigen::VectorXd & rhs) const
+{
+  return std::make_unique<Impl>(f, t, rhs, d_, dt_);
+}
+
+Order OneStepToZero::order_() const { return d_; }
+
+OneStepToZero::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs, Order d, double dt)
+: TaskDynamicsImpl(d, f, t, rhs), dt_(dt)
+{
+  OneStepToZero::checkParam(d, dt);
+}
+
+void OneStepToZero::Impl::updateValue()
+{
+  value_ = (rhs() - function().value()) / dt_;
+  if(order() == Order::Two)
+  {
+    value_ -= function().velocity();
+    value_ *= 2 / dt_;
+  }
+}
+
+} // namespace task_dynamics
+
+} // namespace tvm

--- a/src/task_dynamics/OneStepToZero.cpp
+++ b/src/task_dynamics/OneStepToZero.cpp
@@ -6,6 +6,8 @@
 
 #include <tvm/function/abstract/Function.h>
 
+#include <sstream>
+
 namespace tvm
 {
 
@@ -19,10 +21,19 @@ void OneStepToZero::checkParam(Order d, double dt)
                              "0, maybe task_dynamics::None would fit you need.");
 
   if(d > Order::Two)
-    throw std::runtime_error("[task_dynamics::OneStepToZero] Implementation only accepts order up to 2.");
+  {
+    std::stringstream ss;
+    ss << "[task_dynamics::OneStepToZero] Implementation only accepts order up to 2 (input was" << static_cast<int>(d)
+       << ").";
+    throw std::runtime_error(ss.str());
+  }
 
   if(dt <= 0)
-    throw std::runtime_error("[task_dynamics::OneStepToZero] dt needs to be positive");
+  {
+    std::stringstream ss;
+    ss << "[task_dynamics::OneStepToZero] dt needs to be positive (input was" << dt << ").";
+    throw std::runtime_error(ss.str());
+  }
 }
 
 OneStepToZero::OneStepToZero(Order d, double dt) : d_(d), dt_(dt) { checkParam(d, dt); }


### PR DESCRIPTION
This introduces a task dynamics that would bring a task to zero in one step if the Taylor expansion of the task was exact.

Its primary intended use is to transform inequality constraints on a variable into inequality constraints on one of its derivative, assuming a Euler integration. This is typically the case for compound bounds on a variable.