### PR TITLE
Add problem description events to handle functions changes

### DIFF
--- a/include/tvm/ControlProblem.h
+++ b/include/tvm/ControlProblem.h
@@ -56,8 +56,8 @@ public:
                               const requirements::SolvingRequirements & req = {});
   template<constraint::Type T>
   TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements & req = {});
-  void add(TaskWithRequirementsPtr tr);
-  void remove(const TaskWithRequirements & tr);
+  void add(TaskWithRequirementsPtr tr, bool notify = true);
+  void remove(const TaskWithRequirements & tr, bool notify = true);
   const std::vector<TaskWithRequirementsPtr> & tasks() const;
 
   /** Number of tasks in the problem.*/

--- a/include/tvm/LinearizedControlProblem.h
+++ b/include/tvm/LinearizedControlProblem.h
@@ -51,7 +51,6 @@ public:
   const hint::internal::Substitutions & substitutions() const;
   void removeSubstitutionFor(const constraint::abstract::LinearConstraint & cstr);
 
-
   /** Access to the variables of the problem.
    *
    * \note These are all the variables irrespective of any substitutions as

--- a/include/tvm/LinearizedControlProblem.h
+++ b/include/tvm/LinearizedControlProblem.h
@@ -37,13 +37,20 @@ public:
                               const requirements::SolvingRequirements & req = {});
   template<constraint::Type T>
   TaskWithRequirementsPtr add(utils::LinearProtoTask<T> proto, const requirements::SolvingRequirements & req = {});
-  void add(TaskWithRequirementsPtr tr);
-  void remove(const TaskWithRequirements & tr);
+  void add(TaskWithRequirementsPtr tr, bool notify = true);
+  void remove(const TaskWithRequirements & tr, bool notify = true);
 
   void add(const hint::Substitution & s);
   void remove(const hint::Substitution & s);
+  /**
+   * If the task's function has changed (added variables, etc), then we need to recreate
+   * the associated constraint
+   * */
+  void updateConstraint(const TaskWithRequirements & task);
+
   const hint::internal::Substitutions & substitutions() const;
   void removeSubstitutionFor(const constraint::abstract::LinearConstraint & cstr);
+
 
   /** Access to the variables of the problem.
    *

--- a/include/tvm/constraint/internal/LinearizedTaskConstraint.h
+++ b/include/tvm/constraint/internal/LinearizedTaskConstraint.h
@@ -172,9 +172,13 @@ public:
   void updateU2Kin();
   /** Update the \p u vector, for dynamic, double-sided tasks.*/
   void updateU2Dyn();
+  /** Update the variables according to the function f_ variables */
+  void updateVariables();
 
   /** Return the jacobian matrix corresponding to \p x */
   tvm::internal::MatrixConstRefWithProperties jacobian(const Variable & x) const override;
+
+  const tvm::VariableVector & functionVariables() { return f_->variables(); }
 
 private:
   FunctionPtr f_;

