### PR TITLE
[graph] Disallow input dependencies without registered update

### DIFF
--- a/include/tvm/graph/abstract/Node.hpp
+++ b/include/tvm/graph/abstract/Node.hpp
@@ -172,6 +172,16 @@ template<typename U, typename EnumU, typename S, typename EnumO>
 void Node<T>::addInputDependency(EnumU u, S * source, EnumO i)
 {
   static_assert(is_valid_output<S>(EnumO()), "Invalid output for this type of source.");
+
+  // Make sure we have a registered update
+  if(!updates_.count(static_cast<int>(u)))
+  {
+    std::stringstream ss;
+    ss << "Attempted to register an input dependency to " << U::UpdateBaseName << " for update " << U::UpdateName(u)
+       << " that has no corresponding registered update function. Consider calling registerUpdates first.";
+    throw std::runtime_error(ss.str());
+  }
+
   if(inputDependencies_.count(static_cast<int>(u)))
   {
     auto & inputDependency = inputDependencies_[static_cast<int>(u)];

--- a/src/task_dynamics/TaskDynamicsImpl.cpp
+++ b/src/task_dynamics/TaskDynamicsImpl.cpp
@@ -25,8 +25,8 @@ TaskDynamicsImpl::TaskDynamicsImpl(Order order, FunctionPtr f, constraint::Type 
   if(!f->imageSpace().isEuclidean())
     throw std::runtime_error(
         "[TaskDynamicsImpl::TaskDynamicsImpl] Task dynamics are for function into a Euclidean space.");
-  setFunction(f);
   registerUpdates(Update::UpdateValue, &TaskDynamicsImpl::updateValue);
+  setFunction(f);
   addOutputDependency(Output::Value, Update::UpdateValue);
 }
 


### PR DESCRIPTION
This PR makes sure that we have a registered update function corresponding to an input dependency.
The reasoning is to avoid a potentially misleading edge case when inheriting from a function and declaring updates.

```cpp
struct BaseFun : public Node
{
SET_UPDATES(BaseFun, Value)

BaseFun() {
  registerUpdates(Update::Value, &BaseFun::updateValue_);
  addInputDependency<BaseFun>(Update::Value, source, Output);
}
};
```

Currently it is possible to do

```cpp
struct DerivedFun : public BaseFun
{
SET_UPDATES(DerivedFun, Value)

DerivedFun() {
  addInputDependency<BaseFun>(Update::Value, source, Output);
}
};
```

Here `DerivedFun::Update::Value` (`=1`) is different from `BaseFun::Update::Value` (`=0`), and only `BaseFun::Update::Value` has a registered update function. Yet it is possible to declare an input dependency for  `DerivedFun::Update::Value` that does not have a corresponding update function. This will only fail at runtime if:
- The update is called => crash in release, false assert in debug
- The graph's Log is printed: there is no update corresponding to `DerivedFun::Update::Value`

Instead we should either decare
```cpp
struct DerivedFun : public BaseFun
{
SET_UPDATES(DerivedFun, Value)

DerivedFun() {
  registerUpdates(Update::Value, &DerivedFun::updateValue_); // explicitely register the update for DerivedFun::Update::Value
  addInputDependency<BaseFun>(Update::Value, source, Output);
}
};
```

or

```cpp
struct DerivedFun : public BaseFun
{
DerivedFun() {
  addInputDependency<BaseFun>(Update::Value, source, Output); // use update signal and function from parent class
}
};
```

This PR merely ensures that we cannot have a call to `addInputDependency` without a corresponding update function. It however forces the user to always call `registerUpdates` before `addInputDependency`, which in practice is already the case with only  very few exceptions.