### PR TITLE
Add events support to HierarchicalLeastSquares

### DIFF
--- a/include/tvm/solver/LexLSHierarchicalLeastSquareSolver.h
+++ b/include/tvm/solver/LexLSHierarchicalLeastSquareSolver.h
@@ -53,7 +53,7 @@ protected:
   void updateInequalityTargetData(int lvl, scheme::internal::AssignmentTarget & target) override;
   void updateBoundTargetData(scheme::internal::AssignmentTarget & target) override;
 
-  void applyImpactLogic(ImpactFromChanges & impact);
+  void applyImpactLogic(ImpactFromChanges & impact) override;
 
   void printProblemData_() const override;
   void printDiagnostic_() const override;

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -67,7 +67,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
             throw std::runtime_error(
                 "[WeightedLeastSquares::updateComputationData_] "
                 "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
-          se.addScalarWeightEvent(c.constraint.get());
+          se.addScalarWeightEvent(c.constraint.get(), c.requirements->priorityLevel().value());
         }
         break;
         case EventType::AnisotropicWeightChange: {
@@ -76,7 +76,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
             throw std::runtime_error(
                 "[WeightedLeastSquares::updateComputationData_] "
                 "WeightedLeastSquares does not allow to change the weight of a Task with priority 0.");
-          se.addVectorWeightEvent(c.constraint.get());
+          se.addVectorWeightEvent(c.constraint.get(), c.requirements->priorityLevel().value());
         }
         break;
         case EventType::TaskAddition:
@@ -255,7 +255,7 @@ void WeightedLeastSquares::addTask(const LinearizedControlProblem & problem,
   {
     if(p == 0)
     {
-      se.addConstraint(c.constraint);
+      se.addConstraint(c.constraint, c.requirements);
     }
     else
     {
@@ -303,7 +303,7 @@ void WeightedLeastSquares::removeTask(const LinearizedControlProblem & problem,
   {
     if(p == 0)
     {
-      se.removeConstraint(c.constraint);
+      se.removeConstraint(c.constraint, 0);
     }
     else
     {

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -228,7 +228,7 @@ void LeastSquareSolver::process(const internal::SolverEvents & se)
         [&](const auto & c) { return nextInequalityConstraintRange_(c); },
         [&](const auto & c) { return constraintSize(c); });
 
-  int dummy;
+  int dummy = 0;
   if(impact.bounds_ || needMappingUpdate) // needMappingUpdate because a variable might have been added or removed
     updateTargetRange(
         boundToAssignments_, dummy, [&](const auto & b) { return b.variables()[0]->getMappingIn(variables()); },
@@ -297,7 +297,7 @@ void LeastSquareSolver::updateWeights(const internal::SolverEvents & se)
 
   for(const auto & e : we)
   {
-    auto [c, scalar, vector] = e;
+    auto [c, p, scalar, vector] = e;
 
     // We might have change of weights on constraints that were not added yet (because process of
     // of weight arise before processing added constraints - if we'd process the weight after, we
@@ -331,7 +331,7 @@ bool LeastSquareSolver::updateVariables(const internal::SolverEvents & se)
 
 LeastSquareSolver::ImpactFromChanges LeastSquareSolver::processRemovedConstraints(const internal::SolverEvents & se)
 {
-  for(const auto & c : se.removedConstraints())
+  for(const auto & [c, _] : se.removedConstraints())
   {
     if(c->isEquality())
     {
@@ -387,7 +387,7 @@ LeastSquareSolver::ImpactFromChanges LeastSquareSolver::previewAddedConstraints(
   eqSize_ = nEq_;
   ineqSize_ = nIneq_;
   objSize_ = nObj_;
-  for(const auto & c : se.addedConstraints())
+  for(const auto & [c, _] : se.addedConstraints())
   {
     if(c->isEquality())
       nEq_ += constraintSize(*c);
@@ -406,7 +406,7 @@ LeastSquareSolver::ImpactFromChanges LeastSquareSolver::previewAddedConstraints(
 void LeastSquareSolver::processAddedConstraints(const internal::SolverEvents & se)
 {
   buildInProgress_ = true;
-  for(const auto & c : se.addedConstraints())
+  for(const auto & [c, _] : se.addedConstraints())
     addConstraint(c);
 
   for(const auto & b : se.addedBounds())


### PR DESCRIPTION
This PR adds event supports to the HierarhicalLeastSquaresScheme|Solver

This does not include support for changing a task's priority while it's active which might come in a later PR