--- a/include/tvm/graph/internal/Log.h
+++ b/include/tvm/graph/internal/Log.h
@@ -23,6 +23,7 @@ class CallGraph;
 
 namespace internal
 {
+
 class Inputs;
 
 /** lexicographic comparison of two objects given an ordered list of the

--- a/include/tvm/graph/internal/Log.h
+++ b/include/tvm/graph/internal/Log.h
@@ -24,6 +24,8 @@ class CallGraph;
 namespace internal
 {
 
+std::string TVM_DLLAPI clean(const std::string & name, bool replaceColons_ = true);
+
 class Inputs;
 
 /** lexicographic comparison of two objects given an ordered list of the

--- a/include/tvm/graph/internal/Logger.h
+++ b/include/tvm/graph/internal/Logger.h
@@ -62,6 +62,14 @@ public:
   template<typename U>
   void logCall(U * node, void (U::*fn)());
 
+  template<typename U>
+  std::string name(U * node)
+  {
+    std::uintptr_t val = reinterpret_cast<std::uintptr_t>(node);
+    auto & types = log_.types_[val];
+    return types.back().name();
+  }
+
 private:
   Logger() = default;
 

--- a/include/tvm/graph/internal/Logger.h
+++ b/include/tvm/graph/internal/Logger.h
@@ -4,6 +4,7 @@
 
 #include <tvm/api.h>
 
+#include <sstream>
 #include <tvm/graph/internal/Log.h>
 
 #include <algorithm>
@@ -62,12 +63,25 @@ public:
   template<typename U>
   void logCall(U * node, void (U::*fn)());
 
+  /**
+   * Return the name of a node previously registered with registerType
+   * If the node hasn't been registered, return its address.
+   */
   template<typename U>
-  std::string name(U * node)
+  std::string typeName(U * node)
   {
     std::uintptr_t val = reinterpret_cast<std::uintptr_t>(node);
-    auto & types = log_.types_[val];
-    return types.back().name();
+    if(log_.types_.count(val) > 0)
+    {
+      auto & types = log_.types_[val];
+      return clean(types.back().name());
+    }
+    else
+    {
+      std::stringstream ss;
+      ss << "UnregisteredNodeType(" << node << ")";
+      return ss.str();
+    }
   }
 
 private:

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -29,7 +29,7 @@ class UpdateVariableCallback : public internal::CallbackManager
 public:
   UpdateVariableCallback() : internal::CallbackManager() {}
 
-  void variableUpdated(VariablePtr v)
+  void variableUpdated(VariablePtr /* v */)
   {
     // std::cout << "UpdateVariableCallback: Calling callback for variable: " << v->name() << std::endl;
     internal::CallbackManager::run();

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -29,7 +29,7 @@ public:
 
   void variableAdded(VariablePtr v)
   {
-    std::cout << "AddVariableCallback: Calling callback for variable: " << v->name() << std::endl;
+    // std::cout << "AddVariableCallback: Calling callback for variable: " << v->name() << std::endl;
     internal::CallbackManager::run();
   }
 };

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -80,6 +80,8 @@ public:
    */
   virtual MatrixConstRefWithProperties jacobian(const Variable & x) const;
 
+  virtual MatrixConstRefWithProperties jacobian(const VariablePtr & x) const;
+
   /** Linearity w.r.t \p x*/
   bool linearIn(const Variable & x) const;
 
@@ -218,6 +220,11 @@ inline const Eigen::VectorXd & FirstOrderProvider::value() const { return value_
 
 inline MatrixConstRefWithProperties FirstOrderProvider::jacobian(const Variable & x) const
 { return jacobian_.at(&x, tvm::utils::internal::with_sub{}); }
+
+inline MatrixConstRefWithProperties FirstOrderProvider::jacobian(const VariablePtr & x) const
+{
+  return jacobian_.at(x.get(), tvm::utils::internal::with_sub{});
+}
 
 inline bool FirstOrderProvider::linearIn(const Variable & x) const
 { return linear_.at(&x, tvm::utils::internal::with_sub{}); }

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -222,9 +222,7 @@ inline MatrixConstRefWithProperties FirstOrderProvider::jacobian(const Variable 
 { return jacobian_.at(&x, tvm::utils::internal::with_sub{}); }
 
 inline MatrixConstRefWithProperties FirstOrderProvider::jacobian(const VariablePtr & x) const
-{
-  return jacobian_.at(x.get(), tvm::utils::internal::with_sub{});
-}
+{ return jacobian_.at(x.get(), tvm::utils::internal::with_sub{}); }
 
 inline bool FirstOrderProvider::linearIn(const Variable & x) const
 { return linear_.at(&x, tvm::utils::internal::with_sub{}); }

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -21,15 +21,17 @@
 namespace tvm::internal
 {
 
-class AddVariableCallback : public internal::CallbackManager
+// A callback class to be fired when variables are added or removed.
+// This is to ensure the function variables are correctly synced to the tasks of the problem when the
+// functions add or remove variables themselves (for example with contacts).
+class UpdateVariableCallback : public internal::CallbackManager
 {
 public:
-  /** Default weight = 1*/
-  AddVariableCallback() : internal::CallbackManager() {}
+  UpdateVariableCallback() : internal::CallbackManager() {}
 
-  void variableAdded(VariablePtr v)
+  void variableUpdated(VariablePtr v)
   {
-    // std::cout << "AddVariableCallback: Calling callback for variable: " << v->name() << std::endl;
+    // std::cout << "UpdateVariableCallback: Calling callback for variable: " << v->name() << std::endl;
     internal::CallbackManager::run();
   }
 };
@@ -86,7 +88,7 @@ public:
   /** Return the variables*/
   const VariableVector & variables() const;
 
-  AddVariableCallback & addVariableCallback() noexcept { return addVariableCallback_; }
+  UpdateVariableCallback & updateVariableCallback() noexcept { return updateVariableCallback_; }
 
 protected:
   struct slice_linear
@@ -202,7 +204,7 @@ protected:
   Space imageSpace_; // output space
   VariableVector variables_;
   utils::internal::MapWithVariableAsKey<bool, slice_linear> linear_;
-  AddVariableCallback addVariableCallback_;
+  UpdateVariableCallback updateVariableCallback_;
 };
 
 inline const Eigen::VectorXd & FirstOrderProvider::value() const { return value_; }

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "tvm/internal/CallbackManager.h"
+#include <iostream>
 #include <tvm/defs.h>
 
 #include <tvm/Variable.h>
@@ -18,6 +20,19 @@
 
 namespace tvm::internal
 {
+
+class AddVariableCallback : public internal::CallbackManager
+{
+public:
+  /** Default weight = 1*/
+  AddVariableCallback() : internal::CallbackManager() {}
+
+  void variableAdded(VariablePtr v)
+  {
+    std::cout << "AddVariableCallback: Calling callback for variable: " << v->name() << std::endl;
+    internal::CallbackManager::run();
+  }
+};
 
 /** Describes an entity that can provide a value and its jacobian
  *
@@ -70,6 +85,8 @@ public:
 
   /** Return the variables*/
   const VariableVector & variables() const;
+
+  AddVariableCallback & addVariableCallback() noexcept { return addVariableCallback_; }
 
 protected:
   struct slice_linear
@@ -185,6 +202,7 @@ protected:
   Space imageSpace_; // output space
   VariableVector variables_;
   utils::internal::MapWithVariableAsKey<bool, slice_linear> linear_;
+  AddVariableCallback addVariableCallback_;
 };
 
 inline const Eigen::VectorXd & FirstOrderProvider::value() const { return value_; }

--- a/include/tvm/internal/FirstOrderProvider.h
+++ b/include/tvm/internal/FirstOrderProvider.h
@@ -21,17 +21,24 @@
 namespace tvm::internal
 {
 
-// A callback class to be fired when variables are added or removed.
-// This is to ensure the function variables are correctly synced to the tasks of the problem when the
-// functions add or remove variables themselves (for example with contacts).
-class UpdateVariableCallback : public internal::CallbackManager
+// A callback class to be fired when the task changes (variables or size change)
+// This is to ensure the function is correctly synced to the tasks of the problem when the
+// functions add or remove variables themselves (for example with contacts), or resize their space.
+class UpdateTaskCallback : public internal::CallbackManager
 {
 public:
-  UpdateVariableCallback() : internal::CallbackManager() {}
+  UpdateTaskCallback() : internal::CallbackManager() {}
 
   void variableUpdated(VariablePtr /* v */)
   {
-    // std::cout << "UpdateVariableCallback: Calling callback for variable: " << v->name() << std::endl;
+    // std::cout << "UpdateTaskCallback: Calling callback for variable: " << v->name() << std::endl;
+    internal::CallbackManager::run();
+  }
+
+  void taskResized(tvm::Space & /*imageSpace*/)
+  {
+    // std::cout << "UpdateTaskCallback: Calling callback to resize to size: " << imageSpace.size()
+    //           << " rsize: " << imageSpace.rSize() << " and tsize: " << imageSpace.tSize() << std::endl;
     internal::CallbackManager::run();
   }
 };
@@ -88,7 +95,7 @@ public:
   /** Return the variables*/
   const VariableVector & variables() const;
 
-  UpdateVariableCallback & updateVariableCallback() noexcept { return updateVariableCallback_; }
+  UpdateTaskCallback & updateTaskCallback() noexcept { return updateTaskCallback_; }
 
 protected:
   struct slice_linear
@@ -204,7 +211,7 @@ protected:
   Space imageSpace_; // output space
   VariableVector variables_;
   utils::internal::MapWithVariableAsKey<bool, slice_linear> linear_;
-  UpdateVariableCallback updateVariableCallback_;
+  UpdateTaskCallback updateTaskCallback_;
 };
 
 inline const Eigen::VectorXd & FirstOrderProvider::value() const { return value_; }

--- a/include/tvm/internal/VariableCountingVector.h
+++ b/include/tvm/internal/VariableCountingVector.h
@@ -85,7 +85,7 @@ private:
 
   void update() const;
 
-  tvm::utils::internal::map<Variable *, std::pair<SpaceRangeCounting, size_t>> count_;
+  tvm::utils::internal::map<VariablePtr, std::pair<SpaceRangeCounting, size_t>> count_;
   bool split_;
   mutable bool upToDate_ = false;
   mutable VariableVector variables_;

--- a/include/tvm/scheme/abstract/ResolutionScheme.h
+++ b/include/tvm/scheme/abstract/ResolutionScheme.h
@@ -73,6 +73,7 @@ inline bool ResolutionScheme<Derived>::solve(Problem & problem) const
 {
   auto data = getComputationData(problem, *this);
   problem.update();
+  problem.addEventsToComputationData();
   updateComputationData(problem, data);
   bool b = derived().solve_(problem, data);
   data->setVariablesToSolution();

--- a/include/tvm/scheme/internal/Assignment.h
+++ b/include/tvm/scheme/internal/Assignment.h
@@ -130,14 +130,14 @@ private:
    * to variable \p x to the block of matrix described by \p M and \p range.
    * \p flip indicates a sign change if \p true.
    */
-  void addMatrixAssignment(Variable & x, MatrixFunction M, const Range & range, bool flip);
+  void addMatrixAssignment(VariablePtr x, MatrixFunction M, const Range & range, bool flip);
 
   /** Creates the assignments due to substituting the variable \p x by the
    * linear expression given by \p sub. The target is given by \p M.
    * \p flip indicates a sign change if \p true.
    */
   void addMatrixSubstitutionAssignments(const VariableVector & variables,
-                                        Variable & x,
+                                        VariablePtr x,
                                         MatrixFunction M,
                                         const function::BasicLinearFunction & sub,
                                         bool flip);
@@ -169,7 +169,7 @@ private:
    */
   void addVectorSubstitutionAssignments(const function::BasicLinearFunction & sub,
                                         VectorFunction v,
-                                        Variable & x,
+                                        VariablePtr x,
                                         bool flip);
 
   /** Create a vector assignment where the source is a constant. The target
@@ -194,7 +194,7 @@ private:
    * and \p range. The variable \p x is simply stored in the corresponding
    * \p MatrixAssignment.
    */
-  void addZeroAssignment(Variable & x, MatrixFunction M, const Range & range);
+  void addZeroAssignment(VariablePtr x, MatrixFunction M, const Range & range);
 
   /** Calls addAssignments(const VariableVector& variables, MatrixFunction M,
    * RHSFunction f1, VectorFunction v1, RHSFunction f2, VectorFunction v2,

--- a/include/tvm/scheme/internal/MatrixAssignment.h
+++ b/include/tvm/scheme/internal/MatrixAssignment.h
@@ -25,7 +25,7 @@ public:
   using MatrixFunction = MatrixRef (AssignmentTarget::*)(int, int) const;
 
   CompiledAssignmentWrapper<Eigen::MatrixXd> assignment;
-  Variable * x;
+  Variable * x = nullptr;
   Range colRange;
   MatrixFunction getTargetMatrix;
 

--- a/include/tvm/scheme/internal/MatrixAssignment.h
+++ b/include/tvm/scheme/internal/MatrixAssignment.h
@@ -25,7 +25,7 @@ public:
   using MatrixFunction = MatrixRef (AssignmentTarget::*)(int, int) const;
 
   CompiledAssignmentWrapper<Eigen::MatrixXd> assignment;
-  Variable * x = nullptr;
+  VariablePtr x;
   Range colRange;
   MatrixFunction getTargetMatrix;
 

--- a/include/tvm/scheme/internal/ProblemDefinitionEvent.h
+++ b/include/tvm/scheme/internal/ProblemDefinitionEvent.h
@@ -23,8 +23,7 @@ public:
     // From here this is a TaskWithRequirements
     WeightChange = 0,
     AnisotropicWeightChange,
-    TaskAddVariable,
-    TaskRemoveVariable,
+    TaskUpdateVariables,
     TaskAddition,
     TaskRemoval,
     // From here this is a hint::Substitution

--- a/include/tvm/scheme/internal/ProblemDefinitionEvent.h
+++ b/include/tvm/scheme/internal/ProblemDefinitionEvent.h
@@ -23,7 +23,7 @@ public:
     // From here this is a TaskWithRequirements
     WeightChange = 0,
     AnisotropicWeightChange,
-    TaskUpdateVariables,
+    TaskUpdate,
     TaskAddition,
     TaskRemoval,
     // From here this is a hint::Substitution

--- a/include/tvm/scheme/internal/ProblemDefinitionEvent.h
+++ b/include/tvm/scheme/internal/ProblemDefinitionEvent.h
@@ -20,10 +20,14 @@ class ProblemDefinitionEvent
 public:
   enum class Type
   {
-    WeightChange,
+    // From here this is a TaskWithRequirements
+    WeightChange = 0,
     AnisotropicWeightChange,
+    TaskAddVariable,
+    TaskRemoveVariable,
     TaskAddition,
     TaskRemoval,
+    // From here this is a hint::Substitution
     SubstitutionAddition,
     SubstitutionRemoval
   };

--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -138,27 +138,28 @@ inline void SolverEvents::removeObjective(LinearConstraintPtr o)
 
 inline void SolverEvents::addVariable(VariablePtr v)
 {
-  std::cout << "SolverEvents::addVariable called" << std::endl;
-  if(!addIfPair(v, addedVariables_, removedVariables_)) {
-    std::cout << "SolverEvents:: addedVariables: " << std::endl;
-    for(const auto & var : addedVariables_)
-    {
-      std::cout << "var: " << var->name() << std::endl;
-    }
+  // std::cout << "SolverEvents::addVariable called" << std::endl;
+  if(!addIfPair(v, addedVariables_, removedVariables_))
+  {
+    // std::cout << "SolverEvents:: addedVariables: " << std::endl;
+    // for(const auto & var : addedVariables_)
+    // {
+    //   std::cout << "var: " << var->name() << std::endl;
+    // }
     hiddenVariableChange_ = true;
   }
 }
 
 inline void SolverEvents::removeVariable(VariablePtr v)
 {
-  std::cout << "SolverEvents::removeVariable called" << std::endl;
+  // std::cout << "SolverEvents::removeVariable called" << std::endl;
   if(!addIfPair(v, removedVariables_, addedVariables_))
   {
-    std::cout << "SolverEvents:: removedVariables: " << std::endl;
-    for(const auto & var : removedVariables_)
-    {
-      std::cout << "var: " << var->name() << std::endl;
-    }
+    // std::cout << "SolverEvents:: removedVariables: " << std::endl;
+    // for(const auto & var : removedVariables_)
+    // {
+    //   std::cout << "var: " << var->name() << std::endl;
+    // }
     hiddenVariableChange_ = true;
   }
 }

--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <tvm/api.h>
 #include <tvm/defs.h>
 
@@ -137,6 +138,7 @@ inline void SolverEvents::removeObjective(LinearConstraintPtr o)
 
 inline void SolverEvents::addVariable(VariablePtr v)
 {
+  std::cout << "SolverEvents::addVariable " << v->name() << std::endl;
   if(!addIfPair(v, addedVariables_, removedVariables_))
     hiddenVariableChange_ = true;
 }

--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -138,7 +138,6 @@ inline void SolverEvents::removeObjective(LinearConstraintPtr o)
 
 inline void SolverEvents::addVariable(VariablePtr v)
 {
-  std::cout << "SolverEvents::addVariable " << v->name() << std::endl;
   if(!addIfPair(v, addedVariables_, removedVariables_))
     hiddenVariableChange_ = true;
 }
@@ -155,7 +154,13 @@ inline bool SolverEvents::addIfPair(T & c, std::vector<T> & addVec, std::vector<
   auto it = std::find(removeVec.begin(), removeVec.end(), c);
   bool notFound = it == removeVec.end();
   if(notFound)
-    addVec.push_back(c);
+  {
+    // Ensure that we add the variable only once
+    if(std::find(addVec.begin(), addVec.end(), c) == addVec.end())
+    {
+      addVec.push_back(c);
+    }
+  }
   else
     removeVec.erase(it);
   return notFound;

--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -171,11 +171,7 @@ inline bool SolverEvents::addIfPair(T & c, std::vector<T> & addVec, std::vector<
   bool notFound = it == removeVec.end();
   if(notFound)
   {
-    // Ensure that we add the variable only once
-    if(std::find(addVec.begin(), addVec.end(), c) == addVec.end())
-    {
-      addVec.push_back(c);
-    }
+    addVec.push_back(c);
   }
   else
     removeVec.erase(it);

--- a/include/tvm/solver/internal/SolverEvents.h
+++ b/include/tvm/solver/internal/SolverEvents.h
@@ -138,14 +138,29 @@ inline void SolverEvents::removeObjective(LinearConstraintPtr o)
 
 inline void SolverEvents::addVariable(VariablePtr v)
 {
-  if(!addIfPair(v, addedVariables_, removedVariables_))
+  std::cout << "SolverEvents::addVariable called" << std::endl;
+  if(!addIfPair(v, addedVariables_, removedVariables_)) {
+    std::cout << "SolverEvents:: addedVariables: " << std::endl;
+    for(const auto & var : addedVariables_)
+    {
+      std::cout << "var: " << var->name() << std::endl;
+    }
     hiddenVariableChange_ = true;
+  }
 }
 
 inline void SolverEvents::removeVariable(VariablePtr v)
 {
+  std::cout << "SolverEvents::removeVariable called" << std::endl;
   if(!addIfPair(v, removedVariables_, addedVariables_))
+  {
+    std::cout << "SolverEvents:: removedVariables: " << std::endl;
+    for(const auto & var : removedVariables_)
+    {
+      std::cout << "var: " << var->name() << std::endl;
+    }
     hiddenVariableChange_ = true;
+  }
 }
 
 template<typename T>

--- a/include/tvm/utils/internal/map.h
+++ b/include/tvm/utils/internal/map.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <map>
+#include <tvm/defs.h>
 #include <unordered_map>
 
 namespace tvm::utils::internal
@@ -14,8 +15,21 @@ class IdLess
 public:
   using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
   constexpr bool operator()(const T * const lhs, const T * const rhs) const
-  { return lhs && rhs && lhs->id() < rhs->id(); }
-  constexpr bool operator()(const T & lhs, const T & rhs) const { return lhs.id() < rhs.id(); }
+  {
+    return lhs && rhs && lhs->id() < rhs->id();
+  }
+
+  constexpr bool operator()(const T & lhs, const T & rhs) const
+  {
+    if constexpr(std::is_same_v<T, VariablePtr>)
+    {
+      return lhs->id() < rhs->id();
+    }
+    else
+    {
+      return lhs.id() < rhs.id();
+    }
+  }
 };
 
 template<typename ObjWithId>
@@ -35,6 +49,7 @@ public:
   using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
   std::size_t operator()(const T * key) const { return key ? std::hash<int>()(key->id()) : std::hash<int>()(-1); }
   std::size_t operator()(const T & key) const { return std::hash<int>()(key.id()); }
+  std::size_t operator()(const std::shared_ptr<T> & key) const { return this->operator()(key->get()); }
 };
 
 template<typename KeyWithId, typename Value, typename Allocator = std::allocator<std::pair<const KeyWithId, Value>>>

--- a/include/tvm/utils/internal/map.h
+++ b/include/tvm/utils/internal/map.h
@@ -15,9 +15,7 @@ class IdLess
 public:
   using T = typename std::decay<typename std::remove_pointer<ObjWithId>::type>::type;
   constexpr bool operator()(const T * const lhs, const T * const rhs) const
-  {
-    return lhs && rhs && lhs->id() < rhs->id();
-  }
+  { return lhs && rhs && lhs->id() < rhs->id(); }
 
   constexpr bool operator()(const T & lhs, const T & rhs) const
   {

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -107,10 +107,9 @@ void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
   // Allow a task's function to change its variables online
   auto updateVars = [this, t]() {
     // std::cout << "notify addVariable" << std::endl;
-    this->notify({EventType::TaskUpdateVariables, *t});
+    this->notify({EventType::TaskUpdate, *t});
   };
-  tokens.emplace_back(tr->task.function()->updateVariableCallback().registerCallback(updateVars));
-  // TODO add also a callback for jacobian resize (in case of plane constraints)
+  tokens.emplace_back(tr->task.function()->updateTaskCallback().registerCallback(updateVars));
 
   callbackTokens_[t] = std::move(tokens);
 }

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -16,15 +16,18 @@ TaskWithRequirementsPtr ControlProblem::add(const Task & task, const requirement
   return tr;
 }
 
-void ControlProblem::add(TaskWithRequirementsPtr tr)
+void ControlProblem::add(TaskWithRequirementsPtr tr, bool notify)
 {
   tr_.push_back(tr);
   addCallBackToTask(tr);
-  notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskAddition, *tr));
+  if(notify)
+  {
+    this->notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskAddition, *tr));
+  }
   finalized_ = false;
 }
 
-void ControlProblem::remove(const TaskWithRequirements & tr)
+void ControlProblem::remove(const TaskWithRequirements & tr, bool notify)
 {
   auto it = std::find_if(tr_.begin(), tr_.end(), [&tr](const TaskWithRequirementsPtr & p) { return p.get() == &tr; });
   if(it == tr_.end())
@@ -32,7 +35,10 @@ void ControlProblem::remove(const TaskWithRequirements & tr)
     return;
   }
   tr_.erase(it);
-  notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
+  if(notify)
+  {
+    this->notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
+  }
   callbackTokens_.erase(&tr);
   finalized_ = false;
 }

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -22,7 +22,8 @@ void ControlProblem::add(TaskWithRequirementsPtr tr, bool notify)
   addCallBackToTask(tr);
   if(notify)
   {
-    this->notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskAddition, *tr));
+    this->notify(
+        scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskAddition, *tr));
   }
   finalized_ = false;
 }
@@ -37,7 +38,8 @@ void ControlProblem::remove(const TaskWithRequirements & tr, bool notify)
   tr_.erase(it);
   if(notify)
   {
-    this->notify(scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
+    this->notify(
+        scheme::internal::ProblemDefinitionEvent(scheme::internal::ProblemDefinitionEvent::Type::TaskRemoval, tr));
   }
   callbackTokens_.erase(&tr);
   finalized_ = false;
@@ -80,10 +82,10 @@ void ControlProblem::addEventsToComputationData()
 {
   while(!eventsToProcess_.empty())
   {
-    const auto & e = eventsToProcess_.back(); // Remove the front element
+    const auto & e = eventsToProcess_.front(); // Remove the front element
     for(auto & c : computationData_)
     {
-      std::cout << "adding event to computation data" << std::endl;
+      // std::cout << "adding event to computation data" << std::endl;
       c.second->addEvent(e);
     }
     eventsToProcess_.pop();

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -82,12 +82,13 @@ void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
   auto l2 = [this, t]() { this->notify({EventType::AnisotropicWeightChange, *t}); };
   tokens.emplace_back(tr->requirements.anisotropicWeight().registerCallback(l2));
 
-  // Allow a FirstOrderProvider (task) to change its variables online
-  auto addVariable = [this, t]() {
+  // Allow a task's function to change its variables online
+  auto updateVars = [this, t]() {
     // std::cout << "notify addVariable" << std::endl;
-    this->notify({EventType::TaskAddVariable, *t});
+    this->notify({EventType::TaskUpdateVariables, *t});
   };
-  tokens.emplace_back(tr->task.function()->addVariableCallback().registerCallback(addVariable));
+  tokens.emplace_back(tr->task.function()->addVariableCallback().registerCallback(updateVars));
+  // TODO add also a callback for jacobian resize (in case of plane constraints)
 
   callbackTokens_[t] = std::move(tokens);
 }

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -87,7 +87,7 @@ void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
     // std::cout << "notify addVariable" << std::endl;
     this->notify({EventType::TaskUpdateVariables, *t});
   };
-  tokens.emplace_back(tr->task.function()->addVariableCallback().registerCallback(updateVars));
+  tokens.emplace_back(tr->task.function()->updateVariableCallback().registerCallback(updateVars));
   // TODO add also a callback for jacobian resize (in case of plane constraints)
 
   callbackTokens_[t] = std::move(tokens);

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -82,6 +82,13 @@ void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
   auto l2 = [this, t]() { this->notify({EventType::AnisotropicWeightChange, *t}); };
   tokens.emplace_back(tr->requirements.anisotropicWeight().registerCallback(l2));
 
+  // Allow a FirstOrderProvider (task) to change its variables online
+  auto addVariable = [this, t]() {
+    std::cout << "notify addVariable" << std::endl;
+    this->notify({EventType::TaskAddVariable, *t});
+  };
+  tokens.emplace_back(tr->task.function()->addVariableCallback().registerCallback(addVariable));
+
   callbackTokens_[t] = std::move(tokens);
 }
 

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -84,7 +84,7 @@ void ControlProblem::addCallBackToTask(TaskWithRequirementsPtr tr)
 
   // Allow a FirstOrderProvider (task) to change its variables online
   auto addVariable = [this, t]() {
-    std::cout << "notify addVariable" << std::endl;
+    // std::cout << "notify addVariable" << std::endl;
     this->notify({EventType::TaskAddVariable, *t});
   };
   tokens.emplace_back(tr->task.function()->addVariableCallback().registerCallback(addVariable));

--- a/src/ControlProblem.cpp
+++ b/src/ControlProblem.cpp
@@ -70,9 +70,23 @@ void ControlProblem::needFinalize() { finalized_ = false; }
 
 void ControlProblem::notify(const scheme::internal::ProblemDefinitionEvent & e)
 {
-  for(auto & c : computationData_)
+  // store events in the order they are received
+  // these events need to be added to the computationData_ event queue for each scheme later
+  // this addiditon is delayed to ensure that the computationData has been created before processing events
+  eventsToProcess_.push(e);
+}
+
+void ControlProblem::addEventsToComputationData()
+{
+  while(!eventsToProcess_.empty())
   {
-    c.second->addEvent(e);
+    const auto & e = eventsToProcess_.back(); // Remove the front element
+    for(auto & c : computationData_)
+    {
+      std::cout << "adding event to computation data" << std::endl;
+      c.second->addEvent(e);
+    }
+    eventsToProcess_.pop();
   }
 }
 

--- a/src/LinearizedControlProblem.cpp
+++ b/src/LinearizedControlProblem.cpp
@@ -88,31 +88,31 @@ void LinearizedControlProblem::remove(const hint::Substitution & s)
 
 void LinearizedControlProblem::updateConstraint(const TaskWithRequirements & task)
 {
-  std::cout << "LinearizedControlProblem::updateConstraint" << std::endl;
+  // std::cout << "LinearizedControlProblem::updateConstraint" << std::endl;
   // find the task
-  auto twr_it = std::find_if(tr_.begin(), tr_.end(),
-      [&](const auto & t) { return(t.get() == &task); }
-      );
+  auto twr_it = std::find_if(tr_.begin(), tr_.end(), [&](const auto & t) { return (t.get() == &task); });
   if(twr_it != tr_.end())
   {
-    std::cout << "task found, recreating the linearized task constraint" << std::endl;
+    // std::cout << "task found, recreating the linearized task constraint" << std::endl;
     auto twr = *twr_it;
 
     auto cstr = constraints_.find(&task);
-    if(cstr != constraints_.end()) std::cout << "constraint before remove: " << &(*cstr) << std::endl;
+    // if(cstr != constraints_.end())
+    //   std::cout << "constraint before remove: " << &(*cstr) << std::endl;
 
     remove(*twr, false);
 
     cstr = constraints_.find(&task);
-    if(cstr != constraints_.end()) std::cout << "should not be here" << std::endl;
+    // if(cstr != constraints_.end())
+    //   std::cout << "should not be here" << std::endl;
 
     add(twr, false);
 
     cstr = constraints_.find(&task);
-    if(cstr != constraints_.end()) std::cout << "constraint after remove: " << &(*cstr) << std::endl;
+    // if(cstr != constraints_.end())
+    //   std::cout << "constraint after remove: " << &(*cstr) << std::endl;
   }
 }
-
 
 const hint::internal::Substitutions & LinearizedControlProblem::substitutions() const { return substitutions_; }
 

--- a/src/LinearizedControlProblem.cpp
+++ b/src/LinearizedControlProblem.cpp
@@ -1,5 +1,6 @@
 /** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
+#include <iostream>
 #include <tvm/LinearizedControlProblem.h>
 
 #include <tvm/constraint/internal/LinearizedTaskConstraint.h>
@@ -23,9 +24,9 @@ TaskWithRequirementsPtr LinearizedControlProblem::add(const Task & task, const r
   return tr;
 }
 
-void LinearizedControlProblem::add(TaskWithRequirementsPtr tr)
+void LinearizedControlProblem::add(TaskWithRequirementsPtr tr, bool notify)
 {
-  ControlProblem::add(tr);
+  ControlProblem::add(tr, notify);
 
   // FIXME A lot of work can be done here based on the properties of the task's jacobian.
   // In particular, we could detect bounds, pairs of tasks forming a double-sided constraints...
@@ -57,12 +58,13 @@ void LinearizedControlProblem::add(TaskWithRequirementsPtr tr)
   }
 }
 
-void LinearizedControlProblem::remove(const TaskWithRequirements & tr)
+void LinearizedControlProblem::remove(const TaskWithRequirements & tr, bool notify)
 {
-  ControlProblem::remove(tr);
+  ControlProblem::remove(tr, notify);
   auto it = constraints_.find(&tr);
   if(it == constraints_.end())
   {
+    std::cout << "LinearizedControlProblem constraint not found so not removed" << std::endl;
     return;
   }
   removeSubstitutionFor(*it->second.constraint);
@@ -83,6 +85,34 @@ void LinearizedControlProblem::remove(const hint::Substitution & s)
   notify({scheme::internal::ProblemDefinitionEvent::Type::SubstitutionRemoval, &s});
   needFinalize();
 }
+
+void LinearizedControlProblem::updateConstraint(const TaskWithRequirements & task)
+{
+  std::cout << "LinearizedControlProblem::updateConstraint" << std::endl;
+  // find the task
+  auto twr_it = std::find_if(tr_.begin(), tr_.end(),
+      [&](const auto & t) { return(t.get() == &task); }
+      );
+  if(twr_it != tr_.end())
+  {
+    std::cout << "task found, recreating the linearized task constraint" << std::endl;
+    auto twr = *twr_it;
+
+    auto cstr = constraints_.find(&task);
+    if(cstr != constraints_.end()) std::cout << "constraint before remove: " << &(*cstr) << std::endl;
+
+    remove(*twr, false);
+
+    cstr = constraints_.find(&task);
+    if(cstr != constraints_.end()) std::cout << "should not be here" << std::endl;
+
+    add(twr, false);
+
+    cstr = constraints_.find(&task);
+    if(cstr != constraints_.end()) std::cout << "constraint after remove: " << &(*cstr) << std::endl;
+  }
+}
+
 
 const hint::internal::Substitutions & LinearizedControlProblem::substitutions() const { return substitutions_; }
 
@@ -145,7 +175,10 @@ std::optional<std::reference_wrapper<const LinearConstraintWithRequirements>>
 {
   auto it = constraints_.find(&t);
   if(it != constraints_.end())
+  {
+    std::cout << "constraintWithRequirementsNoThrow constraint found do not recreate: " << &(*it) << std::endl;
     return it->second;
+  }
   else
     return {};
 }

--- a/src/VariableVector.cpp
+++ b/src/VariableVector.cpp
@@ -1,5 +1,6 @@
 /** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
+#include <iostream>
 #include <tvm/VariableVector.h>
 
 #include <tvm/Variable.h>
@@ -165,7 +166,10 @@ void VariableVector::setZero()
 
 bool VariableVector::contains(const Variable & v) const
 {
-  auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) { return it->contains(v); });
+  auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) {
+    std::cout << "VariableVector::constains: " << it->name() << std::endl;
+    return it->contains(v);
+  });
   return it != variables_.end();
 }
 

--- a/src/VariableVector.cpp
+++ b/src/VariableVector.cpp
@@ -167,7 +167,7 @@ void VariableVector::setZero()
 bool VariableVector::contains(const Variable & v) const
 {
   auto it = find_if(variables_.begin(), variables_.end(), [&v](const VariablePtr & it) {
-    std::cout << "VariableVector::constains: " << it->name() << std::endl;
+    // std::cout << "VariableVector::constains: " << it->name() << std::endl;
     return it->contains(v);
   });
   return it != variables_.end();

--- a/src/constraint/LinearizedTaskConstraint.cpp
+++ b/src/constraint/LinearizedTaskConstraint.cpp
@@ -147,13 +147,16 @@ void LinearizedTaskConstraint::updateU2Dyn() { uRef() = td2_->value() - f_->norm
 void LinearizedTaskConstraint::updateVariables()
 {
   // Update the variables of this first order provider from the underlying function variables
+
+  // Making copies before modifying the variable vectors
   const auto functionVariables = f_->variables();
+  const auto taskVariables = this->variables();
   switch(td_->order())
   {
     case task_dynamics::Order::Zero: {
 
       // removing the variables if they are not present anymore in the function
-      for(auto & taskVar : this->variables())
+      for(auto & taskVar : taskVariables)
       {
         if(!functionVariables.contains(*taskVar.get()))
         {
@@ -167,7 +170,7 @@ void LinearizedTaskConstraint::updateVariables()
         if(!f_->linearIn(*functionVar))
           throw std::runtime_error("The function is not linear in " + functionVar->name());
 
-        if(!this->variables().contains(*functionVar.get()))
+        if(!taskVariables.contains(*functionVar.get()))
         {
           addVariable(functionVar, true);
         }
@@ -177,7 +180,7 @@ void LinearizedTaskConstraint::updateVariables()
     case task_dynamics::Order::One: {
 
       // removing the variables if they are not present anymore in the function
-      for(auto & taskVar : this->variables())
+      for(auto & taskVar : taskVariables)
       {
         if(!functionVariables.contains(*taskVar->primitive<1>().get()))
         {
@@ -188,7 +191,7 @@ void LinearizedTaskConstraint::updateVariables()
       // adding the variables if they are not already present here but are in the function
       for(auto & functionVar : functionVariables)
       {
-        if(!this->variables().contains(*dot(functionVar).get()))
+        if(!taskVariables.contains(*dot(functionVar).get()))
         {
           addVariable(dot(functionVar), true);
         }
@@ -198,7 +201,7 @@ void LinearizedTaskConstraint::updateVariables()
     case task_dynamics::Order::Two: {
 
       // removing the variables if they are not present anymore in the function
-      for(auto & taskVar : this->variables())
+      for(auto & taskVar : taskVariables)
       {
         if(!functionVariables.contains(*taskVar->primitive<2>().get()))
         {
@@ -209,7 +212,7 @@ void LinearizedTaskConstraint::updateVariables()
       // adding the variables if they are not already present here but are in the function
       for(auto & functionVar : functionVariables)
       {
-        if(!this->variables().contains(*dot(functionVar, 2).get()))
+        if(!taskVariables.contains(*dot(functionVar, 2).get()))
         {
           addVariable(dot(functionVar, 2), true);
         }

--- a/src/graph/Log.cpp
+++ b/src/graph/Log.cpp
@@ -13,9 +13,8 @@
 #  include <memory>
 #endif
 
-namespace
+namespace tvm::graph::internal
 {
-using namespace tvm::graph::internal;
 
 /** Replace the spaces in name by underscores*/
 std::string replaceSpaces(std::string name)
@@ -115,7 +114,7 @@ std::string demangle(const std::string & name, bool removeNamespace_ = false)
 /** Return a clean name from typeid by demangling it, replacing spaces and
  * optional replacing colons.
  */
-std::string clean(const std::string & name, bool replaceColons_ = true)
+std::string clean(const std::string & name, bool replaceColons_)
 {
   if(replaceColons_)
   {
@@ -248,7 +247,7 @@ const Log::Output & findOutput(const std::vector<Log::Output> & v, const Log::In
   throw std::runtime_error("Output not found");
 }
 
-} // anonymous namespace
+} // namespace tvm::graph::internal
 
 namespace tvm
 {

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -45,7 +45,7 @@ void FirstOrderProvider::addVariable(VariablePtr v, bool linear)
     linear_[v.get()] = linear;
 
     addVariable_(v);
-    updateVariableCallback_.variableUpdated(v);
+    updateTaskCallback_.variableUpdated(v);
   }
 }
 
@@ -63,7 +63,7 @@ void FirstOrderProvider::removeVariable(VariablePtr v)
   jacobian_.erase(v.get());
   linear_.erase(v.get());
   removeVariable_(v);
-  updateVariableCallback_.variableUpdated(v);
+  updateTaskCallback_.variableUpdated(v);
 }
 
 void FirstOrderProvider::addVariable_(VariablePtr)
@@ -94,6 +94,7 @@ void FirstOrderProvider::resize(int m)
   assert(imageSpace_.isEuclidean());
   imageSpace_ = Space(m);
   resizeCache();
+  updateTaskCallback_.taskResized(imageSpace_);
 }
 
 } // namespace internal

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -45,8 +45,7 @@ void FirstOrderProvider::addVariable(VariablePtr v, bool linear)
     linear_[v.get()] = linear;
 
     addVariable_(v);
