### PR TITLE
Name of subvariable

### DIFF
--- a/include/tvm/Space.h
+++ b/include/tvm/Space.h
@@ -80,6 +80,8 @@ public:
   Type type() const;
   /** Check if this is an Euclidean space.*/
   bool isEuclidean() const;
+  /** Return size triplet as string*/
+  std::string sizeAsString() const;
 
   bool operator==(const Space & other) const
   {

--- a/include/tvm/Variable.h
+++ b/include/tvm/Variable.h
@@ -25,8 +25,10 @@ class VariableVector;
  *
  * \param var the variable to be derived
  * \param ndiff the order of the derivation
+ * \param autoName base the name on that of the supervariable of the primitive
+ * (if the variable was not already created with another name before).
  */
-VariablePtr TVM_DLLAPI dot(VariablePtr var, int ndiff = 1);
+VariablePtr TVM_DLLAPI dot(VariablePtr var, int ndiff = 1, bool autoName = false);
 
 /** Representation of a Variable, i.e. a point in a space.
  *
@@ -170,6 +172,18 @@ public:
    */
   VariablePtr subvariable(Space space, std::string_view baseName, Space shift = {0}) const;
 
+  /** Create a subvariable
+   *
+   * \param space The space in which the variable (or its base primitive in case
+   * of a derivative) is a point.
+   * \param shift The space of the subvariable before this subvariable w.r.t the
+   * current variable.
+   *
+   * Name is automatically generated as x[start:end] (or dk x/ dtk [start:end])
+   * for a k-th derivative.
+   */
+  VariablePtr subvariable(Space space, Space shift = {0}) const;
+
   /** Get the mapping of this variable, within a vector of variables: if all
    * variables values are stacked in one vector v, the returned Range
    * specifies the segment of v corresponding to this variable.
@@ -207,8 +221,11 @@ private:
   /** Constructor for a new variable */
   Variable(const Space & s, std::string_view name);
 
-  /** Constructor for the derivative of var */
-  Variable(Variable * var);
+  /** Constructor for the derivative of var
+   * \param autoName base the name on that of the supervariable of the primitive
+   * (if the variable was not already created with another name before).
+   */
+  Variable(Variable * var, bool autoName);
 
   /** Same as primitive<n> but without checking if n is valid.*/
   template<int n>
@@ -256,7 +273,7 @@ private:
 
   /** friendship declaration */
   friend class Space;
-  friend VariablePtr TVM_DLLAPI dot(VariablePtr, int);
+  friend VariablePtr TVM_DLLAPI dot(VariablePtr, int, bool);
   friend class VariableVector;
 };
 

--- a/include/tvm/Variable.h
+++ b/include/tvm/Variable.h
@@ -165,12 +165,13 @@ public:
    * different).
    * \param shift The space of the subvariable before this subvariable w.r.t the
    * current variable.
-   *
    * For example \c x->subVariable(Space(3), "y", Space(2)) creates a
    * subvariable y of \c x starting after the two first element (x0, x1) and
    * containing the three elements (x2,x3,x4).
+   * This shift is with respect to the space of the supervariable. This is
+   * important if it is not Euclidean.
    */
-  VariablePtr subvariable(Space space, std::string_view baseName, Space shift = {0}) const;
+  [[nodiscard]] VariablePtr subvariable(Space space, std::string_view baseName, Space shift = {0}) const;
 
   /** Create a subvariable
    *
@@ -178,11 +179,16 @@ public:
    * of a derivative) is a point.
    * \param shift The space of the subvariable before this subvariable w.r.t the
    * current variable.
+   * For example \c x->subVariable(Space(3), "y", Space(2)) creates a
+   * subvariable y of \c x starting after the two first element (x0, x1) and
+   * containing the three elements (x2,x3,x4).
+   * This shift is with respect to the space of the supervariable. This is
+   * important if it is not Euclidean.
    *
    * Name is automatically generated as x[start:end] (or dk x/ dtk [start:end])
    * for a k-th derivative.
    */
-  VariablePtr subvariable(Space space, Space shift = {0}) const;
+  [[nodiscard]] VariablePtr subvariable(Space space, Space shift = {0}) const;
 
   /** Get the mapping of this variable, within a vector of variables: if all
    * variables values are stacked in one vector v, the returned Range
@@ -226,6 +232,11 @@ private:
    * (if the variable was not already created with another name before).
    */
   Variable(Variable * var, bool autoName);
+
+  /** Subfunction for the two public overloads. The goal of these overload is to
+   * because autoName = true makes the method effectively ignore baseName.
+   */
+  [[nodiscard]] VariablePtr subvariable(Space space, std::string_view baseName, Space shift, bool autoName) const;
 
   /** Same as primitive<n> but without checking if n is valid.*/
   template<int n>

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -61,4 +61,11 @@ Space::Type Space::type() const { return type_; }
 
 bool Space::isEuclidean() const { return type_ == Type::Euclidean; }
 
