### PR TITLE
Various fixes linked to mc_rtc/topic/TVMBackend

### DIFF
--- a/include/tvm/Range.h
+++ b/include/tvm/Range.h
@@ -42,6 +42,12 @@ public:
   /** Return true if both range intersects. */
   bool intersects(const Range & other) const { return this->contains(other.start) || other.contains(this->start); }
 
+  /** Shift start by \p i.*/
+  Range operator+(int i) const { return {this->start + i, this->dim}; }
+
+  /** Shift start by \p -i.*/
+  Range operator-(int i) const { return {this->start - i, this->dim}; }
+
   /** Return the range of other within this Range.
    *
    * e.g Range(3,8).relativeRange(5,2) returns Range(2,2)
@@ -49,7 +55,7 @@ public:
   Range relativeRange(const Range & other) const
   {
     assert(this->contains(other));
-    return {other.start - this->start, other.dim};
+    return other - this->start;
   }
 };
 

--- a/include/tvm/Variable.h
+++ b/include/tvm/Variable.h
@@ -145,8 +145,13 @@ public:
    */
   bool isSuperVariableOf(const Variable & v) const;
   /** If this variable is a subvariable, return its range within its supevariable.
-   * If not, simply return [0, size()].*/
+   * If not, simply return [0, size()].
+   */
   Range subvariableRange() const;
+  /** Equivalent to dot(this)->subvariableRange (without having to create the
+   * derivative).
+   */
+  Range tSubvariableRange() const;
   /** Return true if \p v is a sub-part of this variable.
    *
    * To the difference of Variable::isSuperVariableOf, it is sufficient that

--- a/include/tvm/function/abstract/LinearFunction.h
+++ b/include/tvm/function/abstract/LinearFunction.h
@@ -67,7 +67,7 @@ public:
   void updateValue();
   void updateVelocity();
   void resizeCache() override;
-  const internal::VectorWithProperties & b() const { return b_; }
+  const tvm::internal::VectorWithProperties & b() const { return b_; }
 
 protected:
   LinearFunction(int m);
@@ -75,7 +75,7 @@ protected:
   virtual void updateVelocity_();
   void setDerivativesToZero();
 
-  internal::VectorWithProperties b_;
+  tvm::internal::VectorWithProperties b_;
 };
 
 } // namespace abstract

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -182,7 +182,7 @@ protected:
 
   // cache
   Eigen::VectorXd value_;
-  utils::internal::MapWithVariableAsKey<MatrixWithProperties, slice_matrix> jacobian_;
+  utils::internal::MapWithVariableAsKey<MatrixWithProperties, slice_matrix, true> jacobian_;
 
 protected:
   /** Resize the function */

--- a/include/tvm/internal/VariableCountingVector.h
+++ b/include/tvm/internal/VariableCountingVector.h
@@ -5,8 +5,8 @@
 #include <tvm/api.h>
 #include <tvm/defs.h>
 
-#include <tvm/VariableVector.h>
 #include <tvm/Space.h>
+#include <tvm/VariableVector.h>
 #include <tvm/internal/RangeCounting.h>
 #include <tvm/utils/internal/map.h>
 

--- a/include/tvm/internal/VariableCountingVector.h
+++ b/include/tvm/internal/VariableCountingVector.h
@@ -6,6 +6,7 @@
 #include <tvm/defs.h>
 
 #include <tvm/VariableVector.h>
+#include <tvm/Space.h>
 #include <tvm/internal/RangeCounting.h>
 #include <tvm/utils/internal/map.h>
 
@@ -76,9 +77,21 @@ public:
   bool isDisjointUnion();
 
 private:
+  struct SpaceRangeCounting
+  {
+    tvm::internal::RangeCounting mSize_;
+    tvm::internal::RangeCounting rSize_;
+    tvm::internal::RangeCounting tSize_;
+
+    bool add(const Space & start, const Space & dim);
+    bool remove(const Space & start, const Space & dim);
+    bool empty() const { return mSize_.empty(); }
+    int maxCount() const { return mSize_.maxCount(); }
+  };
+
   void update() const;
 