-    // std::cout << "variable added: " << v->name() << ", linear: " << linear << std::endl;
-    addVariableCallback_.variableAdded(v);
+    updateVariableCallback_.variableUpdated(v);
   }
 }
 
@@ -64,6 +63,7 @@ void FirstOrderProvider::removeVariable(VariablePtr v)
   jacobian_.erase(v.get());
   linear_.erase(v.get());
   removeVariable_(v);
+  updateVariableCallback_.variableUpdated(v);
 }
 
 void FirstOrderProvider::addVariable_(VariablePtr)

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -45,7 +45,7 @@ void FirstOrderProvider::addVariable(VariablePtr v, bool linear)
     linear_[v.get()] = linear;
 
     addVariable_(v);
-    std::cout << "variable added: " << v->name() << ", linear: " << linear << std::endl;
+    // std::cout << "variable added: " << v->name() << ", linear: " << linear << std::endl;
     addVariableCallback_.variableAdded(v);
   }
 }

--- a/src/internal/FirstOrderProvider.cpp
+++ b/src/internal/FirstOrderProvider.cpp
@@ -45,6 +45,8 @@ void FirstOrderProvider::addVariable(VariablePtr v, bool linear)
     linear_[v.get()] = linear;
 
     addVariable_(v);
+    std::cout << "variable added: " << v->name() << ", linear: " << linear << std::endl;
+    addVariableCallback_.variableAdded(v);
   }
 }
 