+std::string Space::sizeAsString() const
+{
+  std::stringstream ss;
+  ss << "(" << mSize_ << ", " << rSize_ << ", " << tSize_ << ")";
+  return ss.str();
+}
+
 } // namespace tvm

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -233,7 +233,12 @@ Variable::Variable(Variable * var, bool autoName)
 VariablePtr Variable::subvariable(Space space, std::string_view baseName, Space shift, bool autoName) const
 {
   if(!(space * shift <= space_))
-    throw std::runtime_error("[Variable::subvariable] Invalid space and shift dimension");
+  {
+    std::stringstream ss;
+    ss << "[Variable::subvariable] Invalid space and shift dimension. Space of variable is " << space_.sizeAsString()
+       << ", whereas subvariable space is " << space.sizeAsString() << " with shift " << shift.sizeAsString();
+    throw std::runtime_error(ss.str());
+  }
 
   VariablePtr base = superVariable()->basePrimitive();
   VariablePtr sub;

--- a/src/internal/VariableCountingVector.cpp
+++ b/src/internal/VariableCountingVector.cpp
@@ -116,14 +116,12 @@ void VariableCountingVector::update() const
         {
           for(const auto & r : ranges)
           {
-            std::stringstream ss;
-            ss << v->name() << "[" << r.start << ":" << r.end() - 1 << "]";
             // The following line make the assumption that all variables can be treated as euclidean:
             // the dimension and the shift of the subvariable are defined with simple spaces.
             // This is fine if the VariableVector is not differentiated afterwards.
             // If this was really necessary to derive the vector, one could keep track of all the
             // space dimensions with several RangeCounting (one per dimension).
-            variables_.add(v->subvariable(Space(r.dim), ss.str(), Space(r.start)));
+            variables_.add(v->subvariable(Space(r.dim), Space(r.start)));
             simple_.push_back(simple);
           }
         }

--- a/tests/VariableTest.cpp
+++ b/tests/VariableTest.cpp
@@ -170,7 +170,7 @@ TEST_CASE("Test Variable Derivatives")
 
 TEST_CASE("Test Variable Name")
 {
-  VariablePtr v = Space(3).createVariable("v");
+  VariablePtr v = Space(7).createVariable("v");
   FAST_CHECK_EQ(v->name(), "v");
   auto dv = dot(v);
   FAST_CHECK_EQ(dv->name(), "d v / dt");
@@ -184,6 +184,40 @@ TEST_CASE("Test Variable Name")
   FAST_CHECK_EQ(du3->name(), "d3 v' / dt3");
   auto dw3 = dv3->duplicate("w");
   FAST_CHECK_EQ(dw3->name(), "d3 w / dt3");
+
+  {
+    auto sv = v->subvariable(3, 2);
+    FAST_CHECK_EQ(sv->name(), "v[2:4]");
+  }
+  {
+    auto sv = v->subvariable(3, 2);
+    auto sdv2a = dot(sv, 2);
+    FAST_CHECK_EQ(sdv2a->name(), "d2 v[2:4] / dt2");
+  }
+  {
+    auto sv = v->subvariable(3, 2);
+    auto sdv2b = dot(sv, 2, true);
+    FAST_CHECK_EQ(sdv2b->name(), "d2 v / dt2[2:4]");
+  }
+  {
+    auto sv = v->subvariable(3, 2);
+    auto sdv3 = dv3->subvariable(2, 3);
+    FAST_CHECK_EQ(sdv3->name(), "d3 v / dt3[3:4]");
+  }
+  {
+    auto sdv = dv->subvariable(3, "v1", 3);
+    FAST_CHECK_EQ(sdv->name(), "d v1 / dt");
+  }
+  {
+    auto sdv = dv->subvariable(3, "v1", 3);
+    auto sddv1a = dot(sdv);
+    FAST_CHECK_EQ(sddv1a->name(), "d2 v1 / dt2");
+  }
+  {
+    auto sdv = dv->subvariable(3, "v1", 3);
+    auto sddv1b = dot(sdv, 1, true);
+    FAST_CHECK_EQ(sddv1b->name(), "d2 v / dt2[3:5]");
+  }
 }
 
 TEST_CASE("Test derivative lifetime")


### PR DESCRIPTION
This small PR offers more control over the naming of subvariables, in particular the derivatives of subvariables.
An option can be chosen so that such a variable takes the name `dk x / dtk[start:end]`, whatever the order of creation between the derivative and the subvariable.

The system is not perfect because if a subvariable derivative was created without this option, it will keep the name used for this creation when the user try to "recreate it"  which can be a little surprising. But it's an improvement over what already exists anyway, and going for a perfect solution would mean additional check and the creation of new subvariables.
For most practical cases this will work as expected.