-  tvm::utils::internal::map<Variable *, std::pair<tvm::internal::RangeCounting, size_t>> count_;
+  tvm::utils::internal::map<Variable *, std::pair<SpaceRangeCounting, size_t>> count_;
   bool split_;
   mutable bool upToDate_ = false;
   mutable VariableVector variables_;

--- a/include/tvm/internal/VariableCountingVector.h
+++ b/include/tvm/internal/VariableCountingVector.h
@@ -29,7 +29,7 @@ namespace tvm::internal
 class TVM_DLLAPI VariableCountingVector
 {
 public:
-  /** \param split If true, variable parts who do not appears with the same count
+  /** \param split If true, variable parts who do not appear with the same count
    * or were not added at the same time are separated.
    * For example, if x is a variable of size 8, adding x[0:3] then x[4:7] will
    * yield a single variable (x) when split = false but two variables (x[0:3],
@@ -49,13 +49,7 @@ public:
 
   void set(const VectorConstRef & val);
 
-  /** Return the vector of variables resulting from the different add and remove.
-   *
-   * \warning This vector is not meant to be differentiated. This could cause
-   * troubles with non-Euclidean variables.
-   *
-   * \internal see comment in code.
-   */
+  /** Return the vector of variables resulting from the different add and remove. */
   const VariableVector & variables() const;
 
   /** Return a vector mirroring variables() where simple()[i] is \a true when

--- a/include/tvm/internal/VariableVectorPartition.h
+++ b/include/tvm/internal/VariableVectorPartition.h
@@ -7,7 +7,7 @@
 
 namespace tvm::internal
 {
-/** An helper class to iterate over a container of VariablePtr \a c where the
+/** A helper class to iterate over a container of VariablePtr \a c where the
  * variables are split according to a given partition \a p expressed as a
  * VariableCountingVector. The iteration is made over \a c, but the iterator
  * points to (sub)variables in \a p.

--- a/include/tvm/utils/internal/MapWithVariableAsKey.h
+++ b/include/tvm/utils/internal/MapWithVariableAsKey.h
@@ -30,8 +30,10 @@ struct slice_traits
  * the slice of \p t corresponding to \p r (non-const case)
  *  - \code static ConstType get(const T & t, const Range & r)\endcode, same
  * function for the constant case.
+ * \tparam tSize If \c false, use the range of the variable x. If \c true, use
+ * the size of the derivative.
  */
-template<typename T, typename Slicer = slice_traits<T>>
+template<typename T, typename Slicer = slice_traits<T>, bool tSize = false>
 class MapWithVariableAsKey : public tvm::utils::internal::map<const Variable * const, T>
 {
 public:
@@ -42,8 +44,8 @@ public:
   typename Slicer::ConstType at(const typename Base::key_type & key, with_sub) const;
 };
 
-template<typename T, typename Slicer>
-inline typename Slicer::Type MapWithVariableAsKey<T, Slicer>::at(const typename Base::key_type & key, with_sub)
+template<typename T, typename Slicer, bool tSize>
+inline typename Slicer::Type MapWithVariableAsKey<T, Slicer, tSize>::at(const typename Base::key_type & key, with_sub)
 {
   auto it = Base::find(key);
   if(it != Base::end())
@@ -64,7 +66,11 @@ inline typename Slicer::Type MapWithVariableAsKey<T, Slicer>::at(const typename 
         }
         else
         {
-          Range r = it->first->subvariableRange().relativeRange(key->subvariableRange());
+          Range r; 
+          if constexpr(tSize)
+            r = it->first->tSubvariableRange().relativeRange(key->tSubvariableRange());
+          else
+            r = it->first->subvariableRange().relativeRange(key->subvariableRange());
           return Slicer::get(it->second, r);
         }
       }
@@ -74,9 +80,9 @@ inline typename Slicer::Type MapWithVariableAsKey<T, Slicer>::at(const typename 
   throw std::out_of_range("[MapWithVariableAsKey::at] Variable " + key->name() + " is not part of this map.");
 }
 
-template<typename T, typename Slicer>
-inline typename Slicer::ConstType MapWithVariableAsKey<T, Slicer>::at(const typename Base::key_type & key,
-                                                                      with_sub) const
+template<typename T, typename Slicer, bool tSize>
+inline typename Slicer::ConstType MapWithVariableAsKey<T, Slicer, tSize>::at(const typename Base::key_type & key,
+                                                                             with_sub) const
 {
   auto it = Base::find(key);
   if(it != Base::end())
@@ -97,7 +103,11 @@ inline typename Slicer::ConstType MapWithVariableAsKey<T, Slicer>::at(const type
         }
         else
         {
-          Range r = it->first->subvariableRange().relativeRange(key->subvariableRange());
+          Range r;
+          if constexpr(tSize)
+            r = it->first->tSubvariableRange().relativeRange(key->tSubvariableRange());
+          else
+            r = it->first->subvariableRange().relativeRange(key->subvariableRange());
           return Slicer::get(it->second, r);
         }
       }

--- a/include/tvm/utils/internal/MapWithVariableAsKey.h
+++ b/include/tvm/utils/internal/MapWithVariableAsKey.h
@@ -66,7 +66,7 @@ inline typename Slicer::Type MapWithVariableAsKey<T, Slicer, tSize>::at(const ty
         }
         else
         {
-          Range r; 
+          Range r;
           if constexpr(tSize)
             r = it->first->tSubvariableRange().relativeRange(key->tSubvariableRange());
           else

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -176,7 +176,7 @@ Range Variable::subvariableRange() const
 Range Variable::tSubvariableRange() const
 {
   if(isBasePrimitive())
-    return subvariableRange() - (shift_.rSize() - shift_.tSize());
+    return {subvariableRange().start - (shift_.rSize() - shift_.tSize()), space_.tSize()};
   else
     return subvariableRange();
 }

--- a/src/Variable.cpp
+++ b/src/Variable.cpp
@@ -173,6 +173,14 @@ Range Variable::subvariableRange() const
     return {static_cast<int>(value_.data() - superVariable_->value_.data()), size()};
 }
 
+Range Variable::tSubvariableRange() const
+{
+  if(isBasePrimitive())
+    return subvariableRange() - (shift_.rSize() - shift_.tSize());
+  else
+    return subvariableRange();
+}
+
 bool Variable::contains(const Variable & v) const
 {
   return superVariable() == v.superVariable() && subvariableRange().contains(v.subvariableRange());

--- a/src/hint/Substitutions.cpp
+++ b/src/hint/Substitutions.cpp
@@ -160,7 +160,8 @@ const std::vector<VariablePtr> & Substitutions::otherVariables() const { return 
 
 VariableVector Substitutions::substitute(const VariablePtr & x) const
 {
-  auto it = std::find_if(variables_.begin(), variables_.end(), [&x](const VariablePtr & v) { return v->intersects(*x); });
+  auto it =
+      std::find_if(variables_.begin(), variables_.end(), [&x](const VariablePtr & v) { return v->intersects(*x); });
   if(it == variables_.end()) // no substitution of var
   {
     VariableVector v({x});

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -60,6 +60,7 @@ void FirstOrderProvider::removeVariable(VariablePtr v)
 {
   variables_.remove(*v);
   jacobian_.erase(v.get());
+  linear_.erase(v.get());
   removeVariable_(v);
 }
 

--- a/src/internal/VariableCountingVector.cpp
+++ b/src/internal/VariableCountingVector.cpp
@@ -14,7 +14,7 @@ bool VariableCountingVector::add(VariablePtr v)
   const Space & start = v->spaceShift();
   const Space & dim = v->space();
   auto & counterPair = count_.insert({s.get(), {SpaceRangeCounting{}, 0}}).first->second;
-  //bool change = counterPair.first.add(v->subvariableRange());
+  // bool change = counterPair.first.add(v->subvariableRange());
   bool change = counterPair.first.add(start, dim);
   if(change)
     ++counterPair.second;
@@ -114,7 +114,9 @@ void VariableCountingVector::update() const
       {
         auto v = p.first;
         bool simple = p.second.second == mRanges.size();
-        if(mRanges.size() == 1 && ((v->isBasePrimitive() && rRanges[0].dim == v->size()) || (!v->isBasePrimitive() && tRanges[0].dim == v->size())))
+        if(mRanges.size() == 1
+           && ((v->isBasePrimitive() && rRanges[0].dim == v->size())
+               || (!v->isBasePrimitive() && tRanges[0].dim == v->size())))
         {
           assert(mRanges[0].start == 0);
           variables_.add(v->shared_from_this());
@@ -122,7 +124,7 @@ void VariableCountingVector::update() const
         }
         else
         {
-          for(size_t i=0; i<mRanges.size(); ++i)
+          for(size_t i = 0; i < mRanges.size(); ++i)
           {
             const auto & mr = mRanges[i];
             const auto & rr = rRanges[i];

--- a/src/internal/VariableCountingVector.cpp
+++ b/src/internal/VariableCountingVector.cpp
@@ -11,8 +11,11 @@ namespace tvm::internal
 bool VariableCountingVector::add(VariablePtr v)
 {
   VariablePtr s = v->superVariable();
-  auto & counterPair = count_.insert({s.get(), {RangeCounting{}, 0}}).first->second;
-  bool change = counterPair.first.add(v->subvariableRange());
+  const Space & start = v->spaceShift();
+  const Space & dim = v->space();
+  auto & counterPair = count_.insert({s.get(), {SpaceRangeCounting{}, 0}}).first->second;
+  //bool change = counterPair.first.add(v->subvariableRange());
+  bool change = counterPair.first.add(start, dim);
   if(change)
     ++counterPair.second;
   upToDate_ = upToDate_ && !change;
@@ -28,8 +31,10 @@ void VariableCountingVector::add(const VariableVector & v)
 bool VariableCountingVector::remove(const Variable & v)
 {
   VariablePtr s = v.superVariable();
+  const Space & start = v.spaceShift();
+  const Space & dim = v.space();
   auto & counterPair = count_.at(s.get());
-  bool change = counterPair.first.remove(v.subvariableRange());
+  bool change = counterPair.first.remove(start, dim);
   if(change)
   {
     if(counterPair.first.empty())
@@ -97,31 +102,32 @@ void VariableCountingVector::update() const
     simple_.clear();
     for(const auto & p : count_)
     {
-      auto ranges = p.second.first.ranges(split_);
-      if(ranges.size() == 0)
+      auto mRanges = p.second.first.mSize_.ranges(split_);
+      auto rRanges = p.second.first.rSize_.ranges(split_);
+      auto tRanges = p.second.first.tSize_.ranges(split_);
+      assert(mRanges.size() == rRanges.size() && mRanges.size() == tRanges.size());
+      if(mRanges.size() == 0)
       {
         continue;
       }
       else
       {
         auto v = p.first;
-        bool simple = p.second.second == ranges.size();
-        if(ranges.size() == 1 && ranges[0].dim == v->size())
+        bool simple = p.second.second == mRanges.size();
+        if(mRanges.size() == 1 && ((v->isBasePrimitive() && rRanges[0].dim == v->size()) || (!v->isBasePrimitive() && tRanges[0].dim == v->size())))
         {
-          assert(ranges[0].start == 0);
+          assert(mRanges[0].start == 0);
           variables_.add(v->shared_from_this());
           simple_.push_back(simple);
         }
         else
         {
-          for(const auto & r : ranges)
+          for(size_t i=0; i<mRanges.size(); ++i)
           {
-            // The following line make the assumption that all variables can be treated as euclidean:
-            // the dimension and the shift of the subvariable are defined with simple spaces.
-            // This is fine if the VariableVector is not differentiated afterwards.
-            // If this was really necessary to derive the vector, one could keep track of all the
-            // space dimensions with several RangeCounting (one per dimension).
-            variables_.add(v->subvariable(Space(r.dim), Space(r.start)));
+            const auto & mr = mRanges[i];
+            const auto & rr = rRanges[i];
+            const auto & tr = tRanges[i];
+            variables_.add(v->subvariable(Space(mr.dim, rr.dim, tr.dim), Space(mr.start, rr.start, tr.start)));
             simple_.push_back(simple);
           }
         }
@@ -129,5 +135,18 @@ void VariableCountingVector::update() const
     }
     upToDate_ = true;
   }
+}
+bool VariableCountingVector::SpaceRangeCounting::add(const Space & start, const Space & dim)
+{
+  rSize_.add({start.rSize(), dim.rSize()});
+  tSize_.add({start.tSize(), dim.tSize()});
+  return mSize_.add({start.size(), dim.size()});
+}
+
+bool VariableCountingVector::SpaceRangeCounting::remove(const Space & start, const Space & dim)
+{
+  rSize_.remove({start.rSize(), dim.rSize()});
+  tSize_.remove({start.tSize(), dim.tSize()});
+  return mSize_.remove({start.size(), dim.size()});
 }
 } // namespace tvm::internal

--- a/src/solver/LSSOLLeastSquareSolver.cpp
+++ b/src/solver/LSSOLLeastSquareSolver.cpp
@@ -35,6 +35,23 @@ LSSOLLeastSquareSolver::LSSOLLeastSquareSolver(const LSSOLLSSolverOptions & opti
   TVM_PROCESS_OPTION(printLevel, fp_)
   TVM_PROCESS_OPTION(rankTol, fp_)
   TVM_PROCESS_OPTION(warm, fp_)
+  ls_.forceMinSize(false);
+  fp_.forceMinSize(false);
+  if(!options.persistence())
+  {
+    ls_.persistence(true);
+    fp_.persistence(true);
+  }
+  if(!options.feasibilityMaxIter())
+  {
+    ls_.feasibilityMaxIter(4 * ls_.feasibilityMaxIter());
+    fp_.feasibilityMaxIter(4 * fp_.feasibilityMaxIter());
+  }
+  if(!options.optimalityMaxIter())
+  {
+    ls_.optimalityMaxIter(4 * ls_.optimalityMaxIter());
+    fp_.optimalityMaxIter(4 * fp_.optimalityMaxIter());
+  }
 }
 
 void LSSOLLeastSquareSolver::initializeBuild_(int nObj, int nEq, int nIneq, bool)

--- a/tests/RangeCountingTest.cpp
+++ b/tests/RangeCountingTest.cpp
@@ -583,3 +583,39 @@ TEST_CASE("VariableVectorPartition")
   FAST_CHECK_EQ(*u[4], *y->subvariable(2, "yb", 3));
   FAST_CHECK_EQ(*u[5], *y->subvariable(3, "yc", 5));
 }
+
+TEST_CASE("Non-Euclidean variables in VariableCountingVector")
+{
+  VariableCountingVector vc;
+
+  VariablePtr x = Space(21, 27, 23).createVariable("x");
+
+  VariablePtr x1 = x->subvariable(Space(3, 3, 3), "x1", 0);
+  VariablePtr x2 = x->subvariable(Space(3, 4, 3), "x2", Space(3, 3, 3));
+  VariablePtr x3 = x->subvariable(Space(2, 2, 2), "x3", Space(6, 7, 6));
+  VariablePtr x4 = x->subvariable(Space(4, 6, 5), "x4", Space(8, 9, 8));
+  VariablePtr x5 = x->subvariable(Space(1, 1, 1), "x5", Space(12, 15, 13));
+  VariablePtr x6 = x->subvariable(Space(2, 2, 2), "x6", Space(13, 16, 14));
+  VariablePtr x7 = x->subvariable(Space(3, 4, 3), "x7", Space(15, 18, 16));
+  VariablePtr x8 = x->subvariable(Space(2, 4, 3), "x8", Space(18, 22, 19));
+  VariablePtr x9 = x->subvariable(Space(1, 1, 1), "x9", Space(20, 26, 22));
+
+  VariablePtr x12 = x->subvariable(Space(6, 7, 6), "x12", 0);
+  VariablePtr x234 = x->subvariable(Space(9, 12, 10), "x234", Space(3, 3, 3));
+  VariablePtr x456 = x->subvariable(Space(7, 9, 8), "x456", Space(8, 9, 8));
+  VariablePtr x678 = x->subvariable(Space(7, 10, 8), "x678", Space(13, 16, 14));
+  VariablePtr x789 = x->subvariable(Space(6, 9, 7), "x789", Space(15, 18, 16));
+
+  vc.add(x2);
+  vc.add(x678);
+  vc.add(x4);
+  vc.add(x234);
+  vc.add(x789);
+
+  auto v = vc.variables();
+  FAST_CHECK_EQ(v.numberOfVariables(), 2);
+
+  auto dv = dot(v);
+  FAST_CHECK_EQ(dv[0]->subvariableRange(), Range(3, 10));
+  FAST_CHECK_EQ(dv[1]->subvariableRange(), Range(14, 9));
+}

--- a/tests/SolverTest.cpp
+++ b/tests/SolverTest.cpp
@@ -15,6 +15,7 @@
 #include <tvm/scheme/WeightedLeastSquares.h>
 #include <tvm/solver/defaultLeastSquareSolver.h>
 #include <tvm/task_dynamics/None.h>
+#include <tvm/task_dynamics/Proportional.h>
 #include <tvm/task_dynamics/ProportionalDerivative.h>
 #include <tvm/task_dynamics/VelocityDamper.h>
 
@@ -115,4 +116,189 @@ TEST_CASE("Substitution")
 
   FAST_CHECK_UNARY(ddx0.isApprox(ddxs, 1e-5));
   FAST_CHECK_UNARY(ddq0.isApprox(ddqs, 1e-5));
+}
+
+#include <Eigen/Geometry>
+
+Matrix3d hat(const VectorConstRef & v)
+{
+  Matrix3d H;
+  H << 0, -v.z(), v.y(), v.z(), 0, -v.x(), -v.y(), v.x(), 0;
+  return H;
+}
+
+Quaterniond exp(const VectorConstRef & v)
+{
+  double t = v.norm();
+  if(t < 1e-14)
+    return Quaterniond::Identity();
+
+  Vector3d u = std::sin(t / 2) * v / t;
+
+  return {std::cos(t / 2), u.x(), u.y(), u.z()};
+}
+
+class SO3Action : public function::abstract::Function
+{
+public:
+  SET_UPDATES(SO3Action, Rotation, Value, Jacobian)
+
+  SO3Action(VariablePtr q, VariablePtr v) : function::abstract::Function(3), q_(*q), v_(*v)
+  {
+    registerUpdates(Update::Rotation, &SO3Action::updateRotation, Update::Value, &SO3Action::updateValue,
+                    Update::Jacobian, &SO3Action::updateJacobian);
+    addInternalDependency<SO3Action>(Update::Value, Update::Rotation);
+    addInternalDependency<SO3Action>(Update::Jacobian, Update::Rotation);
+    addOutputDependency<SO3Action>(Output::Value, Update::Value);
+    addOutputDependency<SO3Action>(Output::Jacobian, Update::Jacobian);
+    addVariable(q, false);
+    addVariable(v, true);
+  }
+
+  void updateRotation()
+  {
+    const auto & d = q_.value();
+    R_ = Eigen::Quaterniond(d[0], d[1], d[2], d[3]).toRotationMatrix();
+  }
+
+  void updateValue() { value_ = R_ * v_.value(); }
+
+  void updateJacobian()
+  {
+    jacobian_.at(&q_) = -R_ * hat(v_.value());
+    jacobian_.at(&v_) = R_;
+  }
+
+private:
+  Variable & q_;
+  Variable & v_;
+  Matrix3d R_;
+};
+
+class SE3Action : public function::abstract::Function
+{
+public:
+  SET_UPDATES(SE3Action, Rotation, Value, Jacobian)
+
+  SE3Action(VariablePtr h, VariablePtr v) : function::abstract::Function(3), h_(*h), v_(*v)
+  {
+    registerUpdates(Update::Rotation, &SE3Action::updateRotation, Update::Value, &SE3Action::updateValue,
+                    Update::Jacobian, &SE3Action::updateJacobian);
+    addInternalDependency<SE3Action>(Update::Value, Update::Rotation);
+    addInternalDependency<SE3Action>(Update::Jacobian, Update::Rotation);
+    addOutputDependency<SE3Action>(Output::Value, Update::Value);
+    addOutputDependency<SE3Action>(Output::Jacobian, Update::Jacobian);
+    addVariable(h, false);
+    addVariable(v, true);
+  }
+
+  void updateRotation()
+  {
+    const auto & d = h_.value();
+    R_ = Eigen::Quaterniond(d[0], d[1], d[2], d[3]).toRotationMatrix();
+  }
+
+  void updateValue() { value_ = R_ * v_.value() + h_.value().tail<3>(); }
+
+  void updateJacobian()
+  {
+    auto & Jh = jacobian_.at(&h_);
+    Jh.leftCols<3>() = -R_ * hat(v_.value());
+    Jh.rightCols<3>() = R_;
+    jacobian_.at(&v_) = R_;
+  }
+
+private:
+  Variable & h_;
+  Variable & v_;
+  Matrix3d R_;
+};
+
+TEST_CASE("Substitution with non-Euclidean variables")
+{
+  Space SO3(Space::Type::SO3);
+  Space SE3(Space::Type::SE3);
+  Space R3(3);
+
+  VariablePtr h1 = SE3.createVariable("h1");
+  h1 << 1, 0, 0, 0, 0, 0, 0;
+  VariablePtr h2 = SE3.createVariable("h2");
+  h2 << 1, 0, 0, 0, 0, 0, 0;
+  VariablePtr v1 = R3.createVariable("v1");
+  VariablePtr v2 = R3.createVariable("v2");
+
+  VariablePtr h1r = h1->subvariable(SO3, "h1r");
+  VariablePtr h1t = h1->subvariable(R3, "h1t", SO3);
+  VariablePtr h2r = h2->subvariable(SO3, "h2r");
+  VariablePtr h2t = h2->subvariable(R3, "h2t", SO3);
+
+  auto fe1 = std::make_shared<SE3Action>(h1, v1);
+  auto fe2 = std::make_shared<SE3Action>(h2, v2);
+
+  auto sub12 = std::make_shared<Difference>(fe1, fe2);
+
+  double dt = 0.1;
+  auto updateSE3 = [&dt](VariablePtr h, const VectorConstRef & wv) {
+    const auto & d = h->value();
+    const auto & w = wv.head<3>();
+    Quaterniond r = Quaterniond(d[0], d[1], d[2], d[3]) * exp(w * dt);
+    h << r.w(), r.x(), r.y(), r.z(), d.tail<3>() + dt * wv.tail<3>();
+  };
+  auto updateR = [&dt](VariablePtr x, const VectorConstRef & dx) { x->set(x->value() + dt * dx); };
+
+  {
+    LinearizedControlProblem lpb;
+    auto t1 = lpb.add(sub12 == 0., task_dynamics::Proportional(1), {requirements::PriorityLevel(0)});
+    auto t2 = lpb.add(v1 == Vector3d(1, 0, 0), task_dynamics::Proportional(1), {requirements::PriorityLevel(0)});
+    auto t3 = lpb.add(v2 == Vector3d(0, 1, 0), task_dynamics::Proportional(1), {requirements::PriorityLevel(0)});
+    auto t4 = lpb.add(h1t == 0., task_dynamics::Proportional(1), {requirements::PriorityLevel(1)});
+    auto t5 = lpb.add(h2t == 0., task_dynamics::Proportional(1), {requirements::PriorityLevel(1)});
+
+    lpb.add(hint::Substitution(lpb.constraint(*t1), dot(h1t)));
+
+    scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions{});
+    for(int i = 0; i < 200; ++i)
+    {
+      solver.solve(lpb);
+
+      updateSE3(h1, dot(h1)->value());
+      updateSE3(h2, dot(h2)->value());
+      updateR(v1, dot(v1)->value());
+      updateR(v2, dot(v2)->value());
+    }
+
+    FAST_CHECK_LE(sub12->value().norm(), 1e-8);
+    FAST_CHECK_UNARY(v1->value().isApprox(Vector3d::UnitX(), 1e-8));
+    FAST_CHECK_UNARY(v2->value().isApprox(Vector3d::UnitY(), 1e-8));
+    FAST_CHECK_LE(h1t->value().norm(), 1e-8);
+    FAST_CHECK_LE(h2t->value().norm(), 1e-8);
+  }
+
+  {
+    LinearizedControlProblem lpb;
+    auto t1 = lpb.add(sub12 == 0., task_dynamics::Proportional(1), {requirements::PriorityLevel(0)});
+    auto t2 = lpb.add(v1 == Vector3d(1, 0, 0), task_dynamics::Proportional(1), {requirements::PriorityLevel(0)});
+    auto t3 = lpb.add(v2 == Vector3d(0, 1, 0), task_dynamics::Proportional(1), {requirements::PriorityLevel(0)});
+    auto t4 = lpb.add(h1t == 0., task_dynamics::Proportional(1), {requirements::PriorityLevel(1)});
+    auto t5 = lpb.add(h2t == 0., task_dynamics::Proportional(1), {requirements::PriorityLevel(1)});
+
+    lpb.add(hint::Substitution(lpb.constraint(*t1), dot(h2r)));
+
+    scheme::WeightedLeastSquares solver(solver::DefaultLSSolverOptions{});
+    for(int i = 0; i < 200; ++i)
+    {
+      solver.solve(lpb);
+
+      updateSE3(h1, dot(h1)->value());
+      updateSE3(h2, dot(h2)->value());
+      updateR(v1, dot(v1)->value());
+      updateR(v2, dot(v2)->value());
+    }
+
+    FAST_CHECK_LE(sub12->value().norm(), 1e-8);
+    FAST_CHECK_UNARY(v1->value().isApprox(Vector3d::UnitX(), 1e-8));
+    FAST_CHECK_UNARY(v2->value().isApprox(Vector3d::UnitY(), 1e-8));
+    FAST_CHECK_LE(h1t->value().norm(), 1e-8);
+    FAST_CHECK_LE(h2t->value().norm(), 1e-8);
+  }
 }

--- a/tests/VariableTest.cpp
+++ b/tests/VariableTest.cpp
@@ -760,3 +760,36 @@ TEST_CASE("Subvariable contains")
     FAST_CHECK_UNARY(v30->intersects(*v30));
   }
 }
+
+TEST_CASE("Subvariable range")
+{
+  VariablePtr x = Space(6).createVariable("x");
+  VariablePtr y = Space(Space::Type::SE3).createVariable("y");
+
+  VariablePtr x1 = x->subvariable(Space(3), "x1");
+  VariablePtr x2 = x->subvariable(Space(3), "x2", Space(2));
+
+  VariablePtr y1 = y->subvariable(Space(Space::Type::SO3), "y1");
+  VariablePtr y2 = y->subvariable(Space(3), "y2", Space(Space::Type::SO3));
+
+  FAST_CHECK_EQ(x->subvariableRange(), Range(0, 6));
+  FAST_CHECK_EQ(x1->subvariableRange(), Range(0, 3));
+  FAST_CHECK_EQ(x2->subvariableRange(), Range(2, 3));
+  FAST_CHECK_EQ(y->subvariableRange(), Range(0, 7));
+  FAST_CHECK_EQ(y1->subvariableRange(), Range(0, 4));
+  FAST_CHECK_EQ(y2->subvariableRange(), Range(4, 3));
+
+  FAST_CHECK_EQ(dot(x)->subvariableRange(), Range(0, 6));
+  FAST_CHECK_EQ(dot(x1)->subvariableRange(), Range(0, 3));
+  FAST_CHECK_EQ(dot(x2)->subvariableRange(), Range(2, 3));
+  FAST_CHECK_EQ(dot(y)->subvariableRange(), Range(0, 6));
+  FAST_CHECK_EQ(dot(y1)->subvariableRange(), Range(0, 3));
+  FAST_CHECK_EQ(dot(y2)->subvariableRange(), Range(3, 3));
+
+  FAST_CHECK_EQ(x->tSubvariableRange(), dot(x)->subvariableRange());
+  FAST_CHECK_EQ(x1->tSubvariableRange(), dot(x1)->subvariableRange());
+  FAST_CHECK_EQ(x2->tSubvariableRange(), dot(x2)->subvariableRange());
+  FAST_CHECK_EQ(y->tSubvariableRange(), dot(y)->subvariableRange());
+  FAST_CHECK_EQ(y1->tSubvariableRange(), dot(y1)->subvariableRange());
+  FAST_CHECK_EQ(y2->tSubvariableRange(), dot(y2)->subvariableRange());
+}


### PR DESCRIPTION
This PR introduce various fixes on problem triggered in the mc_rtc use of TVM.
Here are the main ones:
 *  `VariableCountingVector` fully handling non-euclidean variable. In particular, this removes the limitation that the resulting vector of variables should not be differentiated
 * Subvariable substitution was adapted and fixed in consequence
 * Various fixes to use the proper variable size depending on derivative level.