--- a/src/internal/VariableCountingVector.cpp
+++ b/src/internal/VariableCountingVector.cpp
@@ -1,5 +1,6 @@
 /** Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
+#include <iostream>
 #include <tvm/internal/VariableCountingVector.h>
 
 #include <tvm/Variable.h>
@@ -30,6 +31,7 @@ void VariableCountingVector::add(const VariableVector & v)
 
 bool VariableCountingVector::remove(const Variable & v)
 {
+  std::cout << "VariableCountingVector removeVariable: " << v.name() << std::endl;
   VariablePtr s = v.superVariable();
   const Space & start = v.spaceShift();
   const Space & dim = v.space();
@@ -37,6 +39,7 @@ bool VariableCountingVector::remove(const Variable & v)
   bool change = counterPair.first.remove(start, dim);
   if(change)
   {
+    std::cout << "removed " << v.name() << std::endl;
     if(counterPair.first.empty())
     {
       counterPair.second = 0;

--- a/src/internal/VariableCountingVector.cpp
+++ b/src/internal/VariableCountingVector.cpp
@@ -14,7 +14,7 @@ bool VariableCountingVector::add(VariablePtr v)
   VariablePtr s = v->superVariable();
   const Space & start = v->spaceShift();
   const Space & dim = v->space();
-  auto & counterPair = count_.insert({s.get(), {SpaceRangeCounting{}, 0}}).first->second;
+  auto & counterPair = count_.insert({s, {SpaceRangeCounting{}, 0}}).first->second;
   // bool change = counterPair.first.add(v->subvariableRange());
   bool change = counterPair.first.add(start, dim);
   if(change)
@@ -35,7 +35,7 @@ bool VariableCountingVector::remove(const Variable & v)
   VariablePtr s = v.superVariable();
   const Space & start = v.spaceShift();
   const Space & dim = v.space();
-  auto & counterPair = count_.at(s.get());
+  auto & counterPair = count_.at(s);
   bool change = counterPair.first.remove(start, dim);
   if(change)
   {
@@ -122,7 +122,7 @@ void VariableCountingVector::update() const
                || (!v->isBasePrimitive() && tRanges[0].dim == v->size())))
         {
           assert(mRanges[0].start == 0);
-          variables_.add(v->shared_from_this());
+          variables_.add(v);
           simple_.push_back(simple);
         }
         else
@@ -132,7 +132,8 @@ void VariableCountingVector::update() const
             const auto & mr = mRanges[i];
             const auto & rr = rRanges[i];
             const auto & tr = tRanges[i];
-            variables_.add(v->subvariable(Space(mr.dim, rr.dim, tr.dim), Space(mr.start, rr.start, tr.start)));
+            auto sub = v->subvariable(Space(mr.dim, rr.dim, tr.dim), Space(mr.start, rr.start, tr.start));
+            variables_.add(sub);
             simple_.push_back(simple);
           }
         }

--- a/src/scheme/Assignment.cpp
+++ b/src/scheme/Assignment.cpp
@@ -418,7 +418,7 @@ void Assignment::processRequirements()
 
 void Assignment::addMatrixAssignment(Variable & x, MatrixFunction M, const Range & range, bool flip)
 {
-  std::cout << "Assignment::addMatrixAssignment for var " << &x << ", " << x.name() << std::endl;
+  // std::cout << "Assignment::addMatrixAssignment for var " << &x << ", " << x.name() << std::endl;
   MatrixConstRef from = source_->jacobian(x);
   const MatrixRef & to = (target_.*M)(range.start, range.dim);
   auto w = createAssignment<Eigen::MatrixXd, AssignType::COPY>(from, to, flip);

--- a/src/scheme/Assignment.cpp
+++ b/src/scheme/Assignment.cpp
@@ -80,6 +80,11 @@ void Assignment::onUpdatedTarget()
 
 void Assignment::onUpdatedMapping(const VariableVector & newVar, bool updateMatrixTarget)
 {
+  // std::cout << "Assignment::onUpdatedMapping newVar vector: " << std::endl;
+  // for(const auto &var : newVar)
+  // {
+  //   std::cout << "\t- newVar: " << var.get() << ", " << var->name() << std::endl;
+  // }
   for(auto & a : matrixAssignments_)
     a.updateMapping(newVar, target_, updateMatrixTarget);
   for(auto & a : matrixSubstitutionAssignments_)
@@ -413,6 +418,7 @@ void Assignment::processRequirements()
 
 void Assignment::addMatrixAssignment(Variable & x, MatrixFunction M, const Range & range, bool flip)
 {
+  std::cout << "Assignment::addMatrixAssignment for var " << &x << ", " << x.name() << std::endl;
   MatrixConstRef from = source_->jacobian(x);
   const MatrixRef & to = (target_.*M)(range.start, range.dim);
   auto w = createAssignment<Eigen::MatrixXd, AssignType::COPY>(from, to, flip);

--- a/src/scheme/Assignment.cpp
+++ b/src/scheme/Assignment.cpp
@@ -416,23 +416,22 @@ void Assignment::processRequirements()
   }
 }
 
-void Assignment::addMatrixAssignment(Variable & x, MatrixFunction M, const Range & range, bool flip)
+void Assignment::addMatrixAssignment(VariablePtr x, MatrixFunction M, const Range & range, bool flip)
 {
-  // std::cout << "Assignment::addMatrixAssignment for var " << &x << ", " << x.name() << std::endl;
-  MatrixConstRef from = source_->jacobian(x);
+  MatrixConstRef from = source_->jacobian(*x);
   const MatrixRef & to = (target_.*M)(range.start, range.dim);
   auto w = createAssignment<Eigen::MatrixXd, AssignType::COPY>(from, to, flip);
 
-  matrixAssignments_.push_back({w, &x, range, M});
+  matrixAssignments_.push_back({w, x, range, M});
 }
 
 void Assignment::addMatrixSubstitutionAssignments(const VariableVector & variables,
-                                                  Variable & x,
+                                                  VariablePtr x,
                                                   MatrixFunction M,
                                                   const function::BasicLinearFunction & sub,
                                                   bool flip)
 {
-  auto J = source_->jacobian(x);
+  auto J = source_->jacobian(*x);
   for(const auto & xi : sub.variables())
   {
     Range range = xi->getMappingIn(variables);
@@ -465,13 +464,13 @@ void Assignment::addMatrixSubstitutionAssignments(const VariableVector & variabl
     // - use CUSTOM multiplications
     // - in particular use the nullspace custom multiplication for variable z
     // when appropriate.
-    matrixSubstitutionAssignments_.push_back({w, xi.get(), range, M});
+    matrixSubstitutionAssignments_.push_back({w, xi, range, M});
   }
 }
 
 void Assignment::addVectorSubstitutionAssignments(const function::BasicLinearFunction & sub,
                                                   VectorFunction v,
-                                                  Variable & x,
+                                                  VariablePtr x,
                                                   bool flip)
 {
   bool useSource = !sub.b().properties().isConstant() || !sub.b().properties().isZero();
@@ -486,7 +485,7 @@ void Assignment::addVectorSubstitutionAssignments(const function::BasicLinearFun
 
     const VectorRef & to = (target_.*v)();
     const VectorConstRef & from = sub.b();
-    auto A = source_->jacobian(x);
+    auto A = source_->jacobian(*x);
 
     CompiledAssignmentWrapper<Eigen::VectorXd> w;
     if(A.properties().isIdentity())
@@ -514,12 +513,12 @@ void Assignment::addVectorSubstitutionAssignments(const function::BasicLinearFun
   }
 }
 
-void Assignment::addZeroAssignment(Variable & x, MatrixFunction M, const Range & range)
+void Assignment::addZeroAssignment(VariablePtr x, MatrixFunction M, const Range & range)
 {
   const MatrixRef & to = (target_.*M)(range.start, range.dim);
   auto w = CompiledAssignmentWrapper<Eigen::MatrixXd>::make<COPY, NONE, IDENTITY, ZERO>(to);
 
-  matrixAssignments_.push_back({w, &x, range, M});
+  matrixAssignments_.push_back({w, x, range, M});
 }
 
 void Assignment::addAssignments(const VariableVector & variables,
@@ -576,7 +575,7 @@ void Assignment::addAssignments(const VariableVector & variables,
     if(!xc.contains(*x))
     {
       Range cols = x->getMappingIn(variables);
-      addZeroAssignment(*x, M, cols);
+      addZeroAssignment(x, M, cols);
     }
   }
 
@@ -591,15 +590,15 @@ void Assignment::addAssignments(const VariableVector & variables,
     if(i >= 0) // x needs to be substituted
     {
       const auto & sub = *variableSubstitutions_[static_cast<int>(i)];
-      addMatrixSubstitutionAssignments(variables, *x, M, sub, flip);
-      addVectorSubstitutionAssignments(sub, v1, *x, flip);
+      addMatrixSubstitutionAssignments(variables, x, M, sub, flip);
+      addVectorSubstitutionAssignments(sub, v1, x, flip);
       if(f2)
-        addVectorSubstitutionAssignments(sub, v2, *x, flip);
+        addVectorSubstitutionAssignments(sub, v2, x, flip);
     }
     else // usual case
     {
       Range cols = x->getMappingIn(variables);
-      addMatrixAssignment(*x, M, cols, flip);
+      addMatrixAssignment(x, M, cols, flip);
     }
   }
 }

--- a/src/scheme/MatrixAssignment.cpp
+++ b/src/scheme/MatrixAssignment.cpp
@@ -1,5 +1,6 @@
 /* Copyright 2017-2020 CNRS-AIST JRL and CNRS-UM LIRMM */
 
+#include <iostream>
 #include <tvm/VariableVector.h>
 #include <tvm/scheme/internal/MatrixAssignment.h>
 
@@ -12,6 +13,8 @@ void MatrixAssignment::updateMapping(const VariableVector & newVar,
                                      const AssignmentTarget & target,
                                      bool updateMatrixTarget)
 {
+  // FIXME: x pointer becomes invalid when there is a SolverEvent::addVariable
+  // std::cout << "assignement var x: " << x << ", " << x->name() << std::endl;
   if(newVar.contains(*x))
   {
     Range newRange = x->getMappingIn(newVar);

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -174,9 +174,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
     memory->variables(); // update variable vector if needed
     memory->solver->process(se);
 
-    if(rebuildProblem)
-    {
-    }
+    if(rebuildProblem) {}
   }
 }
 

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -94,7 +94,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
         break;
         case EventType::TaskAddition: {
           // std::cout << "Firing task addition event !" << std::endl;
-          auto & task = e.typedEmitter<EventType::TaskUpdate>();
+          auto & task = e.typedEmitter<EventType::TaskAddition>();
           removeTask(problem, memory, task, se);
           addTask(problem, memory, task, se);
         }
@@ -174,6 +174,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
     memory->variables(); // update variable vector if needed
     memory->solver->process(se);
 
+    // Do not run processProblem anymore, tasks and mappings should be handled by task events now
     if(rebuildProblem) {}
   }
 }
@@ -347,7 +348,7 @@ void WeightedLeastSquares::addTask(const LinearizedControlProblem & problem,
   auto optc = problem.constraintWithRequirementsNoThrow(task);
   if(!optc)
     return;
-  std::cout << "addTask: " << &optc->get() << std::endl;
+  // std::cout << "addTask: " << &optc->get() << std::endl;
 
   // If there is really a task to be added, we need to record the mapping in memory
   auto c = optc->get();

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -5,9 +5,9 @@
 #include <tvm/LinearizedControlProblem.h>
 #include <tvm/constraint/abstract/LinearConstraint.h>
 #include <tvm/constraint/internal/LinearizedTaskConstraint.h>
+#include <tvm/graph/internal/Logger.h>
 #include <tvm/solver/internal/SolverEvents.h>
 #include <tvm/utils/internal/map.h>
-#include <tvm/graph/internal/Logger.h>
 
 using Logger = tvm::graph::internal::Logger;
 
@@ -44,10 +44,13 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
   using EventType = ProblemDefinitionEvent::Type;
   solver::internal::SolverEvents se;
 
+  bool rebuildProblem = false;
+  // std::cout << "Running updateComputationData_ !" << std::endl;
+
   if(data->hasEvents())
   {
     Memory * memory = static_cast<Memory *>(data);
-    std::cout << "There are: " << memory->events().size() << " events" << std::endl;
+    // std::cout << "There are: " << memory->events().size() << " events" << std::endl;
 
     // If some events require to rebuild the data, we skip all other events.
     // FIXME this skipping breaks in case of new variables addition or removal (TaskUpdateVariables)
@@ -57,17 +60,20 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
     {
       if(e.type() == EventType::SubstitutionAddition || e.type() == EventType::SubstitutionRemoval)
       {
+        // std::cout << "There is a substitution, skipping all events !" << std::endl;
         resetComputationData(problem, memory);
         return;
       }
     }
+    // std::cout << "Update comp data: there are " << memory->events().size() << " events to process" << std::endl;
     while(memory->hasEvents())
     {
       auto e = memory->popEvent();
-      std::cout << "Pop ProblemDefinitionEvent" << std::endl;
+      // std::cout << "Pop ProblemDefinitionEvent" << std::endl;
       switch(e.type())
       {
         case EventType::WeightChange: {
+          // std::cout << "Firing weight change event !" << std::endl;
           const auto & c = problem.constraintWithRequirements(e.typedEmitter<EventType::WeightChange>());
           if(c.requirements->priorityLevel().value() == 0)
             throw std::runtime_error(
@@ -77,6 +83,7 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
         }
         break;
         case EventType::AnisotropicWeightChange: {
+          // std::cout << "Firing anisotropic weight change event !" << std::endl;
           const auto & c = problem.constraintWithRequirements(e.typedEmitter<EventType::AnisotropicWeightChange>());
           if(c.requirements->priorityLevel().value() == 0)
             throw std::runtime_error(
@@ -85,23 +92,20 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
           se.addVectorWeightEvent(c.constraint.get());
         }
         break;
-        case EventType::TaskAddition:
-        {
-          std::cout << "EventType::TaskAddition" << std::endl;
+        case EventType::TaskAddition: {
+          // std::cout << "Firing task addition event !" << std::endl;
           addTask(problem, memory, e.typedEmitter<EventType::TaskAddition>(), se);
         }
-          break;
-        case EventType::TaskRemoval:
-          {
-          std::cout << "EventType::TaskRemoval" << std::endl;
+        break;
+        case EventType::TaskRemoval: {
+          // std::cout << "Firing task removal event !" << std::endl;
           removeTask(problem, memory, e.typedEmitter<EventType::TaskRemoval>(), se);
-          }
-          break;
+        }
+        break;
         case EventType::TaskUpdateVariables: {
-          std::cout << "EventType::TaskUpdateVariables" << std::endl;
           // Handles the case where a variable was added or removed to the function after the problem has been created
           // e.g calling addVariable in Function::updateJacobian
-          std::cout << "Firing task update variable event !" << std::endl;
+          // std::cout << "Firing task update variable event !" << std::endl;
           auto & task = e.typedEmitter<EventType::TaskUpdateVariables>();
 
           // XXX remove re add is insufficient because it pulls the variables from the constraints in the problem,
@@ -112,32 +116,31 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
           // Instead we call updateVariables on the task constraint which updates the variables of the constraint
           // according to those of the function
 
-
-          std::cout << "remove task " << task.task.function()->UpdateBaseName << std::endl;
-          std::cout << "remove task " << Logger::logger().name(task.task.function().get()) << std::endl;
+          // std::cout << "remove task " << Logger::logger().typeName(task.task.function().get()) << std::endl;
           removeTask(problem, memory, task, se);
           // Fully recreate the linearizedtaskconstraint from the task
           {
-          auto cstr = problem.constraintNoThrow(task);
-          std::cout << "checking constraint variables before update: " << std::endl;
-          for(const auto & var : cstr->variables())
-          {
-            std::cout << "var: " << var->name() << std::endl;
-          }
-          const_cast<LinearizedControlProblem&>(problem).updateConstraint(task);
-          cstr = problem.constraintNoThrow(task);
-          std::cout << "checking constraint variables after update" << std::endl;
-          for(const auto & var : cstr->variables())
-          {
-            std::cout << "var: " << var->name() << std::endl;
-          }
+            // auto cstr = problem.constraintNoThrow(task);
+            // std::cout << "checking constraint variables before update: " << std::endl;
+            // for(const auto & var : cstr->variables())
+            // {
+            //   std::cout << "var: " << var->name() << std::endl;
+            // }
+            const_cast<LinearizedControlProblem &>(problem).updateConstraint(task);
+            // cstr = problem.constraintNoThrow(task);
+            // std::cout << "checking constraint variables after update" << std::endl;
+            // for(const auto & var : cstr->variables())
+            // {
+            //   std::cout << "var: " << var->name() << std::endl;
+            // }
           }
           // // XXX: do we need to then update it in memory?
           //
           // static_cast<tvm::constraint::internal::LinearizedTaskConstraint *>(problem.constraint(task).get())
           //      ->updateVariables();
           addTask(problem, memory, task, se);
-          const_cast<LinearizedControlProblem&>(problem).update();
+          const_cast<LinearizedControlProblem &>(problem).update();
+          rebuildProblem = true;
 
           // FIXME Running this skips other events in the queue as it resets the memory events as well, so some variable
           // updates are missing, but remove and add on the task do not rebuild enough, find the necessary steps in
@@ -163,10 +166,16 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
         default:
           throw std::runtime_error("[WeightedLeastSquares::updateComputationData_] Unimplemented event handling.");
       }
+      // std::cout << "Finished one event" << std::endl;
     }
 
     memory->variables(); // update variable vector if needed
     memory->solver->process(se);
+
+    if(rebuildProblem)
+    {
+      processProblem(problem, memory);
+    }
   }
 }
 
@@ -224,22 +233,22 @@ void WeightedLeastSquares::processProblem(const LinearizedControlProblem & probl
   // std::cout << "Processing constraints" << std::endl;
   for(const auto & c : constraints)
   {
-    std::cout << "New constraint, type " << typelambda(c.constraint->type()) << ", jacobian size "
-              << c.constraint->tSize() << std::endl;
+    // std::cout << "New constraint, type " << typelambda(c.constraint->type()) << ", jacobian size "
+    //           << c.constraint->tSize() << std::endl;
     // If the constraint is used for the substitutions, we skip it.
     if(subs.uses(c.constraint))
       continue;
     abilities_.check(c.constraint, c.requirements); // FIXME: should be done in a parent class
     // XXX c.constraint is a first order provider from which we pull the variables
     // It is a different instance than the function ! and so the variables are not the same directly
-    for(const auto & xi :
-        static_cast<tvm::constraint::internal::LinearizedTaskConstraint *>(c.constraint.get())->functionVariables())
-    {
-      std::cout << "function variable " << xi->name() << std::endl;
-    }
+    // for(const auto & xi :
+    //     static_cast<tvm::constraint::internal::LinearizedTaskConstraint *>(c.constraint.get())->functionVariables())
+    // {
+    //   std::cout << "function variable " << xi->name() << " ptr: " << xi << std::endl;
+    // }
     for(const auto & xi : c.constraint->variables())
     {
-      std::cout << "constraint variable " << xi->name() << std::endl;
+      // std::cout << "constraint variable " << xi->name() << " ptr: " << xi << std::endl;
       memory->addVariable(subs.substitute(xi));
     }
 

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -8,8 +8,6 @@
 #include <tvm/solver/internal/SolverEvents.h>
 #include <tvm/utils/internal/map.h>
 
-#include <iostream>
-
 namespace tvm
 {
 
@@ -85,6 +83,28 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
         case EventType::TaskRemoval:
           removeTask(problem, memory, e.typedEmitter<EventType::TaskRemoval>(), se);
           break;
+        case EventType::TaskAddVariable: {
+          auto & task = e.typedEmitter<EventType::TaskAddVariable>();
+          std::cout << "WeightedLeastSquares: Handling EventType::TaskAddVariable for function: "
+                    << task.task.function()->UpdateBaseName << std::endl;
+          std::cout << "The function has the following variables:" << std::endl;
+          for(const auto & var : task.task.function()->variables())
+          {
+            std::cout << var->name() << std::endl;
+            se.addVariable(var);
+          }
+
+          // removeTask(problem, memory, task, se);
+          // addTask(problem, memory, task, se);
+
+          // // XXX: how to get the actual added variable?
+          // // memory->addVariable(task.task.function()->variables());
+          // for(const auto & var : task.task.function()->variables())
+          // {
+          //   se.addVariable(var);
+          // }
+          break;
+        }
         default:
           throw std::runtime_error("[WeightedLeastSquares::updateComputationData_] Unimplemented event handling.");
       }

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -102,11 +102,11 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
           removeTask(problem, memory, e.typedEmitter<EventType::TaskRemoval>(), se);
         }
         break;
-        case EventType::TaskUpdateVariables: {
+        case EventType::TaskUpdate: {
           // Handles the case where a variable was added or removed to the function after the problem has been created
           // e.g calling addVariable in Function::updateJacobian
           // std::cout << "Firing task update variable event !" << std::endl;
-          auto & task = e.typedEmitter<EventType::TaskUpdateVariables>();
+          auto & task = e.typedEmitter<EventType::TaskUpdate>();
 
           // XXX remove re add is insufficient because it pulls the variables from the constraints in the problem,
           // that were built when the task were added so do not hold any new variables.

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -94,7 +94,9 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
         break;
         case EventType::TaskAddition: {
           // std::cout << "Firing task addition event !" << std::endl;
-          addTask(problem, memory, e.typedEmitter<EventType::TaskAddition>(), se);
+          auto & task = e.typedEmitter<EventType::TaskUpdate>();
+          removeTask(problem, memory, task, se);
+          addTask(problem, memory, task, se);
         }
         break;
         case EventType::TaskRemoval: {
@@ -174,7 +176,6 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
 
     if(rebuildProblem)
     {
-      processProblem(problem, memory);
     }
   }
 }

--- a/src/scheme/WeightedLeastSquares.cpp
+++ b/src/scheme/WeightedLeastSquares.cpp
@@ -84,25 +84,28 @@ void WeightedLeastSquares::updateComputationData_(const LinearizedControlProblem
           removeTask(problem, memory, e.typedEmitter<EventType::TaskRemoval>(), se);
           break;
         case EventType::TaskAddVariable: {
+          // Handles the case where a variable was added to the function after the problem has been created
+          // e.g calling addVariable in Function::updateJacobian
+
           auto & task = e.typedEmitter<EventType::TaskAddVariable>();
-          std::cout << "WeightedLeastSquares: Handling EventType::TaskAddVariable for function: "
-                    << task.task.function()->UpdateBaseName << std::endl;
-          std::cout << "The function has the following variables:" << std::endl;
-          for(const auto & var : task.task.function()->variables())
-          {
-            std::cout << var->name() << std::endl;
-            se.addVariable(var);
-          }
+          // XXX: Remove/re-add the task
+          removeTask(problem, memory, task, se);
+          addTask(problem, memory, task, se);
 
-          // removeTask(problem, memory, task, se);
-          // addTask(problem, memory, task, se);
+          // FIXME: Ideally we would want to only add the new variable,
+          // however the following seems to fail on matrixAssignment when subvariables are
+          // involved (even if they are not added directly)
+          //
+          // std::cout << "WeightedLeastSquares: Handling EventType::TaskAddVariable for function: "
+          //           << task.task.function()->UpdateBaseName << std::endl;
+          // std::cout << "The function has the following variables:" << std::endl;
 
-          // // XXX: how to get the actual added variable?
-          // // memory->addVariable(task.task.function()->variables());
           // for(const auto & var : task.task.function()->variables())
           // {
-          //   se.addVariable(var);
+          //   // std::cout << var->name() << std::endl;
+          //   // se.addVariable(var);
           // }
+
           break;
         }
         default:

--- a/src/scheme/helpers.cpp
+++ b/src/scheme/helpers.cpp
@@ -20,7 +20,7 @@ bool isBound(const ConstraintPtr & c)
   const auto & vars = c->variables();
   if(vars.numberOfVariables() == 0)
     return false;
-  const auto & jac = c->jacobian(*vars[0]);
+  const auto & jac = c->jacobian(vars[0]);
   const auto & p = jac.properties();
   return (c->linearIn(*vars[0]) && vars.numberOfVariables() == 1 && p.isDiagonal() && p.isInvertible());
 }

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -326,15 +326,23 @@ void LeastSquareSolver::updateWeights(const internal::SolverEvents & se)
 
 bool LeastSquareSolver::updateVariables(const internal::SolverEvents & se)
 {
-  // std::cout << "LeastSquareSolver::updateVariables" << std::endl;
-  // if(se.addedVariables().size())
-  // {
-  //   std::cout << "LeastSquareSolver::updateVariables: addedVariables contains" << std::endl;
-  //   for(const auto & var : se.addedVariables())
-  //   {
-  //     std::cout << "var: " << var->name() << ", ptr: " << var << std::endl;
-  //   }
-  // }
+  std::cout << "LeastSquareSolver::updateVariables" << std::endl;
+  if(se.addedVariables().size())
+  {
+    std::cout << "LeastSquareSolver::updateVariables: addedVariables contains" << std::endl;
+    for(const auto & var : se.addedVariables())
+    {
+      std::cout << "var: " << var->name() << ", ptr: " << var << std::endl;
+    }
+  }
+  if(se.removedVariables().size())
+  {
+    std::cout << "LeastSquareSolver::updateVariables: removedVariables contains" << std::endl;
+    for(const auto & var : se.removedVariables())
+    {
+      std::cout << "var: " << var->name() << ", ptr: " << var << std::endl;
+    }
+  }
   return (!(se.removedVariables().empty() && se.addedVariables().empty())) || se.hasHiddenVariableChange();
 }
 

--- a/src/solver/LeastSquareSolver.cpp
+++ b/src/solver/LeastSquareSolver.cpp
@@ -325,7 +325,18 @@ void LeastSquareSolver::updateWeights(const internal::SolverEvents & se)
 }
 
 bool LeastSquareSolver::updateVariables(const internal::SolverEvents & se)
-{ return (!(se.removedVariables().empty() && se.addedVariables().empty())) || se.hasHiddenVariableChange(); }
+{
+  // std::cout << "LeastSquareSolver::updateVariables" << std::endl;
+  // if(se.addedVariables().size())
+  // {
+  //   std::cout << "LeastSquareSolver::updateVariables: addedVariables contains" << std::endl;
+  //   for(const auto & var : se.addedVariables())
+  //   {
+  //     std::cout << "var: " << var->name() << ", ptr: " << var << std::endl;
+  //   }
+  // }
+  return (!(se.removedVariables().empty() && se.addedVariables().empty())) || se.hasHiddenVariableChange();
+}
 
 LeastSquareSolver::ImpactFromChanges LeastSquareSolver::processRemovedConstraints(const internal::SolverEvents & se)
 {

--- a/src/task_dynamics/None.cpp
+++ b/src/task_dynamics/None.cpp
@@ -31,7 +31,25 @@ None::Impl::Impl(FunctionPtr f, constraint::Type t, const Eigen::VectorXd & rhs)
   addInputDependency<Impl>(Update::UpdateValue, std::static_pointer_cast<LinearFunction>(f), LinearFunction::Output::B);
 }
 
-void None::Impl::updateValue() { value_ = rhs() - lf_->b(); }
+void None::Impl::updateValue()
+{
+  const auto & b = lf_->b();
+  if(rhs().size() != b.size())
+  {
+    if(rhs().isConstant(rhs()(0)))
+    {
+      value_ = Eigen::VectorXd::Constant(b.size(), rhs()(0)) - b;
+    }
+    else
+    {
+      throw std::runtime_error("Task dynamics None: can't resize a non constant rhs");
+    }
+  }
+  else
+  {
+    value_ = rhs() - b;
+  }
+}
 
 } // namespace task_dynamics
 


### PR DESCRIPTION
This PR adds internal TVM events to handle function changes automatically:

- An added or removed variable at the function level
- A jacobian size change (function space resize)

This avoids having to remove and re add a task manually at the problem level when the functions themselves are resized or change variables.